### PR TITLE
refactor(consensus)!: collapse simplex/duplex/codec into a single consensus feature and retire the legacy single-threaded paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,23 +179,20 @@ nix = { workspace = true }
 
 [features]
 default = ["consensus"]
-simplex = ["fgumi-consensus/simplex"]
-# duplex and codec depend on simplex (mirrors fgumi-consensus: `duplex = ["simplex"]`
-# and `codec = ["simplex"]`), and their commands share methylation/filter paths
-# that live behind the `simplex` feature in this crate.
-duplex = ["simplex", "fgumi-consensus/duplex"]
-codec = ["simplex", "fgumi-consensus/codec"]
-# Umbrella for all consensus calling (simplex + duplex + codec). The command
-# modules gate individually on `simplex`/`duplex`/`codec`, but the always-
-# compiled chain/runall layer (`pipeline::chains`) references the consensus
-# option-bag surface all-or-nothing: gating those references per-codec lets a
-# reduced-feature build reference a half-present surface and fail to compile, so
-# `consensus` gates them as one unit. This is about consensus *coherence* only — it
-# is NOT a claim that `--no-default-features` compiles: the crate has other
-# always-on references (e.g. the methylation path) that a bare
+# Single umbrella feature for all consensus calling (simplex + duplex + codec).
+# The three commands share one options-bag / builder surface in this crate, and
+# duplex/codec build on simplex, so there is no coherent way to compile one
+# without the others; the always-compiled chain/runall layer
+# (`pipeline::chains`) already references that shared surface as one unit
+# regardless of which individual codec is in play. Splitting this into
+# per-codec features would let a reduced-feature build reference a
+# half-present surface and fail to compile, so `consensus` gates the whole
+# surface as a single unit instead. This is about consensus *coherence*
+# only — it is NOT a claim that `--no-default-features` compiles: the crate
+# has other always-on references (e.g. the methylation path) that a bare
 # `--no-default-features` build still fails on. Enabled by default and by
 # `simulate`.
-consensus = ["simplex", "duplex", "codec"]
+consensus = ["fgumi-consensus/simplex", "fgumi-consensus/duplex", "fgumi-consensus/codec"]
 dhat-heap = ["dep:dhat"]
 # Enable comprehensive memory debugging infrastructure (monitor thread, hot-path atomics, CLI args)
 memory-debug = ["fgumi-sort/memory-debug"]
@@ -234,8 +231,8 @@ noodles = { workspace = true, features = ["bam", "sam", "bgzf"] }
 [[bench]]
 name = "core_functions"
 harness = false
-# Exercises vanilla consensus / overlap helpers that live behind `simplex`.
-required-features = ["simplex"]
+# Exercises vanilla consensus / overlap helpers that live behind `consensus`.
+required-features = ["consensus"]
 
 [[bench]]
 name = "pipeline_dispatch"

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -6,87 +6,33 @@
 //! of the original duplex molecule. R1 comes from one strand, R2 from the opposite strand,
 //! allowing even a single read-pair to generate duplex consensus.
 //!
-//! When `--rejects` is set, the threaded pipeline routes rejected records through
-//! the unified pipeline's first-class secondary output (see
-//! [`crate::unified_pipeline::run_bam_pipeline_from_reader_with_secondary`]).
-//! Both reject paths (success and duplex-disagreement recovery) flow through a
-//! per-batch buffer and land in batch-input order. The rejects BAM advertises
-//! the input header so raw-input RG/PG/contig metadata is preserved. The pattern
-//! matches `commands::filter`, `commands::correct`, `commands::simplex`, and
-//! `commands::duplex`.
+//! When `--rejects` is set, the declarative chain (see [`crate::pipeline::chains`])
+//! routes rejected records through its rejects fan-out branch. Both reject
+//! paths (success and duplex-disagreement recovery) land in batch-input order.
+//! The rejects BAM advertises the input header so raw-input RG/PG/contig
+//! metadata is preserved. The pattern matches `commands::filter`,
+//! `commands::correct`, `commands::simplex`, and `commands::duplex`.
 
-use crate::commands::command::Command;
-use crate::commands::consensus_runner::{ConsensusStatsOps, create_unmapped_consensus_header};
-use crate::per_thread_accumulator::PerThreadAccumulator;
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use clap::Parser;
-use fgoxide::io::DelimFile;
-use fgumi_bam_io::{
-    create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
-    create_raw_bam_reader_with_opts,
-};
 use std::path::Path;
 
 use super::common::{
     AllowUnmappedOptions, BamIoOptions, CompressionOptions, ConsensusCallingOptions,
     QueueMemoryOptions, ReadGroupOptions, RejectsOptions, SchedulerOptions, StatsOptions,
-    ThreadingOptions, build_pipeline_config, reject_output_collisions, serialize_raw_bam_records,
+    ThreadingOptions, reject_output_collisions,
 };
-use crate::consensus::codec_caller::{
-    CodecConsensusCaller, CodecConsensusError, CodecConsensusOptions, CodecConsensusStats,
-};
-use crate::consensus_caller::ConsensusOutput;
-use crate::logging::{OperationTimer, log_consensus_summary};
-use crate::mi_group::{MiGroup, MiGroupBatch, MiGroupIterator, MiGrouper};
-use crate::read_info::LibraryIndex;
-use crate::unified_pipeline::{
-    GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
-    run_bam_pipeline_from_reader_with_secondary,
-};
-use fgumi_bam_io::ProgressTracker;
-use fgumi_raw_bam::{RawRecord, RawRecordView};
-// RejectionTracker now used via ConsensusStatsOps trait in consensus_runner
+use crate::commands::command::Command;
+// Used only by unit tests that build stats structs directly, read back the
+// `--stats` TSV, or set string tags on synthetic test records.
+#[cfg(test)]
+use crate::commands::consensus_runner::ConsensusStatsOps;
+#[cfg(test)]
+use crate::consensus::codec_caller::CodecConsensusStats;
+#[cfg(test)]
 use crate::sam::SamTag;
-use log::info;
-use noodles::sam::Header;
-use noodles::sam::alignment::record::data::field::Tag;
-use std::io::{self, Write as IoWrite};
-use std::sync::Arc;
-
-// ============================================================================
-// Types for 7-step pipeline processing
-// ============================================================================
-
-/// Result from processing a batch of MI groups through CODEC consensus calling.
-struct CodecProcessedBatch {
-    /// Consensus reads to write to output BAM
-    consensus_output: ConsensusOutput,
-    /// Raw-byte rejected records (consensus-caller rejects from both the
-    /// success and duplex-disagreement paths), in batch-input order. Empty
-    /// unless `track_rejects` is true.
-    rejected_records: Vec<Vec<u8>>,
-    /// Number of MI groups in this batch
-    groups_count: u64,
-    /// CODEC consensus calling statistics for this batch
-    stats: CodecConsensusStats,
-}
-
-impl MemoryEstimate for CodecProcessedBatch {
-    fn estimate_heap_size(&self) -> usize {
-        let rej_size: usize = self.rejected_records.iter().map(Vec::capacity).sum();
-        let rej_vec_overhead = self.rejected_records.capacity() * std::mem::size_of::<Vec<u8>>();
-        self.consensus_output.estimate_heap_size() + rej_size + rej_vec_overhead
-    }
-}
-
-/// Metrics collected from each batch during parallel processing.
-#[derive(Default)]
-struct CollectedCodecMetrics {
-    /// CODEC consensus calling statistics
-    stats: CodecConsensusStats,
-    /// Number of MI groups processed
-    groups_processed: u64,
-}
+#[cfg(test)]
+use fgoxide::io::DelimFile;
 
 /// Call CODEC consensus reads from template-coordinate sorted BAM
 ///
@@ -488,25 +434,6 @@ impl Codec {
     }
 }
 
-/// Decide how the single-thread codec loop should handle a typed
-/// [`CodecConsensusError`]: silently swallow recoverable duplex-disagreement
-/// rejects (so the loop continues) and surface any other variant as a fatal
-/// `anyhow::Error` with UMI context.
-///
-/// Extracted from the inline `match` arm so the `Other`-variant branch can be
-/// unit-tested. That branch is unreachable from valid CLI input today —
-/// `consensus_reads_raw` only returns `Other` when `ss_caller.consensus_call`
-/// propagates an error, and the public API gates against the conditions that
-/// trigger it (see `crates/fgumi-consensus/src/vanilla_caller.rs`).
-fn recover_or_propagate_codec_error(e: CodecConsensusError, umi: &str) -> Result<()> {
-    if e.is_duplex_disagreement() {
-        Ok(())
-    } else {
-        Err(anyhow::Error::from(e))
-            .with_context(|| format!("Failed to call consensus for UMI: {umi}"))
-    }
-}
-
 impl CodecOptions {
     /// Validate the codec consensus parameter bounds. Single source of truth,
     /// shared by `Codec::validate` (the CLI pre-flight) and `add_codec` (the
@@ -604,256 +531,27 @@ impl Command for Codec {
         }
         reject_output_collisions(&outputs)?;
 
-        // ---- --threads N on a consensus build: run on the declarative chain ----
-        // Dispatch BEFORE the timer/banner/reader below (execute_chain ->
-        // add_codec builds its own). On a non-consensus build the chain
-        // machinery isn't compiled, so this block is absent and we fall through
-        // to the legacy threaded path.
-        #[cfg(feature = "consensus")]
-        if self.threading.threads.is_some() {
-            return self.execute_chain(command_line);
-        }
-
-        let timer = OperationTimer::new("Calling CODEC consensus");
-
-        // Get threading configuration (codec is balanced workload)
-        let reader_threads = self.threading.num_threads();
-        let worker_threads = self.threading.num_threads();
-        let writer_threads = self.threading.num_threads();
-
-        info!("Starting CODEC consensus calling");
-        info!("Input: {}", self.io.input.display());
-        info!("Output: {}", self.io.output.display());
-        info!("Min reads: {}", self.min_reads);
-        if let Some(max) = self.max_reads {
-            info!("Max reads: {max}");
-        }
-        info!("Error rate pre-UMI: Q{}", self.consensus.error_rate_pre_umi);
-        info!("Error rate post-UMI: Q{}", self.consensus.error_rate_post_umi);
-        info!("Min duplex length: {}", self.min_duplex_length);
-        info!("Worker threads: {worker_threads}");
-        info!("Reader threads: {reader_threads}");
-        if self.consensus.trim {
-            info!("Quality trimming enabled");
-        }
-        // Note: Unlike simplex/duplex, CODEC does not support overlapping consensus calling
-        // (matching fgbio's CallCodecConsensusReads which has no such option).
-
-        // Parse cell tag
-        let cell_tag = Tag::from(SamTag::CB);
-
-        // Enable rejects tracking if rejects file is specified
-        let track_rejects = self.rejects_opts.is_enabled();
-
-        // Process reads using streaming by MI groups
-        info!("Processing reads and calling consensus (streaming)...");
-        // Both the single-threaded fast path (create_raw_bam_reader_with_opts)
-        // and the multi-threaded pipeline honor --check-crc/--no-check-crc (#800).
-        self.io.log_effective_check_crc();
-
-        // ============================================================
-        // --threads N mode: Use 7-step unified pipeline
-        // None: Use single-threaded fast path
-        // ============================================================
-        // IMPORTANT: Check threading BEFORE opening any reader so we only open
-        // the input once — opening twice wastes I/O and breaks stdin streaming.
-        if let Some(threads) = self.threading.threads {
-            let (reader, header) = create_bam_reader_for_pipeline_with_opts(
-                &self.io.input,
-                self.io.pipeline_reader_opts(),
-            )?;
-            crate::commands::common::check_consensus_sort_order(
-                &header,
-                &self.io.input.display().to_string(),
-            )?;
-            let output_header = create_unmapped_consensus_header(
-                &header,
-                &self.read_group.read_group_id,
-                "Read group",
-                command_line,
-            )?;
-            let read_name_prefix = self.read_group.prefix_or_from_header(&header);
-
-            let result = self.execute_threads_mode(
-                threads,
-                reader,
-                header,
-                output_header,
-                read_name_prefix,
-                track_rejects,
-            );
-            timer.log_completion(0); // Completion logged in execute_threads_mode
-            return result;
-        }
-
-        // Single-threaded fast path: open the raw reader once and derive the header from it.
-        let (mut raw_reader, header) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
-        crate::commands::common::check_consensus_sort_order(
-            &header,
-            &self.io.input.display().to_string(),
-        )?;
-        let output_header = create_unmapped_consensus_header(
-            &header,
-            &self.read_group.read_group_id,
-            "Read group",
-            command_line,
-        )?;
-        let read_name_prefix = self.read_group.prefix_or_from_header(&header);
-
-        // ============================================================
-        // For non-pipeline modes, create output writers here
-        // ============================================================
-
-        // Open output BAM writer with multi-threaded BGZF compression
-        let mut writer = create_bam_writer(
-            &self.io.output,
-            &output_header,
-            writer_threads,
-            self.compression.compression_level,
-        )?;
-
-        // Open rejects writer if rejects file is specified
-        let mut rejects_writer = create_optional_bam_writer(
-            self.rejects_opts.rejects.as_ref(),
-            &header,
-            writer_threads,
-            self.compression.compression_level,
-        )?;
-
-        // Create options
-        let options = CodecConsensusOptions {
-            min_input_base_quality: self.consensus.min_input_base_quality,
-            error_rate_pre_umi: self.consensus.error_rate_pre_umi,
-            error_rate_post_umi: self.consensus.error_rate_post_umi,
-            tie_rule: self.consensus.tie_rule.into(),
-            min_reads_per_strand: self.min_reads,
-            max_reads_per_strand: self.max_reads,
-            min_duplex_length: self.min_duplex_length,
-            legacy_overlap_window: self.legacy_overlap_window,
-            single_strand_qual: self.single_strand_qual,
-            outer_bases_qual: self.outer_bases_qual,
-            outer_bases_length: self.outer_bases_length,
-            max_duplex_disagreements: self.max_duplex_disagreements.unwrap_or(usize::MAX),
-            max_duplex_disagreement_rate: self.max_duplex_disagreement_rate,
-            cell_tag: Some(cell_tag),
-            produce_per_base_tags: self.consensus.output_per_base_tags,
-            trim: self.consensus.trim,
-            min_consensus_base_quality: self.consensus.min_consensus_base_quality,
-        };
-
-        // Note: CODEC does not support overlapping consensus (matching fgbio)
-        // We keep the infrastructure in place but it's always disabled.
-
-        // Track progress (count records written, not UMI groups)
-        let mut record_count: usize = 0;
-        let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
-
-        // Use the raw_reader opened above (single input open). Apply the fgbio
-        // pre-group filter: always drop secondary/supplementary; --allow-unmapped
-        // relaxes only the mapped-record rule.
-        let allow_unmapped = self.allow_unmapped.enabled;
-        let raw_record_iter = std::iter::from_fn(move || {
-            loop {
-                let mut record = RawRecord::new();
-                match raw_reader.read_record(&mut record) {
-                    Ok(0) => return None, // EOF
-                    Ok(_) => {
-                        if crate::commands::common::consensus_pregroup_keep_flags(
-                            RawRecordView::new(&record).flags(),
-                            allow_unmapped,
-                        ) {
-                            return Some(Ok(record));
-                        }
-                        // Otherwise filtered out: keep reading.
-                    }
-                    Err(e) => return Some(Err(e.into())),
-                }
-            }
-        });
-        let mi_group_iter =
-            MiGroupIterator::new(raw_record_iter, "MI").with_cell_tag(Some(*SamTag::CB));
-
-        let mut caller = CodecConsensusCaller::new_with_rejects_tracking(
-            read_name_prefix,
-            self.read_group.read_group_id.clone(),
-            options,
-            track_rejects,
-        );
-
-        for result in mi_group_iter {
-            let (umi, records) = result.context("Failed to read MI group")?;
-
-            // Call consensus directly — records are already RawRecord values.
-            // `consensus_reads_typed` returns a typed `CodecConsensusError` so we
-            // can distinguish recoverable duplex disagreements from genuine
-            // failures without string matching (see issue #338).
-            let result: std::result::Result<ConsensusOutput, CodecConsensusError> =
-                caller.consensus_reads_typed(records);
-            match result {
-                Ok(output) => {
-                    let batch_size = output.count;
-                    record_count += batch_size;
-                    writer
-                        .get_mut()
-                        .write_all(&output.data)
-                        .context("Failed to write consensus read")?;
-                    progress.log_if_needed(batch_size as u64);
-                }
-                Err(e) => recover_or_propagate_codec_error(e, &umi)?,
-            }
-
-            // Write rejected reads if tracking is enabled (already raw BAM bytes)
-            if let Some(ref mut rw) = rejects_writer {
-                for raw_record in caller.rejected_reads() {
-                    let block_size = raw_record.len() as u32;
-                    rw.get_mut()
-                        .write_all(&block_size.to_le_bytes())
-                        .context("Failed to write rejected read block size")?;
-                    rw.get_mut().write_all(raw_record).context("Failed to write rejected read")?;
-                }
-                caller.clear_rejected_reads();
-            }
-        }
-
-        // For single-threaded, use the caller's stats
-        let merged_stats = caller.statistics().clone();
-
-        progress.log_final();
-
-        // Finish the buffered writer (flush remaining records and wait for writer thread)
-        writer.into_inner().finish().context("Failed to finish output BAM")?;
-
-        // Log statistics and write to file
-        info!("Consensus calling complete");
-        info!("Total records processed: {record_count}");
-
-        let consensus_count = self.finalize_stats(&merged_stats)?;
-
-        timer.log_completion(consensus_count);
-
-        // Close rejects writer if it was opened
-        if let Some(rw) = rejects_writer {
-            rw.into_inner().finish().context("Failed to finish rejects file")?;
-            info!("Rejected reads written successfully");
-        }
-
-        Ok(())
+        // The declarative chain is the only execution path: `execute` runs the
+        // reader-free pre-flight above and then always dispatches to
+        // `execute_chain`, with or without `--threads` (absent `--threads` runs
+        // the chain at a single worker). `add_codec` logs the `Calling CODEC
+        // consensus` timer, the `Starting CODEC consensus calling` banner +
+        // option lines, and the codec finalize hook logs the summary and the
+        // `--stats` TSV. Running any of those here would double-log and
+        // pre-consume stdin, so `execute` only does the pre-flight above.
+        self.execute_chain(command_line)
     }
 }
 impl Codec {
-    /// Run the codec stage on the declarative chain builder (the `--threads N`
-    /// path on a `consensus`-feature build).
+    /// Run the codec stage on the declarative chain builder — the only
+    /// execution path, with or without `--threads`.
     ///
-    /// Replaces the hand-rolled unified-pipeline construction in `execute` for
-    /// the threaded case. The chain opens its own source, validates the
-    /// template-coordinate sort order, calls consensus, writes the output BAM,
-    /// and writes the rejects/stats via the codec finalize hook — all through
-    /// the same shared helpers as the non-chain path, so the two orchestrations
-    /// stay in parity. The no-`--threads` path keeps its own single-threaded
-    /// fast path in `execute`, which is the in-process parity oracle for this
-    /// one (see `test_codec_chain_matches_single_threaded`).
-    #[cfg(feature = "consensus")]
+    /// The chain opens its own source, validates the template-coordinate sort
+    /// order, calls consensus, writes the output BAM, and writes the
+    /// rejects/stats via the codec finalize hook. `--threads 1` (or absent
+    /// `--threads`) runs the chain at a single worker, which is the in-process
+    /// parity oracle for the multi-worker case (see
+    /// `test_codec_chain_matches_single_threaded`).
     fn execute_chain(&self, command_line: &str) -> Result<()> {
         use crate::pipeline::chains::{
             ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
@@ -873,31 +571,6 @@ impl Codec {
         build_for(spec)?.run()
     }
 
-    /// Convert the caller's merged statistics to fgbio's KV metrics, log the
-    /// consensus summary, and write the seeded KV stats file when `--stats` is
-    /// requested. Returns the number of consensus reads.
-    ///
-    /// Shared by the single- and multi-threaded paths so their metrics output
-    /// cannot drift — emitting the wide table from one path and the KV format
-    /// from the other is exactly the bug this fix addresses. The KV format
-    /// matches `simplex`/`duplex` and is readable by fgbio's `Metric.read`; the
-    /// output must not depend on the number of threads.
-    fn finalize_stats(&self, merged_stats: &CodecConsensusStats) -> Result<u64> {
-        let metrics = merged_stats.to_metrics();
-        let consensus_count = metrics.consensus_reads;
-        log_consensus_summary(&metrics);
-
-        if let Some(stats_path) = &self.stats_opts.stats {
-            let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Codec);
-            DelimFile::default()
-                .write_tsv(stats_path, kv_metrics)
-                .with_context(|| format!("Failed to write statistics: {}", stats_path.display()))?;
-            info!("Wrote statistics to: {}", stats_path.display());
-        }
-
-        Ok(consensus_count)
-    }
-
     /// Validates command-line arguments.
     ///
     /// Delegates to [`CodecOptions::validate`], the single source of truth for
@@ -905,234 +578,6 @@ impl Codec {
     /// (`add_codec`, via the same `CodecOptions::validate`) cannot drift.
     fn validate(&self) -> Result<()> {
         self.to_codec_options().validate()
-    }
-
-    /// Execute using 7-step unified pipeline with --threads.
-    ///
-    /// This method is called when `--threads N` is specified with N > 1.
-    /// It uses the lock-free 7-step unified pipeline for maximum performance.
-    fn execute_threads_mode(
-        &self,
-        num_threads: usize,
-        reader: Box<dyn std::io::Read + Send>,
-        input_header: Header,
-        output_header: Header,
-        read_name_prefix: String,
-        track_rejects: bool,
-    ) -> Result<()> {
-        // Configure pipeline
-        let mut pipeline_config = build_pipeline_config(
-            &self.scheduler_opts,
-            &self.compression,
-            &self.queue_memory,
-            &self.io,
-            num_threads,
-        )?;
-
-        // Per-thread metrics accumulator: bounded metric memory, no unbounded
-        // queue. Rejects buffering semantics are preserved (see follow-up).
-        let collected_metrics = PerThreadAccumulator::<CollectedCodecMetrics>::new(num_threads);
-        let collected_metrics_for_serialize = Arc::clone(&collected_metrics);
-
-        // Parse cell tag
-        let cell_tag = Tag::from(SamTag::CB);
-
-        // Create options for CODEC consensus caller
-        let options = CodecConsensusOptions {
-            min_input_base_quality: self.consensus.min_input_base_quality,
-            error_rate_pre_umi: self.consensus.error_rate_pre_umi,
-            error_rate_post_umi: self.consensus.error_rate_post_umi,
-            tie_rule: self.consensus.tie_rule.into(),
-            min_reads_per_strand: self.min_reads,
-            max_reads_per_strand: self.max_reads,
-            min_duplex_length: self.min_duplex_length,
-            legacy_overlap_window: self.legacy_overlap_window,
-            single_strand_qual: self.single_strand_qual,
-            outer_bases_qual: self.outer_bases_qual,
-            outer_bases_length: self.outer_bases_length,
-            max_duplex_disagreements: self.max_duplex_disagreements.unwrap_or(usize::MAX),
-            max_duplex_disagreement_rate: self.max_duplex_disagreement_rate,
-            cell_tag: Some(cell_tag),
-            produce_per_base_tags: self.consensus.output_per_base_tags,
-            trim: self.consensus.trim,
-            min_consensus_base_quality: self.consensus.min_consensus_base_quality,
-        };
-
-        // Capture configuration for closures
-        let read_group_id = self.read_group.read_group_id.clone();
-
-        // Use larger batch size for codec (less work per group than simplex)
-        let batch_size = 1000;
-
-        // Rejects flow through the unified pipeline's first-class secondary
-        // output (see correct.rs / simplex.rs / duplex.rs / filter.rs for the
-        // shared pattern). `process_fn` collects caller-emitted rejects from
-        // both the success path and the duplex-disagreement recovery path into
-        // `CodecProcessedBatch::rejected_records`; the pipeline's
-        // `secondary_serialize_fn` writes them in batch-input order with the
-        // input header.
-
-        let library_index = LibraryIndex::from_header(&input_header);
-        pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
-
-        // ========== grouper_fn ==========
-        // Apply the fgbio pre-group filter (always drop secondary/supplementary;
-        // --allow-unmapped relaxes only the mapped-record rule).
-        let allow_unmapped = self.allow_unmapped.enabled;
-        let grouper_fn = move |_header: &Header| {
-            let grouper = MiGrouper::new("MI", batch_size)
-                .with_cell_tag(Some(*SamTag::CB))
-                .with_record_filter(move |raw| {
-                    crate::commands::common::consensus_pregroup_keep_raw(raw, allow_unmapped)
-                });
-            Box::new(grouper) as Box<dyn Grouper<Group = MiGroupBatch> + Send>
-        };
-
-        // ========== process_fn: CODEC consensus calling ==========
-        let process_fn = move |batch: MiGroupBatch| -> io::Result<CodecProcessedBatch> {
-            // Create per-thread CODEC consensus caller
-            let mut caller = CodecConsensusCaller::new_with_rejects_tracking(
-                read_name_prefix.clone(),
-                read_group_id.clone(),
-                options.clone(),
-                track_rejects,
-            );
-
-            let mut all_output = ConsensusOutput::default();
-            let mut batch_stats = CodecConsensusStats::default();
-            let groups_count = batch.groups.len() as u64;
-            // Caller-emitted rejects collected per-batch (success +
-            // duplex-disagreement recovery paths) and drained by the
-            // pipeline's secondary serializer.
-            let mut rejected_records: Vec<Vec<u8>> = Vec::new();
-
-            for MiGroup { mi, records } in batch.groups {
-                caller.clear();
-
-                // Call CODEC consensus directly — records are already RawRecord values.
-                // `consensus_reads_typed` returns a typed `CodecConsensusError` so we
-                // can distinguish recoverable duplex disagreements from genuine
-                // failures without string matching (see issue #338).
-                let result: std::result::Result<ConsensusOutput, CodecConsensusError> =
-                    caller.consensus_reads_typed(records);
-                match result {
-                    Ok(batch_output) => {
-                        all_output.merge(batch_output);
-                        batch_stats.merge(caller.statistics());
-                        if track_rejects {
-                            for raw in caller.take_rejected_reads() {
-                                rejected_records.push(raw);
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        // Handle duplex disagreement errors by merging stats and
-                        // preserving rejects so --rejects output matches single-threaded mode.
-                        if e.is_duplex_disagreement() {
-                            batch_stats.merge(caller.statistics());
-                            if track_rejects {
-                                for raw in caller.take_rejected_reads() {
-                                    rejected_records.push(raw);
-                                }
-                            }
-                        } else {
-                            return Err(io::Error::other(format!(
-                                "CODEC consensus error for MI {mi}: {e}"
-                            )));
-                        }
-                    }
-                }
-            }
-
-            Ok(CodecProcessedBatch {
-                consensus_output: all_output,
-                rejected_records,
-                groups_count,
-                stats: batch_stats,
-            })
-        };
-
-        // ========== serialize_fn: Serialize + collect metrics ==========
-        let serialize_fn = move |processed: CodecProcessedBatch,
-                                 _header: &Header,
-                                 output: &mut Vec<u8>|
-              -> io::Result<u64> {
-            // Merge per-batch metrics into this worker's accumulator slot.
-            // Rejects are drained by `secondary_serialize_fn` separately.
-            let batch_stats = processed.stats;
-            let groups_count = processed.groups_count;
-            collected_metrics_for_serialize.with_slot(|m| {
-                m.stats.merge(&batch_stats);
-                m.groups_processed += groups_count;
-            });
-
-            // Serialize consensus reads
-            let count = processed.consensus_output.count as u64;
-            output.extend_from_slice(&processed.consensus_output.data);
-            Ok(count)
-        };
-
-        // ========== secondary_serialize_fn: Drain rejected records ==========
-        let secondary_serialize_fn =
-            |batch: &CodecProcessedBatch, buf: &mut Vec<u8>| -> io::Result<u64> {
-                serialize_raw_bam_records(&batch.rejected_records, buf)
-            };
-
-        // Run the 7-step pipeline with the already-opened reader (supports streaming).
-        // When `--rejects` is set, route rejects through the unified pipeline's
-        // first-class secondary output so they land in input/batch-serial order
-        // and the rejects BAM carries the input header.
-        let consensus_reads_written = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref()
-        {
-            let secondary_header = input_header.clone();
-            run_bam_pipeline_from_reader_with_secondary(
-                pipeline_config,
-                reader,
-                input_header,
-                &self.io.output,
-                Some(output_header.clone()),
-                rejects_path,
-                Some(secondary_header),
-                grouper_fn,
-                process_fn,
-                serialize_fn,
-                secondary_serialize_fn,
-            )
-            .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?
-        } else {
-            run_bam_pipeline_from_reader(
-                pipeline_config,
-                reader,
-                input_header,
-                &self.io.output,
-                Some(output_header.clone()),
-                grouper_fn,
-                process_fn,
-                serialize_fn,
-            )
-            .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?
-        };
-
-        // ========== Post-pipeline: Aggregate metrics ==========
-        let mut total_groups = 0u64;
-        let mut merged_stats = CodecConsensusStats::default();
-
-        for slot in collected_metrics.slots() {
-            let m = slot.lock();
-            total_groups += m.groups_processed;
-            merged_stats.merge(&m.stats);
-        }
-
-        // Log statistics
-        info!("CODEC consensus calling complete");
-        info!("Total MI groups processed: {total_groups}");
-        info!("Total consensus reads written by pipeline: {consensus_reads_written}");
-
-        let consensus_count = self.finalize_stats(&merged_stats)?;
-
-        info!("Wrote {consensus_count} CODEC consensus reads");
-
-        Ok(())
     }
 }
 
@@ -1379,11 +824,12 @@ mod tests {
     /// consensus caller (observed via `total_input_reads`, which counts
     /// post-filter reads) — with the flag both off and on. This pins the leak
     /// where a bypassed filter would let non-primary alignments into grouping.
-    /// Runs the single-threaded fast path and the multi-threaded pipeline path,
-    /// which install the filter at independent sites.
+    /// Runs the single-worker chain (absent `--threads`) and the multi-worker
+    /// chain, which install the filter at the same `add_codec` site — worker
+    /// count is the only difference between the two cases.
     #[rstest]
-    #[case::fast_path_default(ThreadingOptions::none(), false)]
-    #[case::fast_path_allow_unmapped(ThreadingOptions::none(), true)]
+    #[case::no_threads_default(ThreadingOptions::none(), false)]
+    #[case::no_threads_allow_unmapped(ThreadingOptions::none(), true)]
     #[case::threaded_default(ThreadingOptions::new(2), false)]
     #[case::threaded_allow_unmapped(ThreadingOptions::new(2), true)]
     fn test_codec_allow_unmapped_gates_pregroup_filter(
@@ -1771,7 +1217,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::fast_path(ThreadingOptions::none())]
+    #[case::single_worker(ThreadingOptions::none())]
     #[case::pipeline_1(ThreadingOptions::new(1))]
     #[case::pipeline_2(ThreadingOptions::new(2))]
     fn test_codec_execute_rejects_non_template_coordinate_input(
@@ -1780,9 +1226,9 @@ mod tests {
         // CONS-01: codec requires template-coordinate-sorted input. An ungrouped header must be
         // rejected by execute() (via check_consensus_sort_order) rather than silently
         // mis-grouping molecules; the accept branch is covered by the other execute tests.
-        // `check_consensus_sort_order` is invoked separately on the single-threaded fast path and
-        // inside the `--threads` pipeline path, so parameterize over both to guard either branch
-        // from silently dropping the check.
+        // `check_consensus_sort_order` is guarded on codec being the chain's source stage, so
+        // parameterize over both the absent-`--threads` (single-worker) and `--threads` cases to
+        // guard that the check still fires regardless of worker count.
         use noodles::sam::header::record::value::Map;
         use noodles::sam::header::record::value::map::{ReferenceSequence, header::Version};
         use std::num::NonZeroUsize;
@@ -2052,11 +1498,11 @@ mod tests {
     /// Parameterized test for all threading modes.
     ///
     /// Tests:
-    /// - `None`: Single-threaded fast path, no pipeline
+    /// - `None`: single-worker chain (no `--threads`)
     /// - `Some(1)`: Pipeline with 1 thread
     /// - `Some(2)`: Pipeline with 2 threads
     #[rstest]
-    #[case::fast_path(ThreadingOptions::none())]
+    #[case::single_worker(ThreadingOptions::none())]
     #[case::pipeline_1(ThreadingOptions::new(1))]
     #[case::pipeline_2(ThreadingOptions::new(2))]
     fn test_threading_modes(#[case] threading: ThreadingOptions) -> Result<()> {
@@ -2081,50 +1527,6 @@ mod tests {
         assert!(output_path.exists());
 
         Ok(())
-    }
-
-    #[rstest]
-    #[case::empty_rejects(1024, 100, vec![])]
-    #[case::non_empty_rejects(64, 32, vec![256, 128])]
-    fn test_codec_processed_batch_memory_estimate(
-        #[case] consensus_capacity: usize,
-        #[case] consensus_len: usize,
-        #[case] rej_capacities: Vec<usize>,
-    ) {
-        let mut data = Vec::with_capacity(consensus_capacity);
-        data.resize(consensus_len, 0u8);
-
-        let rejected_records: Vec<Vec<u8>> = rej_capacities
-            .iter()
-            .map(|&cap| {
-                let mut v = Vec::with_capacity(cap);
-                v.extend_from_slice(&[1u8; 8]);
-                v
-            })
-            .collect();
-        let rej_outer_capacity = rejected_records.capacity();
-        // Vec::with_capacity(n) only guarantees AT LEAST n; the allocator may
-        // round up. Read the observed capacities back so the expected value
-        // matches what was actually allocated under any allocator.
-        let rej_inner_total: usize = rejected_records.iter().map(Vec::capacity).sum();
-
-        let batch = CodecProcessedBatch {
-            consensus_output: ConsensusOutput { data, count: 0 },
-            rejected_records,
-            groups_count: 0,
-            stats: CodecConsensusStats::default(),
-        };
-
-        // Heap = consensus capacity + sum of per-reject inner capacities
-        // + outer-vec capacity * size_of::<Vec<u8>>().
-        let expected = consensus_capacity
-            + rej_inner_total
-            + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
-        assert_eq!(
-            batch.estimate_heap_size(),
-            expected,
-            "estimate should account for consensus capacity, rejects inner capacities, and outer-vec overhead",
-        );
     }
 
     /// Asserts that single-threaded and multi-threaded codec produce the same number of
@@ -2213,141 +1615,5 @@ mod tests {
         );
 
         Ok(())
-    }
-
-    /// `recover_or_propagate_codec_error` must let
-    /// [`CodecConsensusError::DuplexDisagreementCount`] flow through as `Ok(())`
-    /// so the single-thread codec loop continues processing the next MI group.
-    #[test]
-    fn test_recover_or_propagate_codec_error_swallows_disagreement_count() {
-        let err = CodecConsensusError::DuplexDisagreementCount { disagreements: 42 };
-        recover_or_propagate_codec_error(err, "UMI_X")
-            .expect("disagreement-count must be recoverable");
-    }
-
-    /// Same as above for the rate variant.
-    #[test]
-    fn test_recover_or_propagate_codec_error_swallows_disagreement_rate() {
-        let err = CodecConsensusError::DuplexDisagreementRate { rate: 0.42 };
-        recover_or_propagate_codec_error(err, "UMI_Y")
-            .expect("disagreement-rate must be recoverable");
-    }
-
-    /// The `Other` variant (any non-disagreement failure) must be propagated as
-    /// a fatal `anyhow::Error` with the UMI threaded into the context. Covers
-    /// the codec.rs propagation branch that's unreachable from valid CLI input
-    /// today (issue #338).
-    #[test]
-    fn test_recover_or_propagate_codec_error_propagates_other_with_umi_context() {
-        let err = CodecConsensusError::Other(anyhow::anyhow!("synthetic upstream failure"));
-        let result = recover_or_propagate_codec_error(err, "UMI_FATAL");
-        let propagated = result.expect_err("non-disagreement variant must propagate");
-        let chain = format!("{propagated:#}");
-        assert!(
-            chain.contains("Failed to call consensus for UMI: UMI_FATAL"),
-            "context must include the UMI; got: {chain}"
-        );
-        assert!(
-            chain.contains("synthetic upstream failure"),
-            "underlying source must be preserved; got: {chain}"
-        );
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // CodecOptions / MultiCodecOptions parity (multi_options)
-    // ─────────────────────────────────────────────────────────────────────
-
-    /// `MultiCodecOptions` derives `clap::Args`, not `Parser` — flatten it
-    /// into a local wrapper to drive it through `try_parse_from`.
-    #[derive(clap::Parser, Debug)]
-    struct PrefixedCodec {
-        #[command(flatten)]
-        opts: MultiCodecOptions,
-    }
-
-    /// The re-exposed `MultiCodecOptions` defaults must equal the standalone
-    /// `codec` command's defaults, projected through `to_codec_options`.
-    /// Unlike simplex, `min_reads` has a `default_value` on the standalone
-    /// command, so `MultiCodecOptions` is NOT staged-required and validates
-    /// with no flags at all.
-    #[test]
-    fn multi_codec_options_defaults_match_command() {
-        let base = Codec::try_parse_from(["codec", "-i", "in.bam", "-o", "o.bam"])
-            .expect("parses")
-            .to_codec_options();
-        let multi =
-            PrefixedCodec::try_parse_from(["x"]).expect("parses").opts.validate().expect("valid");
-
-        assert_eq!(multi.error_rate_pre_umi, base.error_rate_pre_umi);
-        assert_eq!(multi.error_rate_post_umi, base.error_rate_post_umi);
-        assert_eq!(multi.min_input_base_quality, base.min_input_base_quality);
-        assert_eq!(multi.output_per_base_tags, base.output_per_base_tags);
-        assert_eq!(multi.trim, base.trim);
-        assert_eq!(multi.min_consensus_base_quality, base.min_consensus_base_quality);
-        assert_eq!(multi.tie_rule, base.tie_rule);
-        assert_eq!(multi.min_reads, base.min_reads);
-        assert_eq!(multi.min_reads, 1);
-        assert_eq!(multi.max_reads, base.max_reads);
-        assert_eq!(multi.min_duplex_length, base.min_duplex_length);
-        assert_eq!(multi.min_duplex_length, 1);
-        assert_eq!(multi.legacy_overlap_window, base.legacy_overlap_window);
-        assert_eq!(multi.single_strand_qual, base.single_strand_qual);
-        assert_eq!(multi.outer_bases_qual, base.outer_bases_qual);
-        assert_eq!(multi.outer_bases_length, base.outer_bases_length);
-        assert_eq!(multi.outer_bases_length, 5);
-        assert!(
-            (multi.max_duplex_disagreement_rate - base.max_duplex_disagreement_rate).abs() < 1e-12
-        );
-        assert!((multi.max_duplex_disagreement_rate - 1.0).abs() < 1e-12);
-        assert_eq!(multi.max_duplex_disagreements, base.max_duplex_disagreements);
-
-        assert_eq!(multi.allow_unmapped.enabled, base.allow_unmapped.enabled);
-        assert_eq!(multi.io.async_reader, base.io.async_reader);
-        assert_eq!(multi.io.check_crc, base.io.check_crc);
-        assert_eq!(multi.io.no_check_crc, base.io.no_check_crc);
-        assert_eq!(multi.rejects_opts.rejects, base.rejects_opts.rejects);
-        assert_eq!(multi.stats_opts.stats, base.stats_opts.stats);
-        assert_eq!(multi.read_group.read_group_id, base.read_group.read_group_id);
-        assert_eq!(multi.read_group.read_name_prefix, base.read_group.read_name_prefix);
-    }
-
-    /// A prefixed flag must round-trip through `MultiCodecOptions::validate`.
-    #[test]
-    fn multi_codec_options_round_trips_outer_bases_length() {
-        let multi = PrefixedCodec::try_parse_from(["x", "--codec::outer-bases-length", "7"])
-            .expect("parses")
-            .opts
-            .validate()
-            .expect("valid");
-        assert_eq!(multi.outer_bases_length, 7);
-    }
-
-    /// Guards the hand-written `impl Default for CodecOptions` against
-    /// drifting from the standalone `codec` command's
-    /// `#[arg(default_value...)]` literals.
-    #[test]
-    fn codec_options_default_matches_cli_defaults() {
-        let parsed = Codec::try_parse_from(["codec", "-i", "in.bam", "-o", "o.bam"])
-            .expect("parses")
-            .to_codec_options();
-        let d = CodecOptions::default();
-        assert_eq!(d.error_rate_pre_umi, parsed.error_rate_pre_umi);
-        assert_eq!(d.error_rate_post_umi, parsed.error_rate_post_umi);
-        assert_eq!(d.min_input_base_quality, parsed.min_input_base_quality);
-        assert_eq!(d.output_per_base_tags, parsed.output_per_base_tags);
-        assert_eq!(d.trim, parsed.trim);
-        assert_eq!(d.min_consensus_base_quality, parsed.min_consensus_base_quality);
-        assert_eq!(d.min_reads, parsed.min_reads);
-        assert_eq!(d.min_duplex_length, parsed.min_duplex_length);
-        assert_eq!(d.outer_bases_length, parsed.outer_bases_length);
-        assert!(
-            (d.max_duplex_disagreement_rate - parsed.max_duplex_disagreement_rate).abs() < 1e-12
-        );
-        // Chain-engine skip field: no `--codec::tie-rule` CLI flag exists to
-        // parse, so compare directly against the resolved default.
-        assert_eq!(d.tie_rule, fgumi_consensus::TieRule::default());
-        // Skip field: `AllowUnmappedOptions` has no `PartialEq`, so compare its
-        // `enabled` flag directly against the `#[arg(skip = ...)]` literal.
-        assert!(!d.allow_unmapped.enabled);
     }
 }

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -6,11 +6,11 @@
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use std::sync::Arc;
 
 use crate::assigner::Strategy;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use crate::logging::OperationTimer;
 use crate::unified_pipeline::{
     BACKPRESSURE_THRESHOLD_BYTES, BamPipelineConfig, Q5_BACKPRESSURE_THRESHOLD_BYTES,
@@ -22,7 +22,7 @@ use clap::Args;
 use fgumi_bam_io::is_stdout_path;
 use fgumi_consensus::methylation::RefBaseProvider;
 use fgumi_umi::IndexThreshold;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use log::{info, warn};
 use noodles::sam::Header;
 
@@ -108,7 +108,7 @@ pub fn resolve_methylation_mode(
 }
 
 /// Methylation reference pair: reference base provider + contig name mapping.
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub type MethylationRef = Option<(
     Arc<dyn fgumi_consensus::methylation::RefBaseProvider + Send + Sync>,
     Arc<Vec<String>>,
@@ -117,7 +117,7 @@ pub type MethylationRef = Option<(
 /// Loads the reference FASTA and builds contig name mapping for methylation-aware modes.
 ///
 /// Returns `None` if methylation mode is disabled. Errors if enabled but `reference` is `None`.
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub fn load_methylation_reference(
     methylation_mode: fgumi_consensus::MethylationMode,
     reference: &Option<PathBuf>,
@@ -1580,11 +1580,23 @@ impl QueueMemoryOptions {
 /// downstream BGZF compression stage operates on the framed bytes verbatim.
 ///
 /// Used by command-level `serialize_fn` and `secondary_serialize_fn`
-/// closures that produce raw record bytes (e.g. `commands::filter`,
-/// the `--rejects` paths in `commands::correct`/`simplex`/`duplex`/`codec`).
+/// closures that produce raw record bytes: `commands::filter`'s no-`--threads`
+/// pipeline and the `--rejects` path in `commands::correct`'s legacy
+/// `execute_threads_mode`.
 ///
 /// Generic over `R: AsRef<[u8]>` so callers can pass either
 /// `&[fgumi_raw_bam::RawRecord]` or `&[Vec<u8>]` without copying.
+///
+/// `#[allow(dead_code)]`: after this PR retired the `simplex`/`duplex`/`codec`
+/// serial paths (their non-generic `--rejects` call sites), the only remaining
+/// references are through generic pipeline code (`filter::run_filter_pipeline`,
+/// still live on filter's not-yet-migrated no-`--threads` path) and
+/// `correct::execute_threads_mode` (itself already `#[allow(dead_code)]` — see
+/// its doc). `cargo ci-lint`'s reachability analysis does not credit those
+/// generic/legacy references, so it flags this as dead even though it is live
+/// on filter's path — the same migration-transitional situation, and the same
+/// remedy, as `correct::execute_threads_mode`. Drop the attribute once filter's
+/// serial path is retired and this becomes a genuine chain-only helper.
 ///
 /// # Errors
 ///
@@ -1598,6 +1610,7 @@ impl QueueMemoryOptions {
 /// Both error paths are checked in a single up-front validation pass, so
 /// `output` is never partially appended on error: either every record is
 /// written or none of `output`'s bytes are touched.
+#[allow(dead_code)]
 pub(crate) fn serialize_raw_bam_records<R: AsRef<[u8]>>(
     records: &[R],
     output: &mut Vec<u8>,

--- a/src/lib/commands/consensus_runner.rs
+++ b/src/lib/commands/consensus_runner.rs
@@ -3,7 +3,7 @@
 //! This module provides shared traits and utilities used by simplex, duplex, and codec
 //! consensus calling commands to reduce code duplication.
 
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 use crate::consensus::codec_caller::CodecConsensusStats;
 use crate::consensus_caller::ConsensusCallingStats;
 use crate::metrics::consensus::ConsensusMetrics;
@@ -49,7 +49,7 @@ impl ConsensusStatsOps for ConsensusCallingStats {
     }
 }
 
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 impl ConsensusStatsOps for CodecConsensusStats {
     fn merge(&mut self, other: &Self) {
         self.total_input_reads += other.total_input_reads;
@@ -413,7 +413,7 @@ mod tests {
     /// into `ConsensusMetrics`, which is the only thing `to_kv_metrics` can see.
     /// They were dropped here, so all five fgbio codec rows were absent from
     /// `codec --stats` regardless of what the caller had counted.
-    #[cfg(feature = "codec")]
+    #[cfg(feature = "consensus")]
     #[test]
     fn test_codec_stats_to_metrics_carries_codec_counters() {
         let mut stats = CodecConsensusStats {

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -5,100 +5,26 @@
 //! 1. Single-strand consensus for /A and /B reads separately
 //! 2. Duplex consensus from paired single-strand consensuses
 //!
-//! When `--rejects` is set, the threaded pipeline routes rejected records through
-//! the unified pipeline's first-class secondary output (see
-//! [`crate::unified_pipeline::run_bam_pipeline_from_reader_with_secondary`]).
-//! Caller-emitted rejects flow through a per-batch buffer and land in batch-input
-//! order. The rejects BAM advertises the input header so raw-input RG/PG/contig
-//! metadata is preserved. The pattern matches `commands::filter`,
-//! `commands::correct`, and `commands::simplex`.
+//! When `--rejects` is set, the declarative chain (see [`crate::pipeline::chains`])
+//! routes rejected records through its rejects fan-out branch, landing in
+//! batch-input order. The rejects BAM advertises the input header so
+//! raw-input RG/PG/contig metadata is preserved. The pattern matches
+//! `commands::filter`, `commands::correct`, and `commands::simplex`.
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use clap::Parser;
-use fgoxide::io::DelimFile;
-use fgumi_bam_io::{
-    create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
-    create_raw_bam_reader_with_opts,
-};
 use std::path::Path;
 
+use super::command::Command;
 use super::common::{
     AllowUnmappedOptions, BamIoOptions, CompressionOptions, ConsensusCallingOptions,
     OverlappingConsensusOptions, QueueMemoryOptions, ReadGroupOptions, RejectsOptions,
-    SchedulerOptions, StatsOptions, ThreadingOptions, build_pipeline_config,
-    consensus_pregroup_keep_flags, consensus_pregroup_keep_raw, reject_output_collisions,
-    serialize_raw_bam_records,
+    SchedulerOptions, StatsOptions, ThreadingOptions, reject_output_collisions,
 };
-use crate::commands::consensus_runner::{
-    ConsensusStatsOps, create_unmapped_consensus_header, log_overlapping_stats,
-};
-use crate::consensus_caller::{ConsensusCaller, ConsensusCallingStats, ConsensusOutput};
 use crate::duplex_consensus_caller::DuplexConsensusCaller;
-use crate::logging::{OperationTimer, log_consensus_summary};
-use crate::mi_group::{MiGroup, MiGroupBatch, MiGroupIterator, MiGrouper};
-use crate::overlapping_consensus::{
-    AgreementStrategy, CorrectionStats, DisagreementStrategy, OverlappingBasesConsensusCaller,
-    apply_overlapping_consensus,
-};
-use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::read_info::LibraryIndex;
 use crate::sam::SamTag;
-use crate::umi::extract_mi_base;
-use crate::unified_pipeline::{
-    GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
-    run_bam_pipeline_from_reader_with_secondary,
-};
-use fgumi_bam_io::ProgressTracker;
 use fgumi_raw_bam;
-use fgumi_raw_bam::{RawRecord, RawRecordView};
-use log::info;
-use noodles::sam::Header;
-use noodles::sam::alignment::record::data::field::Tag;
-use std::io;
-use std::io::Write as IoWrite;
-use std::sync::Arc;
-
-use super::command::Command;
-
-use super::common::{MethylationRef, load_methylation_reference};
-
-// ============================================================================
-// Types for 7-step pipeline processing
-// ============================================================================
-
-/// Result from processing a batch of MI groups through duplex consensus calling.
-struct DuplexProcessedBatch {
-    /// Consensus reads to write to output BAM
-    consensus_output: ConsensusOutput,
-    /// Raw-byte rejected records (consensus-caller rejects), in batch-input
-    /// order. Empty unless `track_rejects` is true.
-    rejected_records: Vec<Vec<u8>>,
-    /// Number of MI groups in this batch
-    groups_count: u64,
-    /// Consensus calling statistics for this batch
-    stats: ConsensusCallingStats,
-    /// Overlapping correction stats for this batch (if enabled)
-    overlapping_stats: Option<CorrectionStats>,
-}
-
-impl MemoryEstimate for DuplexProcessedBatch {
-    fn estimate_heap_size(&self) -> usize {
-        let rej_size: usize = self.rejected_records.iter().map(Vec::capacity).sum();
-        let rej_vec_overhead = self.rejected_records.capacity() * std::mem::size_of::<Vec<u8>>();
-        self.consensus_output.estimate_heap_size() + rej_size + rej_vec_overhead
-    }
-}
-
-/// Metrics collected from each batch during parallel processing.
-#[derive(Default)]
-struct CollectedDuplexMetrics {
-    /// Consensus calling statistics
-    stats: ConsensusCallingStats,
-    /// Overlapping consensus stats (if enabled)
-    overlapping_stats: Option<CorrectionStats>,
-    /// Number of MI groups processed
-    groups_processed: u64,
-}
+use fgumi_raw_bam::RawRecord;
 
 /// Call duplex consensus reads from grouped reads with /A and /B MI tags
 #[derive(Parser, Debug)]
@@ -541,293 +467,21 @@ impl Command for Duplex {
         // Validate consensus arguments (e.g. error rates must be > 0).
         self.validate()?;
 
-        // ---- --threads N on a consensus build: run on the declarative chain ----
-        // Dispatch here, after the reader-free pre-flight (io.validate /
-        // output-collision / validate — which must run on both paths) and BEFORE
-        // building the timer/reader below, because `execute_chain` -> `add_duplex`
-        // builds its own timer and reader. Placing the dispatch above the timer
-        // avoids logging the "Calling duplex consensus" start line twice on the
-        // threaded path. On a non-consensus build the chain machinery isn't
-        // compiled, so this block is absent and we fall through to legacy.
-        #[cfg(feature = "consensus")]
-        if self.threading.threads.is_some() {
-            return self.execute_chain(command_line);
-        }
-
-        // Start timing (legacy single-threaded path only; the chain path above
-        // builds its own timer).
-        let timer = OperationTimer::new("Calling duplex consensus");
-
-        // Get threading configuration (duplex is worker-heavy with consensus calling)
-        let reader_threads = self.threading.num_threads();
-        let worker_threads = self.threading.num_threads();
-        let writer_threads = self.threading.num_threads();
-
-        info!("Duplex");
-        info!("  Input: {}", self.io.input.display());
-        info!("  Output: {}", self.io.output.display());
-        info!("  Min reads: {:?}", self.min_reads);
-        info!("  Min base quality: {}", self.consensus.min_input_base_quality);
-        info!("  Output per-base tags: {}", self.consensus.output_per_base_tags);
-        info!("  Worker threads: {worker_threads}");
-        info!("  Reader threads: {reader_threads}");
-        info!("  Trim reads: {}", self.consensus.trim);
-        info!("  Max reads per strand: {:?}", self.max_reads_per_strand);
-        info!(
-            "  Consensus call overlapping bases: {}",
-            self.overlapping.consensus_call_overlapping_bases
-        );
-
-        // Cell barcode tag is fixed to the SAM standard CB tag
-        let cell_tag = Tag::from(SamTag::CB);
-
-        // Enable rejects tracking if rejects file is specified
-        let track_rejects = self.rejects_opts.is_enabled();
-
         if self.reference.is_some() && self.methylation_mode.is_none() {
             bail!("--ref requires --methylation-mode to be set");
         }
-        let methylation_mode =
-            crate::commands::common::resolve_methylation_mode(self.methylation_mode);
 
-        // Track overlapping consensus settings (callers created per-thread in threaded mode)
-        let overlapping_enabled = self.overlapping.consensus_call_overlapping_bases;
-        if overlapping_enabled {
-            info!("Overlapping consensus calling enabled");
-        }
-
-        // Process reads grouped by MI tag (streaming approach)
-        info!("Processing reads...");
-        // Both the single-threaded fast path (create_raw_bam_reader_with_opts)
-        // and the multi-threaded pipeline honor --check-crc/--no-check-crc (#800).
-        self.io.log_effective_check_crc();
-
-        // ============================================================
-        // --threads N mode: Use 7-step unified pipeline
-        // None: Use single-threaded fast path
-        // ============================================================
-        // IMPORTANT: Check threading BEFORE opening any reader so we only open
-        // the input once — opening twice wastes I/O and breaks stdin streaming.
-        if let Some(threads) = self.threading.threads {
-            let (reader, header) = create_bam_reader_for_pipeline_with_opts(
-                &self.io.input,
-                self.io.pipeline_reader_opts(),
-            )?;
-            crate::commands::common::check_consensus_sort_order(
-                &header,
-                &self.io.input.display().to_string(),
-            )?;
-            let header = crate::commands::common::add_pg_record(header, command_line)?;
-            let read_name_prefix = self.read_group.prefix_or_from_header(&header);
-            let methylation_ref: MethylationRef =
-                load_methylation_reference(methylation_mode, &self.reference, &header)?;
-
-            let result = self.execute_threads_mode(
-                threads,
-                reader,
-                header,
-                read_name_prefix,
-                track_rejects,
-                command_line,
-                methylation_ref,
-                methylation_mode,
-            );
-            timer.log_completion(0); // Completion logged in execute_threads_mode
-            return result;
-        }
-
-        // Single-threaded fast path: open the raw reader once and derive the header from it.
-        let (mut raw_reader, header) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
-        crate::commands::common::check_consensus_sort_order(
-            &header,
-            &self.io.input.display().to_string(),
-        )?;
-        let header = crate::commands::common::add_pg_record(header, command_line)?;
-        let read_name_prefix = self.read_group.prefix_or_from_header(&header);
-        let methylation_ref: MethylationRef =
-            load_methylation_reference(methylation_mode, &self.reference, &header)?;
-
-        // Consensus reads are unmapped and carry the single collapsed read group, so the
-        // output advertises a freshly built consensus header (no @SQ, no SS sub-sort)
-        // rather than the input header — matching fgbio and the `--threads` path below.
-        let read_group_id = &self.read_group.read_group_id;
-        let output_header =
-            create_unmapped_consensus_header(&header, read_group_id, "Read group", command_line)?;
-
-        // ============================================================
-        // For non-pipeline modes, create output writers here
-        // ============================================================
-
-        // Create output BAM writer with multi-threaded BGZF compression
-        let mut writer = create_bam_writer(
-            &self.io.output,
-            &output_header,
-            writer_threads,
-            self.compression.compression_level,
-        )?;
-
-        // Create optional rejects writer
-        let mut rejects_writer = create_optional_bam_writer(
-            self.rejects_opts.rejects.as_ref(),
-            &header,
-            writer_threads,
-            self.compression.compression_level,
-        )?;
-
-        // Create duplex consensus caller
-        // Note: Threading is handled here in duplex.rs, not in DuplexConsensusCaller
-        let mut consensus_caller = DuplexConsensusCaller::new(
-            read_name_prefix.clone(),
-            self.read_group.read_group_id.clone(),
-            self.min_reads.clone(),
-            self.consensus.min_input_base_quality,
-            self.consensus.output_per_base_tags,
-            self.consensus.trim,
-            self.max_reads_per_strand,
-            Some(cell_tag),
-            track_rejects,
-            self.consensus.error_rate_pre_umi,
-            self.consensus.error_rate_post_umi,
-        )?
-        .with_tie_rule(self.consensus.tie_rule.into());
-
-        // Set reference for methylation-aware consensus if enabled
-        if let Some((ref reference, ref ref_names)) = methylation_ref {
-            consensus_caller.set_reference(
-                Arc::clone(reference),
-                Arc::clone(ref_names),
-                methylation_mode,
-            );
-        }
-
-        // Accumulator for overlapping stats from parallel processing
-        let mut merged_overlapping_stats = CorrectionStats::new();
-
-        // Track progress and aggregate stats
-        let mut consensus_count = 0usize;
-        let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
-
-        // Use the raw_reader opened above (single input open). Apply the fgbio
-        // pre-group filter: always drop secondary/supplementary; --allow-unmapped
-        // relaxes only the mapped-record rule.
-        let allow_unmapped = self.allow_unmapped.enabled;
-        let raw_record_iter = std::iter::from_fn(move || {
-            loop {
-                let mut record = RawRecord::new();
-                match raw_reader.read_record(&mut record) {
-                    Ok(0) => return None, // EOF
-                    Ok(_) => {
-                        if consensus_pregroup_keep_flags(
-                            RawRecordView::new(&record).flags(),
-                            allow_unmapped,
-                        ) {
-                            return Some(Ok(record));
-                        }
-                        // Otherwise filtered out: keep reading.
-                    }
-                    Err(e) => return Some(Err(e.into())),
-                }
-            }
-        });
-
-        // Group by base MI (strip /A, /B suffix) for streaming using raw bytes
-        let mi_group_iter =
-            MiGroupIterator::with_transform(raw_record_iter, "MI", |mi_bytes: &[u8]| {
-                let mi_str = String::from_utf8_lossy(mi_bytes);
-                extract_mi_base(&mi_str).to_string()
-            })
-            .with_cell_tag(Some(*SamTag::CB));
-        // Single-threaded processing
-        // Create overlapping consensus caller for single-threaded mode
-        let single_strand_allowed = self.allows_single_strand_consensus();
-        let mut overlapping_caller = if overlapping_enabled {
-            Some(OverlappingBasesConsensusCaller::new(
-                AgreementStrategy::Consensus,
-                DisagreementStrategy::Consensus,
-            ))
-        } else {
-            None
-        };
-
-        for group_result in mi_group_iter {
-            let (_base_mi, mut records) = group_result.context("Failed to read MI group")?;
-
-            // Apply overlapping consensus if enabled (modifies raw bytes in-place).
-            // Skip single-strand groups only when they cannot produce a consensus anyway.
-            if let Some(ref mut oc) = overlapping_caller
-                && (single_strand_allowed || has_both_strands_raw(&records))
-            {
-                apply_overlapping_consensus(&mut records, oc)?;
-            }
-
-            // Call consensus directly — records are already RawRecord values.
-            let output = consensus_caller.consensus_reads(records)?;
-
-            // Write pre-serialized consensus reads
-            let batch_size = output.count;
-            consensus_count += batch_size;
-            writer.get_mut().write_all(&output.data).context("Failed to write consensus read")?;
-            progress.log_if_needed(batch_size as u64);
-        }
-
-        // Collect stats from single-threaded caller and merge overlapping stats
-        let merged_stats = consensus_caller.statistics();
-        if let Some(ref oc) = overlapping_caller {
-            merged_overlapping_stats.merge(oc.stats());
-        }
-
-        // Write rejected reads as raw BAM bytes if tracking is enabled
-        if let Some(ref mut rw) = rejects_writer {
-            let rejected_reads = consensus_caller.rejected_reads();
-            for raw_record in rejected_reads {
-                let block_size = raw_record.len() as u32;
-                rw.get_mut()
-                    .write_all(&block_size.to_le_bytes())
-                    .context("Failed to write rejected read block size")?;
-                rw.get_mut().write_all(raw_record).context("Failed to write rejected read")?;
-            }
-            info!("Wrote {} rejected reads", rejected_reads.len());
-        }
-
-        // Finish the rejects writer to ensure BGZF EOF marker is written
-        if let Some(rw) = rejects_writer {
-            rw.into_inner().finish().context("Failed to finish rejects file")?;
-        }
-
-        progress.log_final();
-
-        // Finish the buffered writer (flush remaining records and wait for writer thread)
-        writer.into_inner().finish().context("Failed to finish output BAM")?;
-
-        // Log overlapping consensus statistics if enabled
-        if overlapping_enabled {
-            log_overlapping_stats(&merged_overlapping_stats);
-        }
-
-        // Convert stats to metrics and log. `consensus_reads` comes from the caller's own
-        // accounting rather than the locally tracked write count so both this path and
-        // `execute_threads_mode` report the same number for the same input.
-        let metrics = merged_stats.to_metrics();
-        log_consensus_summary(&metrics);
-
-        // Write statistics file if requested. Emit the same fgbio seeded key-value format as
-        // the multi-threaded path (`execute_threads_mode`) so duplex metrics output is
-        // thread-independent — the single-threaded path previously wrote the wide format,
-        // omitting the always-seeded `usedByDuplex` rejection rows (R2-MET-05).
-        if let Some(stats_path) = &self.stats_opts.stats {
-            let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Duplex);
-            DelimFile::default().write_tsv(stats_path, kv_metrics).map_err(|e| {
-                anyhow::anyhow!("Failed to write statistics to {}: {}", stats_path.display(), e)
-            })?;
-            info!("Statistics written to: {}", stats_path.display());
-        }
-
-        // Log timing completion
-        timer.log_completion(consensus_count as u64);
-
-        info!("Done!");
-        Ok(())
+        // The declarative chain is the only execution path: `execute` runs the
+        // reader-free pre-flight above (io.validate / output-collision /
+        // validate / the `--ref requires --methylation-mode` bail) and then
+        // always dispatches to `execute_chain`, with or without `--threads`
+        // (absent `--threads` runs the chain at a single worker). `add_duplex`
+        // logs the `Calling duplex consensus` timer and the `Starting Duplex`
+        // banner + option lines; the duplex finalize hook logs the overlapping
+        // stats, the summary, and the `--stats` TSV. Running any of those here
+        // would double-log and pre-consume stdin, so `execute` only does the
+        // pre-flight above.
+        self.execute_chain(command_line)
     }
 }
 
@@ -868,29 +522,15 @@ impl Duplex {
         self.to_duplex_options().validate_numeric()
     }
 
-    /// Whether a molecule seen on only one strand can still yield a consensus, i.e. whether
-    /// the per-strand minimum for the less-covered strand is 0 (fgbio's `-M 1 1 0` mode).
+    /// Run the duplex stage on the declarative chain builder — the only
+    /// execution path, with or without `--threads`.
     ///
-    /// Delegates to `DuplexConsensusCaller`, which owns the `padTo(3, last)` rule, so this
-    /// gate cannot drift from the `min_yx_reads` the caller actually applies. The threaded
-    /// path needs the answer before a caller exists, which is why the delegate takes the
-    /// raw `min_reads` slice rather than reading it off a constructed caller.
-    fn allows_single_strand_consensus(&self) -> bool {
-        DuplexConsensusCaller::allows_single_strand_consensus(&self.min_reads)
-    }
-
-    /// Run the duplex stage on the declarative chain builder (the `--threads N`
-    /// path on a `consensus`-feature build).
-    ///
-    /// Replaces the hand-rolled unified-pipeline construction in `execute` for
-    /// the threaded case. The chain opens its own source, validates the
-    /// template-coordinate sort order, calls consensus, writes the output BAM,
-    /// and writes the rejects/stats via `DuplexFinalizeHook` — all through the
-    /// same shared helpers as the non-chain path, so the two orchestrations stay
-    /// in parity. The no-`--threads` path keeps its own single-threaded fast
-    /// path in `execute`, which is the in-process parity oracle for this one
-    /// (see `test_duplex_chain_matches_single_threaded`).
-    #[cfg(feature = "consensus")]
+    /// The chain opens its own source, validates the template-coordinate sort
+    /// order, calls consensus, writes the output BAM, and writes the
+    /// rejects/stats via `DuplexFinalizeHook`. `--threads 1` (or absent
+    /// `--threads`) runs the chain at a single worker, which is the in-process
+    /// parity oracle for the multi-worker case (see
+    /// `test_duplex_chain_matches_single_threaded`).
     fn execute_chain(&self, command_line: &str) -> Result<()> {
         use crate::pipeline::chains::{
             ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
@@ -908,282 +548,6 @@ impl Duplex {
         };
         let spec = ChainSpec::single_stage(Stage::Duplex, stage_opts, &ctx);
         build_for(spec)?.run()
-    }
-
-    /// Execute using 7-step unified pipeline with --threads.
-    ///
-    /// This method is called when `--threads N` is specified with N > 1.
-    /// It uses the lock-free 7-step unified pipeline for maximum performance.
-    #[expect(clippy::too_many_arguments, reason = "pipeline setup needs all configuration")]
-    fn execute_threads_mode(
-        &self,
-        num_threads: usize,
-        reader: Box<dyn std::io::Read + Send>,
-        input_header: Header,
-        read_name_prefix: String,
-        track_rejects: bool,
-        command_line: &str,
-        methylation_ref: MethylationRef,
-        methylation_mode: fgumi_consensus::MethylationMode,
-    ) -> Result<()> {
-        // Create output header (for duplex, output is unmapped like simplex)
-        let output_header = create_unmapped_consensus_header(
-            &input_header,
-            &self.read_group.read_group_id,
-            "Read group",
-            command_line,
-        )?;
-
-        // Configure pipeline
-        let mut pipeline_config = build_pipeline_config(
-            &self.scheduler_opts,
-            &self.compression,
-            &self.queue_memory,
-            &self.io,
-            num_threads,
-        )?;
-
-        // Per-thread metrics accumulator: bounded metric memory, no unbounded
-        // queue. Rejects buffering semantics are preserved (see follow-up).
-        let collected_metrics = PerThreadAccumulator::<CollectedDuplexMetrics>::new(num_threads);
-        let collected_metrics_for_serialize = Arc::clone(&collected_metrics);
-
-        // Capture configuration for closures
-        let single_strand_allowed = self.allows_single_strand_consensus();
-        let min_reads = self.min_reads.clone();
-        let min_input_base_quality = self.consensus.min_input_base_quality;
-        let output_per_base_tags = self.consensus.output_per_base_tags;
-        let trim = self.consensus.trim;
-        let max_reads_per_strand = self.max_reads_per_strand;
-        let error_rate_pre_umi = self.consensus.error_rate_pre_umi;
-        let error_rate_post_umi = self.consensus.error_rate_post_umi;
-        let tie_rule: fgumi_consensus::TieRule = self.consensus.tie_rule.into();
-        let overlapping_enabled = self.overlapping.consensus_call_overlapping_bases;
-        let read_group_id = self.read_group.read_group_id.clone();
-        let cell_tag = Tag::from(SamTag::CB);
-        let batch_size = 100; // MI groups per batch
-
-        // Apply the fgbio pre-group filter: always drop secondary/supplementary;
-        // --allow-unmapped relaxes only the mapped-record rule.
-        let allow_unmapped = self.allow_unmapped.enabled;
-
-        // MI transform for raw bytes: strip /A and /B suffixes for duplex grouping
-        let mi_transform = |mi_bytes: &[u8]| -> String {
-            let mi_str = String::from_utf8_lossy(mi_bytes);
-            extract_mi_base(&mi_str).to_string()
-        };
-
-        // Rejects flow through the unified pipeline's first-class secondary
-        // output (see correct.rs / simplex.rs / filter.rs for the shared
-        // pattern). `process_fn` collects caller-emitted rejects into
-        // `DuplexProcessedBatch::rejected_records`; the pipeline's
-        // `secondary_serialize_fn` writes them in batch-input order with the
-        // input header.
-
-        let library_index = LibraryIndex::from_header(&input_header);
-        pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
-
-        // ========== grouper_fn ==========
-        let grouper_fn = move |_header: &Header| {
-            let grouper = MiGrouper::new("MI", batch_size)
-                .with_mi_transform(mi_transform)
-                .with_cell_tag(Some(*SamTag::CB))
-                .with_record_filter(move |raw| consensus_pregroup_keep_raw(raw, allow_unmapped));
-            Box::new(grouper) as Box<dyn Grouper<Group = MiGroupBatch> + Send>
-        };
-
-        // ========== process_fn: Duplex consensus calling ==========
-        let process_fn = move |batch: MiGroupBatch| -> io::Result<DuplexProcessedBatch> {
-            // Create per-thread duplex consensus caller
-            let mut caller = DuplexConsensusCaller::new(
-                read_name_prefix.clone(),
-                read_group_id.clone(),
-                min_reads.clone(),
-                min_input_base_quality,
-                output_per_base_tags,
-                trim,
-                max_reads_per_strand,
-                Some(cell_tag),
-                track_rejects,
-                error_rate_pre_umi,
-                error_rate_post_umi,
-            )
-            .map_err(|e| io::Error::other(format!("Failed to create DuplexConsensusCaller: {e}")))?
-            .with_tie_rule(tie_rule);
-
-            // Set reference for methylation-aware consensus if enabled
-            if let Some((ref reference, ref ref_names)) = methylation_ref {
-                caller.set_reference(
-                    Arc::clone(reference),
-                    Arc::clone(ref_names),
-                    methylation_mode,
-                );
-            }
-
-            // Create overlapping caller if enabled
-            let mut overlapping_caller = if overlapping_enabled {
-                Some(OverlappingBasesConsensusCaller::new(
-                    AgreementStrategy::Consensus,
-                    DisagreementStrategy::Consensus,
-                ))
-            } else {
-                None
-            };
-
-            let mut all_output = ConsensusOutput::default();
-            let mut batch_stats = ConsensusCallingStats::new();
-            let mut batch_overlapping = CorrectionStats::new();
-            let groups_count = batch.groups.len() as u64;
-            // Caller-emitted rejects collected per-batch and drained by the
-            // pipeline's secondary serializer.
-            let mut rejected_records: Vec<Vec<u8>> = Vec::new();
-
-            for MiGroup { mi, records: mut group_reads } in batch.groups {
-                caller.clear();
-
-                // Apply overlapping consensus if enabled (modifies raw bytes in-place).
-                // Skip single-strand groups only when they cannot produce a consensus anyway.
-                // Propagate errors to match single-threaded behavior; silent drops here
-                // would turn real failures into output gaps in --threads mode only.
-                if let Some(ref mut oc) = overlapping_caller
-                    && (single_strand_allowed || has_both_strands_raw(&group_reads))
-                {
-                    oc.reset_stats();
-                    apply_overlapping_consensus(&mut group_reads, oc).map_err(|e| {
-                        io::Error::other(format!("Overlapping consensus error for MI {mi}: {e}"))
-                    })?;
-                    batch_overlapping.merge(oc.stats());
-                }
-
-                // Call duplex consensus directly — records are already RawRecord values.
-                // Propagate errors to match single-threaded behavior; a warn-and-drop here
-                // would silently turn real failures (OOM, malformed records, etc.) into
-                // output gaps in --threads mode only.
-                let batch_output = caller.consensus_reads(group_reads).map_err(|e| {
-                    io::Error::other(format!("Duplex consensus error for MI {mi}: {e}"))
-                })?;
-                all_output.merge(batch_output);
-                batch_stats.merge(&caller.statistics());
-                if track_rejects {
-                    for raw in caller.take_rejected_reads() {
-                        rejected_records.push(raw);
-                    }
-                }
-            }
-
-            Ok(DuplexProcessedBatch {
-                consensus_output: all_output,
-                rejected_records,
-                groups_count,
-                stats: batch_stats,
-                overlapping_stats: if overlapping_enabled { Some(batch_overlapping) } else { None },
-            })
-        };
-
-        // ========== serialize_fn: Serialize + collect metrics ==========
-        let serialize_fn = move |processed: DuplexProcessedBatch,
-                                 _header: &Header,
-                                 output: &mut Vec<u8>|
-              -> io::Result<u64> {
-            // Merge per-batch metrics into this worker's accumulator slot.
-            // Rejects are drained by `secondary_serialize_fn` separately.
-            let batch_stats = processed.stats;
-            let batch_overlapping = processed.overlapping_stats;
-            let groups_count = processed.groups_count;
-            collected_metrics_for_serialize.with_slot(|m| {
-                m.stats.merge(&batch_stats);
-                if let Some(o) = batch_overlapping {
-                    m.overlapping_stats.get_or_insert_with(CorrectionStats::new).merge(&o);
-                }
-                m.groups_processed += groups_count;
-            });
-
-            let count = processed.consensus_output.count as u64;
-            output.extend_from_slice(&processed.consensus_output.data);
-            Ok(count)
-        };
-
-        // ========== secondary_serialize_fn: Drain rejected records ==========
-        let secondary_serialize_fn =
-            |batch: &DuplexProcessedBatch, buf: &mut Vec<u8>| -> io::Result<u64> {
-                serialize_raw_bam_records(&batch.rejected_records, buf)
-            };
-
-        // Run the 7-step pipeline with the already-opened reader (supports streaming).
-        // When `--rejects` is set, route rejects through the unified pipeline's
-        // first-class secondary output so they land in input/batch-serial order
-        // and the rejects BAM carries the input header.
-        let consensus_reads_written = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref()
-        {
-            let secondary_header = input_header.clone();
-            run_bam_pipeline_from_reader_with_secondary(
-                pipeline_config,
-                reader,
-                input_header,
-                &self.io.output,
-                Some(output_header.clone()),
-                rejects_path,
-                Some(secondary_header),
-                grouper_fn,
-                process_fn,
-                serialize_fn,
-                secondary_serialize_fn,
-            )
-            .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?
-        } else {
-            run_bam_pipeline_from_reader(
-                pipeline_config,
-                reader,
-                input_header,
-                &self.io.output,
-                Some(output_header.clone()),
-                grouper_fn,
-                process_fn,
-                serialize_fn,
-            )
-            .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?
-        };
-
-        // ========== Post-pipeline: Aggregate metrics ==========
-        let mut total_groups = 0u64;
-        let mut merged_stats = ConsensusCallingStats::new();
-        let mut merged_overlapping_stats = CorrectionStats::new();
-
-        for slot in collected_metrics.slots() {
-            let m = slot.lock();
-            total_groups += m.groups_processed;
-            merged_stats.merge(&m.stats);
-            if let Some(ref ocs) = m.overlapping_stats {
-                merged_overlapping_stats.merge(ocs);
-            }
-        }
-
-        // Log overlapping consensus statistics if enabled
-        if self.overlapping.consensus_call_overlapping_bases {
-            log_overlapping_stats(&merged_overlapping_stats);
-        }
-
-        // Log statistics
-        info!("Duplex consensus calling complete");
-        info!("Total MI groups processed: {total_groups}");
-        info!("Total consensus reads written by pipeline: {consensus_reads_written}");
-
-        let metrics = merged_stats.to_metrics();
-        let consensus_count = metrics.consensus_reads;
-        log_consensus_summary(&metrics);
-
-        // Write statistics file if requested
-        if let Some(stats_path) = &self.stats_opts.stats {
-            let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Duplex);
-            DelimFile::default()
-                .write_tsv(stats_path, kv_metrics)
-                .with_context(|| format!("Failed to write statistics: {}", stats_path.display()))?;
-            info!("Wrote statistics to: {}", stats_path.display());
-        }
-
-        info!("Wrote {consensus_count} duplex consensus reads");
-
-        Ok(())
     }
 }
 
@@ -1859,13 +1223,64 @@ mod tests {
         to_record_buf(b.build())
     }
 
+    /// CONS-01: duplex requires template-coordinate-sorted input. A plain
+    /// (unstamped) header must be rejected by `execute()` via the shared
+    /// `check_consensus_sort_order` guard rather than silently mis-grouping
+    /// molecules; the accept branch is covered by the other execute tests. The
+    /// absent-`--threads` (single-worker) case was reassigned from the retired
+    /// `execute_threads_mode` path to the chain in this PR, so parameterize over
+    /// both the single-worker and `--threads` cases to guard that the check
+    /// still fires regardless of worker count — mirroring codec's
+    /// `test_codec_execute_rejects_non_template_coordinate_input`.
+    #[rstest]
+    #[case::single_worker(ThreadingOptions::none())]
+    #[case::pipeline_1(ThreadingOptions::new(1))]
+    #[case::pipeline_2(ThreadingOptions::new(2))]
+    fn test_duplex_execute_rejects_non_template_coordinate_input(
+        #[case] threading: ThreadingOptions,
+    ) -> Result<()> {
+        // Plain header — deliberately NOT stamped template-coordinate (unlike
+        // `create_test_header`), so the sort-order guard must reject it.
+        let header = sam::Header::builder()
+            .set_header(Map::default())
+            .add_reference_sequence(
+                "chr1",
+                Map::<ReferenceSequence>::new(
+                    NonZeroUsize::new(248_956_422).expect("non-zero chromosome length"),
+                ),
+            )
+            .build();
+
+        let (r1, r2) =
+            build_duplex_pair("q1", 0, 100, 200, "1/A", b"AAAAAAAAAA", Some("AAT-CCG"), None);
+
+        let dir = TempDir::new()?;
+        let input_path = dir.path().join("input.bam");
+        let mut writer = create_bam_writer(&input_path, &header, 1, 6)?;
+        writer.write_alignment_record(&header, &r1)?;
+        writer.write_alignment_record(&header, &r2)?;
+        drop(writer);
+
+        let paths = TestPaths::new()?;
+        let mut cmd = create_duplex_with_paths(input_path, paths.output.clone());
+        cmd.threading = threading;
+        let err =
+            cmd.execute("test").expect_err("duplex must reject non-template-coordinate input");
+        assert!(
+            err.to_string().contains("template-coordinate"),
+            "error must suggest template-coordinate sorting: {err}"
+        );
+
+        Ok(())
+    }
+
     /// The `--allow-unmapped` flag gates the fgbio pre-group filter for duplex.
     /// The same AB/BA molecule as `test_duplex_consensus_basic_ab_ba_pairing`,
     /// but with every read unmapped: dropped by default (fgbio parity),
-    /// consensus-called with `--allow-unmapped`. Covers both the single-threaded
-    /// fast path and the multi-threaded pipeline path.
+    /// consensus-called with `--allow-unmapped`. Covers both the single-worker
+    /// chain (no `--threads`) and the multi-threaded pipeline path.
     #[rstest]
-    #[case::fast_path(ThreadingOptions::none())]
+    #[case::single_worker(ThreadingOptions::none())]
     #[case::threaded(ThreadingOptions::new(2))]
     fn test_duplex_allow_unmapped_gates_pregroup_filter(
         #[case] threading: ThreadingOptions,
@@ -2351,11 +1766,11 @@ mod tests {
     /// Parameterized test for all threading modes.
     ///
     /// Tests:
-    /// - `None`: Single-threaded fast path, no pipeline
+    /// - `None`: single-worker chain (no `--threads`)
     /// - `Some(1)`: Pipeline with 1 thread
     /// - `Some(2)`: Pipeline with 2 threads
     #[rstest]
-    #[case::fast_path(ThreadingOptions::none())]
+    #[case::single_worker(ThreadingOptions::none())]
     #[case::pipeline_1(ThreadingOptions::new(1))]
     #[case::pipeline_2(ThreadingOptions::new(2))]
     fn test_threading_modes(#[case] threading: ThreadingOptions) -> Result<()> {
@@ -2406,53 +1821,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case::empty_rejects(1024, 100, vec![])]
-    #[case::non_empty_rejects(64, 32, vec![256, 128])]
-    fn test_duplex_processed_batch_memory_estimate(
-        #[case] consensus_capacity: usize,
-        #[case] consensus_len: usize,
-        #[case] rej_capacities: Vec<usize>,
-    ) {
-        let mut data = Vec::with_capacity(consensus_capacity);
-        data.resize(consensus_len, 0u8);
-
-        let rejected_records: Vec<Vec<u8>> = rej_capacities
-            .iter()
-            .map(|&cap| {
-                let mut v = Vec::with_capacity(cap);
-                v.extend_from_slice(&[1u8; 8]);
-                v
-            })
-            .collect();
-        let rej_outer_capacity = rejected_records.capacity();
-        // Vec::with_capacity(n) only guarantees AT LEAST n; the allocator may
-        // round up. Read the observed capacities back so the expected value
-        // matches what was actually allocated under any allocator.
-        let rej_inner_total: usize = rejected_records.iter().map(Vec::capacity).sum();
-
-        let batch = DuplexProcessedBatch {
-            consensus_output: ConsensusOutput { data, count: 0 },
-            rejected_records,
-            groups_count: 0,
-            stats: ConsensusCallingStats::default(),
-            overlapping_stats: None,
-        };
-
-        // Heap = consensus capacity + sum of per-reject inner capacities
-        // + outer-vec capacity * size_of::<Vec<u8>>().
-        let expected = consensus_capacity
-            + rej_inner_total
-            + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
-        assert_eq!(
-            batch.estimate_heap_size(),
-            expected,
-            "estimate should account for consensus capacity, rejects inner capacities, and outer-vec overhead",
-        );
-    }
-
-    #[rstest]
-    #[case::single_threaded(ThreadingOptions::none())]
-    #[case::multi_threaded(ThreadingOptions::new(2))]
+    #[case::single_worker(ThreadingOptions::none())]
+    #[case::pipeline_2(ThreadingOptions::new(2))]
     fn test_duplex_em_seq_command(#[case] threading: ThreadingOptions) -> Result<()> {
         use std::io::Write;
 

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -9,7 +9,7 @@
 //!    (min reads, max read error rate, max no-calls, min mean quality)
 
 use crate::alignment_tags::regenerate_alignment_tags_raw;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use crate::consensus_filter::resolve_ref_bases_for_record;
 use crate::consensus_filter::{
     FilterConfig, FilterResult, MethylationDepthThresholds, MethylationTags,
@@ -1141,8 +1141,8 @@ impl Filter {
         methylation_mode: fgumi_consensus::MethylationMode,
         ref_names: &[String],
     ) -> Result<(u64, bool)> {
-        // `ref_names` is only consumed by the `simplex`-gated ref-base resolver below.
-        #[cfg(not(feature = "simplex"))]
+        // `ref_names` is only consumed by the `consensus`-gated ref-base resolver below.
+        #[cfg(not(feature = "consensus"))]
         let _ = ref_names;
 
         // Fail fast if we encounter a mapped read without a reference, since masking
@@ -1215,10 +1215,10 @@ impl Filter {
         }
 
         // Resolve reference bases once for all reference-dependent filters.
-        // The resolver lives in the `simplex`-gated `methylation` module, so the
+        // The resolver lives in the `consensus`-gated `methylation` module, so the
         // reference-dependent methylation filters below are only available when
-        // `simplex` is enabled. Without `simplex` we skip the lookup entirely.
-        #[cfg(feature = "simplex")]
+        // `consensus` is enabled. Without `consensus` we skip the lookup entirely.
+        #[cfg(feature = "consensus")]
         let ref_base_map = {
             let needs_ref_bases = (require_strand_methylation_agreement && is_duplex)
                 || min_conversion_fraction.is_some();
@@ -1228,13 +1228,13 @@ impl Filter {
                 None
             }
         };
-        #[cfg(not(feature = "simplex"))]
+        #[cfg(not(feature = "consensus"))]
         let ref_base_map: Option<Vec<Option<u8>>> = {
             if (require_strand_methylation_agreement && is_duplex)
                 || min_conversion_fraction.is_some()
             {
                 bail!(
-                    "reference-dependent methylation filters require building fgumi with the `simplex` feature"
+                    "reference-dependent methylation filters require building fgumi with the `consensus` feature"
                 );
             }
             None

--- a/src/lib/commands/mod.rs
+++ b/src/lib/commands/mod.rs
@@ -51,7 +51,7 @@
 )]
 
 pub mod clip;
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 pub mod codec;
 pub mod command;
 pub mod common;
@@ -62,9 +62,9 @@ pub mod copy_umi;
 pub mod correct;
 pub mod dedup;
 pub mod downsample;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 pub mod duplex;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 pub mod duplex_metrics;
 pub mod extract;
 pub mod fastq;
@@ -75,9 +75,9 @@ pub mod retag;
 pub mod review;
 pub mod runall;
 pub mod shared_metrics;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub mod simplex;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub mod simplex_metrics;
 #[cfg(feature = "simulate")]
 pub mod simulate;

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -4,107 +4,26 @@
 //! consensus reads using a likelihood-based model that accounts for sequencing errors and
 //! errors introduced during sample preparation.
 //!
-//! When `--rejects` is set, the threaded pipeline routes rejected records through
-//! the unified pipeline's first-class secondary output (see
-//! [`crate::unified_pipeline::run_bam_pipeline_from_reader_with_secondary`]).
-//! Both reject sources (input-record skips below `--min-reads` and caller-emitted
-//! rejects) flow through the same per-batch buffer and land in batch-input order.
-//! The rejects BAM advertises the input header so raw-input RG/PG/contig metadata
-//! is preserved. The pattern matches `commands::filter` and `commands::correct`.
+//! When `--rejects` is set, the declarative chain (see [`crate::pipeline::chains`])
+//! routes rejected records through its rejects fan-out branch. Both reject
+//! sources (input-record skips below `--min-reads` and caller-emitted rejects)
+//! land in batch-input order. The rejects BAM advertises the input header so
+//! raw-input RG/PG/contig metadata is preserved. The pattern matches
+//! `commands::filter` and `commands::correct`.
 
-use crate::consensus_caller::{
-    ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason,
-};
-use crate::logging::{OperationTimer, log_consensus_summary};
-use crate::mi_group::{MiGroup, MiGroupBatch, MiGroupIterator, MiGrouper};
-use crate::overlapping_consensus::{
-    AgreementStrategy, CorrectionStats, DisagreementStrategy, OverlappingBasesConsensusCaller,
-    apply_overlapping_consensus,
-};
-use crate::read_info::LibraryIndex;
-use crate::unified_pipeline::{
-    GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
-    run_bam_pipeline_from_reader_with_secondary,
-};
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use clap::Parser;
-use fgoxide::io::DelimFile;
-use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::{
-    create_bam_reader_for_pipeline_with_opts, create_bam_writer, create_optional_bam_writer,
-    create_raw_bam_reader_with_opts,
-};
-use fgumi_raw_bam::{RawRecord, RawRecordView};
 use std::path::Path;
-// RejectionTracker now used via ConsensusStatsOps trait in consensus_runner
-use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::sam::SamTag;
-use crate::vanilla_consensus_caller::{VanillaUmiConsensusCaller, VanillaUmiConsensusOptions};
-
-use log::info;
-use noodles::sam::Header;
-use noodles::sam::alignment::record::data::field::Tag;
-use std::io;
-use std::io::Write as IoWrite;
-use std::sync::Arc;
 
 use crate::commands::command::Command;
 use crate::commands::common::{
     AllowUnmappedOptions, BamIoOptions, CompressionOptions, ConsensusCallingOptions,
     OverlappingConsensusOptions, QueueMemoryOptions, ReadGroupOptions, RejectsOptions,
-    SchedulerOptions, StatsOptions, ThreadingOptions, build_pipeline_config,
-    consensus_pregroup_keep_flags, consensus_pregroup_keep_raw, reject_output_collisions,
-    serialize_raw_bam_records,
+    SchedulerOptions, StatsOptions, ThreadingOptions, reject_output_collisions,
 };
-use crate::commands::consensus_runner::{
-    ConsensusStatsOps, create_unmapped_consensus_header, log_overlapping_stats,
-};
-
-use super::common::{MethylationRef, load_methylation_reference};
-
-// ============================================================================
-// Types for 7-step pipeline processing
-// ============================================================================
-
-/// Result from processing a batch of MI groups through consensus calling.
-///
-/// This type is used by the 7-step unified pipeline to pass processed results
-/// from the process step to the serialize step.
-struct SimplexProcessedBatch {
-    /// Pre-serialized consensus reads to write to output BAM
-    consensus_output: ConsensusOutput,
-    /// Raw-byte rejected records (input records on batch-skip + caller
-    /// rejects), in batch-input order. Empty unless `track_rejects` is true.
-    rejected_records: Vec<Vec<u8>>,
-    /// Number of MI groups in this batch
-    groups_count: u64,
-    /// Consensus calling statistics for this batch
-    stats: ConsensusCallingStats,
-    /// Overlapping correction stats for this batch (if enabled)
-    overlapping_stats: Option<CorrectionStats>,
-}
-
-impl MemoryEstimate for SimplexProcessedBatch {
-    fn estimate_heap_size(&self) -> usize {
-        let rej_size: usize = self.rejected_records.iter().map(Vec::capacity).sum();
-        let rej_vec_overhead = self.rejected_records.capacity() * std::mem::size_of::<Vec<u8>>();
-        self.consensus_output.estimate_heap_size() + rej_size + rej_vec_overhead
-    }
-}
-
-/// Per-thread accumulator for simplex consensus metrics.
-///
-/// Merged into final aggregates after the pipeline completes; one instance
-/// per worker slot (see [`PerThreadAccumulator`]).
-#[derive(Default)]
-struct CollectedSimplexMetrics {
-    /// Consensus calling statistics
-    stats: ConsensusCallingStats,
-    /// Overlapping consensus stats (if enabled)
-    overlapping_stats: Option<CorrectionStats>,
-    /// Number of MI groups processed
-    groups_processed: u64,
-}
+// Used only by unit tests that read back the `--stats` TSV.
+#[cfg(test)]
+use fgoxide::io::DelimFile;
 
 /// Calls simplex consensus sequences from reads with the same unique molecular tag.
 #[derive(Debug, Parser)]
@@ -484,277 +403,17 @@ impl Command for Simplex {
             bail!("--ref requires --methylation-mode to be set");
         }
 
-        // ---- --threads N on a consensus build: run on the declarative chain ----
-        // Dispatch BEFORE the timer/banner/reader below (execute_chain ->
-        // add_simplex builds its own). On a non-consensus build the chain
-        // machinery isn't compiled, so this block is absent and we fall through
-        // to the legacy threaded path.
-        #[cfg(feature = "consensus")]
-        if self.threading.threads.is_some() {
-            return self.execute_chain(command_line);
-        }
-
-        // ---- legacy tail (UNCHANGED): timer, banner, methylation resolve,
-        //      reader, Some(threads)->execute_threads_mode / None->single-
-        //      threaded fast path ----
-        // Start timing
-        let timer = OperationTimer::new("Calling simplex consensus");
-
-        info!("Starting Simplex");
-        info!("Input: {}", self.io.input.display());
-        info!("Output: {}", self.io.output.display());
-        info!("Min reads: {}", self.min_reads);
-        if let Some(max) = self.max_reads {
-            info!("Max reads: {max}");
-        }
-        info!("Error rate pre-UMI: Q{}", self.consensus.error_rate_pre_umi);
-        info!("Error rate post-UMI: Q{}", self.consensus.error_rate_post_umi);
-
-        // Get threading configuration
-        let writer_threads = self.threading.num_threads();
-
-        let cell_tag = Tag::from(SamTag::CB);
-
-        // Enable rejects tracking if rejects file is specified
-        let track_rejects = self.rejects_opts.is_enabled();
-
-        let methylation_mode =
-            crate::commands::common::resolve_methylation_mode(self.methylation_mode);
-
-        // Track overlapping consensus settings (callers created per-thread in threaded mode)
-        let overlapping_enabled = self.overlapping.is_enabled();
-        if overlapping_enabled {
-            info!("Overlapping consensus calling enabled");
-        }
-
-        // Process reads using streaming by MI groups
-        info!("Processing reads and calling consensus (streaming)...");
-        // Both the single-threaded fast path (create_raw_bam_reader_with_opts)
-        // and the multi-threaded pipeline honor --check-crc/--no-check-crc (#800).
-        self.io.log_effective_check_crc();
-
-        // ============================================================
-        // --threads N mode: Use 7-step unified pipeline
-        // None: Use single-threaded fast path
-        // ============================================================
-        // IMPORTANT: Check threading BEFORE opening any reader so we only open
-        // the input once — opening twice wastes I/O and breaks stdin streaming.
-        if let Some(threads) = self.threading.threads {
-            let (reader, header) = create_bam_reader_for_pipeline_with_opts(
-                &self.io.input,
-                self.io.pipeline_reader_opts(),
-            )?;
-            crate::commands::common::check_consensus_sort_order(
-                &header,
-                &self.io.input.display().to_string(),
-            )?;
-            let output_header = create_unmapped_consensus_header(
-                &header,
-                &self.read_group.read_group_id,
-                "Read group",
-                command_line,
-            )?;
-            let read_name_prefix = self.read_group.prefix_or_from_header(&header);
-            let methylation_ref: MethylationRef =
-                load_methylation_reference(methylation_mode, &self.reference, &header)?;
-
-            let result = self.execute_threads_mode(
-                threads,
-                reader,
-                header,
-                output_header,
-                read_name_prefix,
-                track_rejects,
-                methylation_ref,
-                methylation_mode,
-            );
-            timer.log_completion(0); // Completion logged in execute_threads_mode
-            return result;
-        }
-
-        // Single-threaded fast path: open the raw reader once and derive the header from it.
-        let (mut raw_reader, header) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
-        crate::commands::common::check_consensus_sort_order(
-            &header,
-            &self.io.input.display().to_string(),
-        )?;
-        let output_header = create_unmapped_consensus_header(
-            &header,
-            &self.read_group.read_group_id,
-            "Read group",
-            command_line,
-        )?;
-        let read_name_prefix = self.read_group.prefix_or_from_header(&header);
-        let methylation_ref: MethylationRef =
-            load_methylation_reference(methylation_mode, &self.reference, &header)?;
-
-        // ============================================================
-        // For non-pipeline modes, create output writers here
-        // ============================================================
-
-        // Open output - use multi-threaded BGZF writer
-        let mut writer = create_bam_writer(
-            &self.io.output,
-            &output_header,
-            writer_threads,
-            self.compression.compression_level,
-        )?;
-
-        // Open rejects writer if rejects file is specified
-        let mut rejects_writer = create_optional_bam_writer(
-            self.rejects_opts.rejects.as_ref(),
-            &header,
-            writer_threads,
-            self.compression.compression_level,
-        )?;
-
-        let options = VanillaUmiConsensusOptions {
-            tag: "MI".to_string(),
-            error_rate_pre_umi: self.consensus.error_rate_pre_umi,
-            error_rate_post_umi: self.consensus.error_rate_post_umi,
-            min_input_base_quality: self.consensus.min_input_base_quality,
-            min_reads: self.min_reads,
-            max_reads: self.max_reads,
-            produce_per_base_tags: self.consensus.output_per_base_tags,
-            trim: self.consensus.trim,
-            min_consensus_base_quality: self.consensus.min_consensus_base_quality,
-            cell_tag: Some(cell_tag),
-            methylation_mode,
-            tie_rule: self.consensus.tie_rule.into(),
-        };
-
-        // Create a single-threaded caller for stats collection
-        let mut caller = VanillaUmiConsensusCaller::new_with_rejects_tracking(
-            read_name_prefix.clone(),
-            self.read_group.read_group_id.clone(),
-            options.clone(),
-            track_rejects,
-        );
-
-        // Set reference for methylation-aware consensus if enabled
-        if let Some((ref reference, ref ref_names)) = methylation_ref {
-            caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
-        }
-
-        // Accumulator for overlapping stats from parallel processing
-        let mut merged_overlapping_stats = CorrectionStats::new();
-
-        // Track progress (count records written, not UMI groups)
-        let mut record_count: usize = 0;
-        let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
-
-        // Use the raw_reader opened above (single input open). Apply the fgbio
-        // pre-group filter: always drop secondary/supplementary; --allow-unmapped
-        // relaxes only the mapped-record rule.
-        let allow_unmapped = self.allow_unmapped.enabled;
-        let raw_record_iter = std::iter::from_fn(move || {
-            loop {
-                let mut record = RawRecord::new();
-                match raw_reader.read_record(&mut record) {
-                    Ok(0) => return None, // EOF
-                    Ok(_) => {
-                        if consensus_pregroup_keep_flags(
-                            RawRecordView::new(&record).flags(),
-                            allow_unmapped,
-                        ) {
-                            return Some(Ok(record));
-                        }
-                        // Otherwise filtered out: keep reading.
-                    }
-                    Err(e) => return Some(Err(e.into())),
-                }
-            }
-        });
-        let mi_group_iter =
-            MiGroupIterator::new(raw_record_iter, "MI").with_cell_tag(Some(*SamTag::CB));
-        // Single-threaded streaming processing
-        // Create overlapping consensus caller for single-threaded mode
-        let mut overlapping_caller = if overlapping_enabled {
-            Some(OverlappingBasesConsensusCaller::new(
-                AgreementStrategy::Consensus,
-                DisagreementStrategy::Consensus,
-            ))
-        } else {
-            None
-        };
-
-        for result in mi_group_iter {
-            let (umi, mut records) = result.context("Failed to read MI group")?;
-
-            // Apply overlapping consensus if enabled (modifies raw bytes in-place)
-            if let Some(ref mut oc) = overlapping_caller {
-                apply_overlapping_consensus(&mut records, oc)?;
-            }
-
-            // Call consensus directly — records are already RawRecord values.
-            let output = caller
-                .consensus_reads(records)
-                .with_context(|| format!("Failed to call consensus for UMI: {umi}"))?;
-
-            let batch_size = output.count;
-            record_count += batch_size;
-
-            // Write pre-serialized consensus reads to output
-            writer.get_mut().write_all(&output.data).context("Failed to write consensus read")?;
-
-            // Write rejected reads if tracking is enabled
-            if let Some(ref mut rw) = rejects_writer {
-                for raw_record in caller.rejected_reads() {
-                    let block_size = raw_record.len() as u32;
-                    rw.get_mut()
-                        .write_all(&block_size.to_le_bytes())
-                        .context("Failed to write rejected read block size")?;
-                    rw.get_mut().write_all(raw_record).context("Failed to write rejected read")?;
-                }
-                caller.clear_rejected_reads();
-            }
-
-            progress.log_if_needed(batch_size as u64);
-        }
-
-        // For single-threaded, use the caller's stats and merge overlapping stats
-        let merged_stats = caller.statistics();
-        if let Some(ref oc) = overlapping_caller {
-            merged_overlapping_stats.merge(oc.stats());
-        }
-
-        progress.log_final();
-
-        // Finish the buffered writer (flush remaining records and wait for writer thread)
-        writer.into_inner().finish().context("Failed to finish output BAM")?;
-
-        // Log overlapping consensus statistics if enabled
-        if overlapping_enabled {
-            log_overlapping_stats(&merged_overlapping_stats);
-        }
-
-        // Log statistics and write to file
-        info!("Consensus calling complete");
-        info!("Total records processed: {record_count}");
-
-        let metrics = merged_stats.to_metrics();
-        let consensus_count = metrics.consensus_reads;
-        log_consensus_summary(&metrics);
-
-        if let Some(stats_path) = &self.stats_opts.stats {
-            // Convert to fgbio-compatible vertical key-value-description format
-            let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Vanilla);
-            DelimFile::default()
-                .write_tsv(stats_path, kv_metrics)
-                .with_context(|| format!("Failed to write statistics: {}", stats_path.display()))?;
-            info!("Wrote statistics to: {}", stats_path.display());
-        }
-
-        timer.log_completion(consensus_count);
-
-        // Close rejects writer if it was opened
-        if let Some(rw) = rejects_writer {
-            rw.into_inner().finish().context("Failed to finish rejects file")?;
-            info!("Rejected reads written successfully");
-        }
-
-        Ok(())
+        // The declarative chain is the only execution path: `execute` runs the
+        // reader-free pre-flight above and then always dispatches to
+        // `execute_chain`, with or without `--threads` (absent `--threads` runs
+        // the chain at a single worker). `add_simplex` logs the `Calling simplex
+        // consensus` timer, the `Starting Simplex` banner + Input/Output/Min
+        // reads/Error rate lines, and `Processing reads and calling consensus
+        // (streaming)…`; `SimplexFinalizeHook` logs the overlapping stats, the
+        // summary, and the `--stats` TSV. Running any of those here first would
+        // double-log and pre-consume stdin, so `execute` only does the
+        // pre-flight above.
+        self.execute_chain(command_line)
     }
 }
 impl Simplex {
@@ -771,18 +430,15 @@ impl Simplex {
         self.to_simplex_options().validate_read_bounds()
     }
 
-    /// Run the simplex stage on the declarative chain builder (the `--threads N`
-    /// path on a `consensus`-feature build).
+    /// Run the simplex stage on the declarative chain builder — the only
+    /// execution path, with or without `--threads`.
     ///
-    /// Replaces the hand-rolled unified-pipeline construction in `execute` for
-    /// the threaded case. The chain opens its own source, validates the
-    /// template-coordinate sort order, calls consensus, writes the output BAM,
-    /// and writes the rejects/stats via `SimplexFinalizeHook` — all through the
-    /// same shared helpers as the non-chain path, so the two orchestrations stay
-    /// in parity. The no-`--threads` path keeps its own single-threaded fast
-    /// path in `execute`, which is the in-process parity oracle for this one
-    /// (see `test_simplex_chain_matches_single_threaded`).
-    #[cfg(feature = "consensus")]
+    /// The chain opens its own source, validates the template-coordinate sort
+    /// order, calls consensus, writes the output BAM, and writes the
+    /// rejects/stats via `SimplexFinalizeHook`. `--threads 1` (or absent
+    /// `--threads`) runs the chain at a single worker, which is the in-process
+    /// parity oracle for the multi-worker case (see
+    /// `test_simplex_chain_matches_single_threaded`).
     fn execute_chain(&self, command_line: &str) -> Result<()> {
         use crate::pipeline::chains::{
             ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
@@ -800,281 +456,6 @@ impl Simplex {
         };
         let spec = ChainSpec::single_stage(Stage::Simplex, stage_opts, &ctx);
         build_for(spec)?.run()
-    }
-
-    /// Execute using 7-step unified pipeline with --threads.
-    ///
-    /// This method is called when `--threads N` is specified with N > 1.
-    /// It uses the lock-free 7-step unified pipeline for maximum performance.
-    #[expect(clippy::too_many_arguments, reason = "pipeline setup needs all configuration")]
-    fn execute_threads_mode(
-        &self,
-        num_threads: usize,
-        reader: Box<dyn std::io::Read + Send>,
-        input_header: Header,
-        output_header: Header,
-        read_name_prefix: String,
-        track_rejects: bool,
-        methylation_ref: MethylationRef,
-        methylation_mode: fgumi_consensus::MethylationMode,
-    ) -> Result<()> {
-        // Configure pipeline
-        let mut pipeline_config = build_pipeline_config(
-            &self.scheduler_opts,
-            &self.compression,
-            &self.queue_memory,
-            &self.io,
-            num_threads,
-        )?;
-
-        // Per-thread metrics accumulator: bounded metric memory, no unbounded
-        // queue. Rejects buffering semantics are preserved (see follow-up).
-        let collected_metrics = PerThreadAccumulator::<CollectedSimplexMetrics>::new(num_threads);
-        let collected_metrics_for_serialize = Arc::clone(&collected_metrics);
-
-        // Capture configuration for closures
-        let tag_str = "MI".to_string();
-        let min_reads = self.min_reads;
-        let max_reads = self.max_reads;
-        let error_rate_pre_umi = self.consensus.error_rate_pre_umi;
-        let error_rate_post_umi = self.consensus.error_rate_post_umi;
-        let min_input_base_quality = self.consensus.min_input_base_quality;
-        let output_per_base_tags = self.consensus.output_per_base_tags;
-        let min_consensus_base_quality = self.consensus.min_consensus_base_quality;
-        let trim = self.consensus.trim;
-        let overlapping_enabled = self.overlapping.is_enabled();
-        let read_group_id = self.read_group.read_group_id.clone();
-        let cell_tag = Tag::from(SamTag::CB);
-        let batch_size = 50; // MI groups per batch (reduced for memory efficiency)
-
-        // Create options for consensus caller
-        let options = VanillaUmiConsensusOptions {
-            tag: tag_str.clone(),
-            error_rate_pre_umi,
-            error_rate_post_umi,
-            min_input_base_quality,
-            min_reads,
-            max_reads,
-            produce_per_base_tags: output_per_base_tags,
-            trim,
-            min_consensus_base_quality,
-            cell_tag: Some(cell_tag),
-            methylation_mode,
-            tie_rule: self.consensus.tie_rule.into(),
-        };
-
-        // Rejects (`--rejects`) flow through the unified pipeline's first-class
-        // secondary output (see `run_bam_pipeline_from_reader_with_secondary` in
-        // `unified_pipeline/bam.rs`). `process_fn` collects rejected raw bytes
-        // (input records when an MI group is skipped + caller-emitted rejects)
-        // into `SimplexProcessedBatch::rejected_records`; the pipeline's
-        // `secondary_serialize_fn` writes them in batch-input order. The rejects
-        // BAM advertises the input header (via `secondary_output_header =
-        // Some(input_header)`) so it carries raw-input RG/PG/contig metadata.
-
-        let library_index = LibraryIndex::from_header(&input_header);
-        pipeline_config.group_key_config = Some(GroupKeyConfig::new(library_index, cell_tag));
-
-        // ========== grouper_fn ==========
-        // Apply the fgbio pre-group filter (always drop secondary/supplementary;
-        // --allow-unmapped relaxes only the mapped-record rule).
-        let allow_unmapped = self.allow_unmapped.enabled;
-        let grouper_fn = move |_header: &Header| {
-            let grouper = MiGrouper::new("MI", batch_size)
-                .with_cell_tag(Some(*SamTag::CB))
-                .with_record_filter(move |raw| consensus_pregroup_keep_raw(raw, allow_unmapped));
-            Box::new(grouper) as Box<dyn Grouper<Group = MiGroupBatch> + Send>
-        };
-
-        // ========== process_fn: Consensus calling ==========
-        let process_fn = move |batch: MiGroupBatch| -> io::Result<SimplexProcessedBatch> {
-            // Create per-thread consensus caller
-            let mut caller = VanillaUmiConsensusCaller::new_with_rejects_tracking(
-                read_name_prefix.clone(),
-                read_group_id.clone(),
-                options.clone(),
-                track_rejects,
-            );
-
-            // Set reference for methylation-aware consensus if enabled
-            if let Some((ref reference, ref ref_names)) = methylation_ref {
-                caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
-            }
-
-            // Create overlapping caller if enabled
-            let mut overlapping_caller = if overlapping_enabled {
-                Some(OverlappingBasesConsensusCaller::new(
-                    AgreementStrategy::Consensus,
-                    DisagreementStrategy::Consensus,
-                ))
-            } else {
-                None
-            };
-
-            let mut all_output = ConsensusOutput::default();
-            let mut batch_stats = ConsensusCallingStats::new();
-            let mut batch_overlapping = CorrectionStats::new();
-            let groups_count = batch.groups.len() as u64;
-            // Rejected records (input-record skips + caller rejects) collected
-            // per-batch and drained by the pipeline's secondary serializer.
-            let mut rejected_records: Vec<Vec<u8>> = Vec::new();
-
-            for MiGroup { mi, records: mut raw_records } in batch.groups {
-                caller.clear();
-
-                // Skip if below min_reads threshold
-                if raw_records.len() < min_reads {
-                    batch_stats.record_input(raw_records.len());
-                    batch_stats
-                        .record_rejection(RejectionReason::InsufficientReads, raw_records.len());
-                    if track_rejects {
-                        for raw in &raw_records {
-                            rejected_records.push(raw.as_ref().to_vec());
-                        }
-                    }
-                    continue;
-                }
-
-                // Apply overlapping consensus if enabled (modifies raw bytes in-place).
-                // Propagate errors to match the single-threaded path (line ~410),
-                // which treats overlapping-consensus failures as fatal via `?`.
-                if let Some(ref mut oc) = overlapping_caller {
-                    oc.reset_stats();
-                    apply_overlapping_consensus(&mut raw_records, oc).map_err(|e| {
-                        io::Error::other(format!("Overlapping consensus error for MI {mi}: {e}"))
-                    })?;
-                    batch_overlapping.merge(oc.stats());
-                }
-
-                // Call consensus — mi_group yields Vec<RawRecord> directly.
-                // Propagate errors to match the single-threaded path, which
-                // treats consensus failures as fatal.
-                let batch_output = caller
-                    .consensus_reads(raw_records)
-                    .map_err(|e| io::Error::other(format!("Consensus error for MI {mi}: {e}")))?;
-                all_output.merge(batch_output);
-                batch_stats.merge(&caller.statistics());
-                if track_rejects {
-                    for raw in caller.take_rejected_reads() {
-                        rejected_records.push(raw);
-                    }
-                }
-            }
-
-            Ok(SimplexProcessedBatch {
-                consensus_output: all_output,
-                rejected_records,
-                groups_count,
-                stats: batch_stats,
-                overlapping_stats: if overlapping_enabled { Some(batch_overlapping) } else { None },
-            })
-        };
-
-        // ========== serialize_fn: Serialize + collect metrics ==========
-        let serialize_fn = move |processed: SimplexProcessedBatch,
-                                 _header: &Header,
-                                 output: &mut Vec<u8>|
-              -> io::Result<u64> {
-            // Merge per-batch metrics into this worker's accumulator slot.
-            // Rejects are drained by `secondary_serialize_fn` separately.
-            let batch_stats = processed.stats;
-            let batch_overlapping = processed.overlapping_stats;
-            let groups_count = processed.groups_count;
-            collected_metrics_for_serialize.with_slot(|m| {
-                m.stats.merge(&batch_stats);
-                if let Some(o) = batch_overlapping {
-                    m.overlapping_stats.get_or_insert_with(CorrectionStats::new).merge(&o);
-                }
-                m.groups_processed += groups_count;
-            });
-
-            // Serialize consensus reads
-            let count = processed.consensus_output.count as u64;
-            output.extend_from_slice(&processed.consensus_output.data);
-            Ok(count)
-        };
-
-        // ========== secondary_serialize_fn: Drain rejected records ==========
-        let secondary_serialize_fn =
-            |batch: &SimplexProcessedBatch, buf: &mut Vec<u8>| -> io::Result<u64> {
-                serialize_raw_bam_records(&batch.rejected_records, buf)
-            };
-
-        // Run the 7-step pipeline with the already-opened reader (supports streaming).
-        // When `--rejects` is set, route rejects through the unified pipeline's
-        // first-class secondary output so they land in input/batch-serial order
-        // and the rejects BAM carries the input header.
-        let consensus_reads_written = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref()
-        {
-            let secondary_header = input_header.clone();
-            run_bam_pipeline_from_reader_with_secondary(
-                pipeline_config,
-                reader,
-                input_header,
-                &self.io.output,
-                Some(output_header.clone()),
-                rejects_path,
-                Some(secondary_header),
-                grouper_fn,
-                process_fn,
-                serialize_fn,
-                secondary_serialize_fn,
-            )
-            .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?
-        } else {
-            run_bam_pipeline_from_reader(
-                pipeline_config,
-                reader,
-                input_header,
-                &self.io.output,
-                Some(output_header.clone()),
-                grouper_fn,
-                process_fn,
-                serialize_fn,
-            )
-            .map_err(|e| anyhow::anyhow!("Pipeline error: {e}"))?
-        };
-
-        // ========== Post-pipeline: Aggregate metrics ==========
-        let mut total_groups = 0u64;
-        let mut merged_stats = ConsensusCallingStats::new();
-        let mut merged_overlapping_stats = CorrectionStats::new();
-
-        for slot in collected_metrics.slots() {
-            let m = slot.lock();
-            total_groups += m.groups_processed;
-            merged_stats.merge(&m.stats);
-            if let Some(ref ocs) = m.overlapping_stats {
-                merged_overlapping_stats.merge(ocs);
-            }
-        }
-
-        // Log overlapping consensus statistics if enabled
-        if self.overlapping.is_enabled() {
-            log_overlapping_stats(&merged_overlapping_stats);
-        }
-
-        // Log statistics and write to file
-        info!("Consensus calling complete");
-        info!("Total MI groups processed: {total_groups}");
-        info!("Total consensus reads written by pipeline: {consensus_reads_written}");
-
-        let metrics = merged_stats.to_metrics();
-        let consensus_count = metrics.consensus_reads;
-        log_consensus_summary(&metrics);
-
-        if let Some(stats_path) = &self.stats_opts.stats {
-            // Convert to fgbio-compatible vertical key-value-description format
-            let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Vanilla);
-            DelimFile::default()
-                .write_tsv(stats_path, kv_metrics)
-                .with_context(|| format!("Failed to write statistics: {}", stats_path.display()))?;
-            info!("Wrote statistics to: {}", stats_path.display());
-        }
-
-        info!("Wrote {consensus_count} consensus reads");
-
-        Ok(())
     }
 }
 
@@ -1485,7 +866,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::fast_path(ThreadingOptions::none())]
+    #[case::single_worker(ThreadingOptions::none())]
     #[case::threaded(ThreadingOptions::new(2))]
     fn test_end_to_end_single_end_workflow(#[case] threading: ThreadingOptions) -> Result<()> {
         // Verify CB partitioning: two groups share the same MI but differ in CB.
@@ -1557,10 +938,11 @@ mod tests {
     /// filter. By default (fgbio parity) unmapped, unpaired reads are dropped
     /// before consensus calling, so no consensus is produced; with
     /// `--allow-unmapped` they are consensus-called. Runs both the
-    /// single-threaded fast path and the multi-threaded pipeline path, which
-    /// install the filter at independent sites.
+    /// single-worker chain (absent `--threads`) and the multi-worker chain,
+    /// which install the filter at the same `add_simplex` site — worker count
+    /// is the only difference between the two cases.
     #[rstest]
-    #[case::fast_path(ThreadingOptions::none())]
+    #[case::no_threads(ThreadingOptions::none())]
     #[case::threaded(ThreadingOptions::new(2))]
     fn test_allow_unmapped_gates_pregroup_filter(
         #[case] threading: ThreadingOptions,
@@ -2183,11 +1565,11 @@ mod tests {
     /// Parameterized test for all threading modes.
     ///
     /// Tests:
-    /// - `None`: Single-threaded fast path, no pipeline
+    /// - `None`: single-worker chain (no `--threads`)
     /// - `Some(1)`: Pipeline with 1 thread
     /// - `Some(2)`: Pipeline with 2 threads
     #[rstest]
-    #[case::fast_path(ThreadingOptions::none())]
+    #[case::single_worker(ThreadingOptions::none())]
     #[case::pipeline_1(ThreadingOptions::new(1))]
     #[case::pipeline_2(ThreadingOptions::new(2))]
     fn test_threading_modes(#[case] threading: ThreadingOptions) -> Result<()> {
@@ -2214,53 +1596,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case::empty_rejects(1024, 100, vec![])]
-    #[case::non_empty_rejects(64, 32, vec![256, 128])]
-    fn test_simplex_processed_batch_memory_estimate(
-        #[case] consensus_capacity: usize,
-        #[case] consensus_len: usize,
-        #[case] rej_capacities: Vec<usize>,
-    ) {
-        let mut data = Vec::with_capacity(consensus_capacity);
-        data.resize(consensus_len, 0u8);
-
-        let rejected_records: Vec<Vec<u8>> = rej_capacities
-            .iter()
-            .map(|&cap| {
-                let mut v = Vec::with_capacity(cap);
-                v.extend_from_slice(&[1u8; 8]);
-                v
-            })
-            .collect();
-        let rej_outer_capacity = rejected_records.capacity();
-        // Vec::with_capacity(n) only guarantees AT LEAST n; the allocator may
-        // round up. Read the observed capacities back so the expected value
-        // matches what was actually allocated under any allocator.
-        let rej_inner_total: usize = rejected_records.iter().map(Vec::capacity).sum();
-
-        let batch = SimplexProcessedBatch {
-            consensus_output: ConsensusOutput { data, count: 0 },
-            rejected_records,
-            groups_count: 0,
-            stats: ConsensusCallingStats::default(),
-            overlapping_stats: None,
-        };
-
-        // Heap = consensus capacity + sum of per-reject inner capacities
-        // + outer-vec capacity * size_of::<Vec<u8>>().
-        let expected = consensus_capacity
-            + rej_inner_total
-            + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
-        assert_eq!(
-            batch.estimate_heap_size(),
-            expected,
-            "estimate should account for consensus capacity, rejects inner capacities, and outer-vec overhead",
-        );
-    }
-
-    #[rstest]
-    #[case::single_threaded(ThreadingOptions::none())]
-    #[case::multi_threaded(ThreadingOptions::new(2))]
+    #[case::single_worker(ThreadingOptions::none())]
+    #[case::pipeline_2(ThreadingOptions::new(2))]
     fn test_simplex_em_seq_command(#[case] threading: ThreadingOptions) -> Result<()> {
         use crate::sam::builder::{Strand, create_test_fasta};
 

--- a/src/lib/consensus/mod.rs
+++ b/src/lib/consensus/mod.rs
@@ -4,11 +4,11 @@
 
 pub use fgumi_consensus::{base_builder, caller, filter, overlapping, sequence, simple_umi, tags};
 
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 pub use fgumi_consensus::codec_caller;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 pub use fgumi_consensus::duplex_caller;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub use fgumi_consensus::vanilla_caller;
 
 // Re-export commonly used items
@@ -20,15 +20,9 @@ pub use fgumi_consensus::{
     log_consensus_statistics, mask_bases, mask_duplex_bases, mean_base_quality, template_passes,
 };
 
-#[cfg(feature = "simplex")]
-pub use fgumi_consensus::{
-    VanillaConsensusRead, VanillaUmiConsensusCaller, VanillaUmiConsensusOptions,
-};
-
-#[cfg(feature = "duplex")]
-pub use fgumi_consensus::{DuplexConsensusCaller, DuplexConsensusRead};
-
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 pub use fgumi_consensus::{
     CodecConsensusCaller, CodecConsensusError, CodecConsensusOptions, CodecConsensusStats,
+    DuplexConsensusCaller, DuplexConsensusRead, VanillaConsensusRead, VanillaUmiConsensusCaller,
+    VanillaUmiConsensusOptions,
 };

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -175,11 +175,11 @@ pub use umi::assigner;
 
 // Re-export consensus items for backward compatibility
 pub use consensus::caller as consensus_caller;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 pub use consensus::duplex_caller as duplex_consensus_caller;
 pub use consensus::filter as consensus_filter;
 pub use consensus::overlapping as overlapping_consensus;
 pub use consensus::simple_umi as simple_umi_consensus;
 pub use consensus::tags as consensus_tags;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 pub use consensus::vanilla_caller as vanilla_consensus_caller;

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -406,9 +406,8 @@ pub struct ChainBuilder<'a> {
     /// stage must advertise the *unmodified* input header rather than the
     /// chain's output header — specifically the consensus commands' `--rejects`
     /// sink, whose records are raw-input records in input order (the PR #332
-    /// contract) and so must carry the input's `@PG`/`@RG`/`@HD` verbatim, to
-    /// match the single-threaded fast path (which opens the raw reader and
-    /// writes rejects with that header, un-augmented).
+    /// contract) and so must carry the input's `@PG`/`@RG`/`@HD` verbatim,
+    /// un-augmented.
     raw_source_header: Header,
 
     /// In-progress chain state. `None` before the first step (before
@@ -3255,8 +3254,8 @@ impl<'a> ChainBuilder<'a> {
     /// output is already record-aligned, so no boundary/parse step is needed.
     ///
     /// Applies the M5 fix: enforces that `--ref` requires `--methylation-mode`
-    /// to be set (mirrors the same check in `Simplex::execute`'s
-    /// single-threaded fast path).
+    /// to be set (mirrors the same check in `Simplex::execute`'s CLI
+    /// pre-flight).
     ///
     /// Registers a `SimplexFinalizeHook` for accumulators reduce, stats write,
     /// overlapping-consensus stats log, summary banner, rejects-writer
@@ -3286,10 +3285,10 @@ impl<'a> ChainBuilder<'a> {
         use crate::pipeline::chains::commands::simplex::{
             CollectedSimplexMetrics, SimplexConsensusCaptures, SimplexFinalizeHook,
             build_simplex_consensus_step_kept_only, build_simplex_consensus_step_with_rejects,
+            simplex_consensus_options,
         };
         use crate::pipeline::steps::group::mi::GroupByMi;
         use crate::sam::SamTag;
-        use crate::vanilla_consensus_caller::VanillaUmiConsensusOptions;
         use log::info;
         use noodles::sam::alignment::record::data::field::Tag;
 
@@ -3300,9 +3299,9 @@ impl<'a> ChainBuilder<'a> {
             .as_ref()
             .ok_or_else(|| anyhow!("Stage::Simplex options missing from StageOptionsBag"))?;
 
-        // M5 fix: mirrors the same check in Simplex::execute's single-threaded
-        // fast path. Enforced here so runall's execute_consensus_only path also
-        // rejects --ref without --methylation-mode.
+        // M5 fix: mirrors the same check in Simplex::execute's CLI pre-flight.
+        // Enforced here so runall's execute_consensus_only path also rejects
+        // --ref without --methylation-mode.
         if simplex.reference.is_some()
             && simplex.methylation_mode == fgumi_consensus::MethylationMode::Disabled
         {
@@ -3399,9 +3398,8 @@ impl<'a> ChainBuilder<'a> {
         // stage-aware, mirroring the `check_consensus_sort_order` guard above:
         // when simplex consumes the raw source directly (the standalone
         // `[Stage::Simplex]` chain), it is `raw_source_header` (the header before
-        // this chain's `@PG` injection), so threaded rejects carry the same
-        // provenance as the single-threaded fast path — which writes rejects with
-        // the un-augmented input header. In a fused chain (e.g. `sort -> simplex`)
+        // this chain's `@PG` injection), so rejects carry the un-augmented input
+        // header. In a fused chain (e.g. `sort -> simplex`)
         // an upstream stage rewrote `self.header`; the rejects must then advertise
         // that stage-input header, not the original source — so use `self.header`,
         // which is still the stage input here (`replace_header` below has not yet
@@ -3427,21 +3425,11 @@ impl<'a> ChainBuilder<'a> {
         let cell_tag = Tag::from(SamTag::CB);
 
         let read_group_id = simplex.read_group.read_group_id.clone();
-        let consensus_options = VanillaUmiConsensusOptions {
-            tag: "MI".to_string(),
-            error_rate_pre_umi: consensus.error_rate_pre_umi,
-            error_rate_post_umi: consensus.error_rate_post_umi,
-            min_input_base_quality: consensus.min_input_base_quality,
-            min_reads: simplex.min_reads,
-            max_reads: simplex.max_reads,
-            produce_per_base_tags: consensus.output_per_base_tags,
-            trim: consensus.trim,
-            min_consensus_base_quality: consensus.min_consensus_base_quality,
-            cell_tag: Some(cell_tag),
-            methylation_mode,
-            // `simplex.tie_rule` is already the resolved `TieRule` on `SimplexOptions`.
-            tie_rule: simplex.tie_rule,
-        };
+        // The `SimplexOptions -> VanillaUmiConsensusOptions` mapping is
+        // extracted into `simplex_consensus_options` (see its doc comment for
+        // why) so it has its own direct unit test independent of this parity
+        // comparison.
+        let consensus_options = simplex_consensus_options(simplex, cell_tag);
 
         let progress_records = Arc::clone(&self.progress_records);
 
@@ -3553,8 +3541,8 @@ impl<'a> ChainBuilder<'a> {
     /// where `prefix_or_from_header` was called on `input_header`.
     ///
     /// Applies the M5 fix: enforces that `--ref` requires `--methylation-mode`
-    /// to be set (mirrors the same check in `Duplex::execute`'s single-threaded
-    /// fast path).
+    /// to be set (mirrors the same check in `Duplex::execute`'s CLI
+    /// pre-flight).
     ///
     /// Registers a `DuplexFinalizeHook` for accumulators reduce, stats write,
     /// overlapping-consensus stats log, summary banner, rejects-writer
@@ -3583,6 +3571,7 @@ impl<'a> ChainBuilder<'a> {
         use crate::pipeline::chains::commands::duplex::{
             CollectedDuplexMetrics, DuplexConsensusCaptures, DuplexFinalizeHook,
             build_duplex_consensus_step_kept_only, build_duplex_consensus_step_with_rejects,
+            duplex_consensus_tuning,
         };
         use crate::pipeline::steps::group::mi::GroupByMi;
         use crate::sam::SamTag;
@@ -3597,17 +3586,17 @@ impl<'a> ChainBuilder<'a> {
             .as_ref()
             .ok_or_else(|| anyhow!("Stage::Duplex options missing from StageOptionsBag"))?;
 
-        // M5 fix: mirrors the same check in Duplex::execute's single-threaded
-        // fast path. Enforced here so runall's execute_consensus_only path also
-        // rejects --ref without --methylation-mode.
+        // M5 fix: mirrors the same check in Duplex::execute's CLI pre-flight.
+        // Enforced here so runall's execute_consensus_only path also rejects
+        // --ref without --methylation-mode.
         if duplex.reference.is_some()
             && duplex.methylation_mode == fgumi_consensus::MethylationMode::Disabled
         {
             bail!("--ref requires --methylation-mode to be set");
         }
 
-        // Validate min_reads UP FRONT (mirrors Duplex::execute's single-threaded
-        // path). The per-worker init closure builds DuplexConsensusCaller with
+        // Validate min_reads UP FRONT (mirrors Duplex::execute's CLI
+        // pre-flight). The per-worker init closure builds DuplexConsensusCaller with
         // `.expect()`, so an invalid ordering (e.g. `--duplex::min-reads 1 5`)
         // would otherwise panic inside a worker thread — likely wedging the
         // pipeline — instead of surfacing a clean error here before it is built.
@@ -3675,10 +3664,15 @@ impl<'a> ChainBuilder<'a> {
         info!("Processing reads and calling duplex consensus (streaming)...");
         info!("Reading input");
 
+        // The `DuplexOptions -> DuplexConsensusCaptures` scalar-tuning mapping
+        // is extracted into `duplex_consensus_tuning` (see its doc comment for
+        // why) so it has its own direct unit test independent of this parity
+        // comparison.
+        let tuning = duplex_consensus_tuning(duplex);
+
         // Resolve methylation mode and load reference if needed.
-        let methylation_mode = duplex.methylation_mode;
         let methylation_ref =
-            load_methylation_reference(methylation_mode, &duplex.reference, &self.header)?;
+            load_methylation_reference(tuning.methylation_mode, &duplex.reference, &self.header)?;
 
         // create_unmapped_consensus_header already inserts the @PG record via
         // add_pg_to_builder, so no second add_pg_record call is needed here.
@@ -3718,13 +3712,6 @@ impl<'a> ChainBuilder<'a> {
         let cell_tag = Tag::from(SamTag::CB);
 
         let read_group_id = duplex.read_group.read_group_id.clone();
-        let min_reads = duplex.min_reads.clone();
-        let min_input_base_quality = consensus.min_input_base_quality;
-        let output_per_base_tags = consensus.output_per_base_tags;
-        let trim = consensus.trim;
-        let max_reads_per_strand = duplex.max_reads_per_strand;
-        let error_rate_pre_umi = consensus.error_rate_pre_umi;
-        let error_rate_post_umi = consensus.error_rate_post_umi;
 
         let progress_records = Arc::clone(&self.progress_records);
 
@@ -3734,19 +3721,17 @@ impl<'a> ChainBuilder<'a> {
             track_rejects,
             overlapping_enabled,
             methylation_ref,
-            methylation_mode,
+            methylation_mode: tuning.methylation_mode,
             read_name_prefix,
             read_group_id,
-            min_reads,
-            min_input_base_quality,
-            output_per_base_tags,
-            trim,
-            max_reads_per_strand,
-            error_rate_pre_umi,
-            error_rate_post_umi,
-            // Resolved `--tie-rule`, converted exactly as both oracle paths do
-            // (`self.consensus.tie_rule.into()` in Duplex::execute).
-            tie_rule: consensus.tie_rule.into(),
+            min_reads: tuning.min_reads,
+            min_input_base_quality: tuning.min_input_base_quality,
+            output_per_base_tags: tuning.output_per_base_tags,
+            trim: tuning.trim,
+            max_reads_per_strand: tuning.max_reads_per_strand,
+            error_rate_pre_umi: tuning.error_rate_pre_umi,
+            error_rate_post_umi: tuning.error_rate_post_umi,
+            tie_rule: tuning.tie_rule,
             cell_tag,
             accumulators: accumulators_for_step,
             progress: progress_records,
@@ -3876,12 +3861,12 @@ impl<'a> ChainBuilder<'a> {
     fn add_codec(&mut self, position: StagePosition) -> Result<()> {
         use crate::commands::common::{consensus_pregroup_keep_raw, warn_unwired_pipeline_flags};
         use crate::commands::consensus_runner::create_unmapped_consensus_header;
-        use crate::consensus::codec_caller::CodecConsensusOptions;
         use crate::logging::OperationTimer;
         use crate::per_thread_accumulator::PerThreadAccumulator;
         use crate::pipeline::chains::commands::codec::{
             CodecConsensusCaptures, CodecFinalizeHook, CollectedCodecMetrics,
             build_codec_consensus_step_kept_only, build_codec_consensus_step_with_rejects,
+            codec_consensus_options,
         };
         use crate::pipeline::steps::group::mi::GroupByMi;
         use crate::sam::SamTag;
@@ -3981,10 +3966,7 @@ impl<'a> ChainBuilder<'a> {
         // (raw-input RG/PG + @HD sort fields), per the PR #332 rejects contract:
         // rejects are raw-input records in input order. Use `raw_source_header`
         // (the header before this chain's `@PG` injection), NOT `self.header`,
-        // so threaded rejects carry the same provenance as the single-threaded
-        // fast path — which writes rejects with the un-augmented input header
-        // (codec.rs's `create_optional_bam_writer(.., &header, ..)`, where
-        // `header` is the raw reader header with no `@PG` applied). In a future
+        // so rejects carry the un-augmented input header. In a future
         // fused chain (e.g. `group -> codec`) an upstream stage rewrote
         // `self.header`; the rejects must then advertise that stage-input header,
         // not the original source — so gate on codec being the source stage
@@ -4011,26 +3993,10 @@ impl<'a> ChainBuilder<'a> {
         let cell_tag = Tag::from(SamTag::CB);
 
         let read_group_id = codec.read_group.read_group_id.clone();
-        let consensus_options = CodecConsensusOptions {
-            min_input_base_quality: consensus.min_input_base_quality,
-            error_rate_pre_umi: consensus.error_rate_pre_umi,
-            error_rate_post_umi: consensus.error_rate_post_umi,
-            min_reads_per_strand: codec.min_reads,
-            max_reads_per_strand: codec.max_reads,
-            min_duplex_length: codec.min_duplex_length,
-            single_strand_qual: codec.single_strand_qual,
-            outer_bases_qual: codec.outer_bases_qual,
-            outer_bases_length: codec.outer_bases_length,
-            max_duplex_disagreements: codec.max_duplex_disagreements.unwrap_or(usize::MAX),
-            max_duplex_disagreement_rate: codec.max_duplex_disagreement_rate,
-            legacy_overlap_window: codec.legacy_overlap_window,
-            cell_tag: Some(cell_tag),
-            produce_per_base_tags: consensus.output_per_base_tags,
-            trim: consensus.trim,
-            min_consensus_base_quality: consensus.min_consensus_base_quality,
-            // `codec.tie_rule` is already the resolved `TieRule` on `CodecOptions`.
-            tie_rule: codec.tie_rule,
-        };
+        // The `CodecOptions -> CodecConsensusOptions` mapping is extracted
+        // into `codec_consensus_options` (see its doc comment for why) so it
+        // has its own direct unit test independent of this parity comparison.
+        let consensus_options = codec_consensus_options(codec, cell_tag);
 
         let progress_records = Arc::clone(&self.progress_records);
 

--- a/src/lib/pipeline/chains/commands/codec.rs
+++ b/src/lib/pipeline/chains/commands/codec.rs
@@ -12,8 +12,9 @@
 //! or methylation mode — matching fgbio's `CallCodecConsensusReads` behaviour.
 //!
 //! This is the chain-builder construction path for the codec stage, consumed via
-//! `ChainBuilder` / [`crate::pipeline::chains::build::build_for`]. It is not
-//! yet wired as `Codec::execute`'s live path.
+//! `ChainBuilder` / [`crate::pipeline::chains::build::build_for`]. It is the
+//! sole path for `Codec::execute` (via `execute_chain`), with or without
+//! `--threads` — absent `--threads` runs the chain at a single worker.
 
 use std::io;
 use std::sync::Arc;
@@ -43,8 +44,7 @@ use crate::pipeline::steps::types::DecompressedBlock;
 // CollectedCodecMetrics
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Per-thread accumulator for codec consensus metrics (mirrors
-/// `commands::codec::CollectedCodecMetrics`).
+/// Per-thread accumulator for codec consensus metrics.
 ///
 /// Merged into final aggregates after the pipeline completes; one instance
 /// per worker slot (see [`PerThreadAccumulator`]).
@@ -112,9 +112,9 @@ impl FinalizeHook for CodecFinalizeHook {
 
         if let Some(ref stats_path) = stats_path {
             use fgoxide::io::DelimFile;
-            // Write the key-value stats format, matching the standalone
-            // `Codec::finalize_stats` and the sibling simplex/duplex chain hooks;
-            // the wide-table `[metrics]` form diverged from both.
+            // Write the key-value stats format, matching the sibling
+            // simplex/duplex chain hooks; the wide-table `[metrics]` form
+            // diverged from both.
             let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Codec);
             DelimFile::default().write_tsv(stats_path, kv_metrics).map_err(|e| {
                 anyhow::anyhow!("Failed to write statistics: {}: {e}", stats_path.display())
@@ -141,6 +141,46 @@ impl FinalizeHook for CodecFinalizeHook {
 // `impl Step<...>` is blocked here because the closure types embed in
 // opaque-return position and cannot name themselves.
 // ─────────────────────────────────────────────────────────────────────────────
+
+/// Maps `CodecOptions` (the resolved options-bag entry `add_codec` receives)
+/// into the `CodecConsensusOptions` the per-worker consensus caller is built
+/// from.
+///
+/// Extracted out of `ChainBuilder::add_codec` so this mapping is
+/// unit-testable on its own: the `test_codec_chain_matches_single_threaded`
+/// parity tests compare two chain runs (single- vs multi-worker) that BOTH go
+/// through this same mapping, so a field dropped or swapped inside it would
+/// make the two sides agree with each other and still pass. See
+/// `codec_consensus_options_carries_every_tuning_flag` below, which mirrors
+/// `to_codec_options_carries_every_tuning_flag`'s non-default-everywhere
+/// discipline for the other half of the CLI-args -> `CodecOptions` ->
+/// `CodecConsensusOptions` pipeline.
+pub(crate) fn codec_consensus_options(
+    codec: &crate::commands::codec::CodecOptions,
+    cell_tag: noodles::sam::alignment::record::data::field::Tag,
+) -> CodecConsensusOptions {
+    let consensus = codec.consensus();
+    CodecConsensusOptions {
+        min_input_base_quality: consensus.min_input_base_quality,
+        error_rate_pre_umi: consensus.error_rate_pre_umi,
+        error_rate_post_umi: consensus.error_rate_post_umi,
+        min_reads_per_strand: codec.min_reads,
+        max_reads_per_strand: codec.max_reads,
+        min_duplex_length: codec.min_duplex_length,
+        single_strand_qual: codec.single_strand_qual,
+        outer_bases_qual: codec.outer_bases_qual,
+        outer_bases_length: codec.outer_bases_length,
+        max_duplex_disagreements: codec.max_duplex_disagreements.unwrap_or(usize::MAX),
+        max_duplex_disagreement_rate: codec.max_duplex_disagreement_rate,
+        legacy_overlap_window: codec.legacy_overlap_window,
+        cell_tag: Some(cell_tag),
+        produce_per_base_tags: consensus.output_per_base_tags,
+        trim: consensus.trim,
+        min_consensus_base_quality: consensus.min_consensus_base_quality,
+        // `codec.tie_rule` is already the resolved `TieRule` on `CodecOptions`.
+        tie_rule: codec.tie_rule,
+    }
+}
 
 /// Captures passed into [`build_codec_consensus_step_with_rejects`] / [`build_codec_consensus_step_kept_only`] from `add_codec`.
 ///
@@ -206,10 +246,9 @@ fn run_codec_consensus_batch(
 
         // Use the typed entry point so recoverable "duplex disagreement" errors
         // are classified by the `CodecConsensusError::is_duplex_disagreement()`
-        // predicate, matching the standalone `recover_or_propagate_codec_error`.
-        // The generic `consensus_reads` erases the typed variant into
-        // `anyhow::Error`, which would force a fragile substring match on the
-        // Display text.
+        // predicate. The generic `consensus_reads` erases the typed variant
+        // into `anyhow::Error`, which would force a fragile substring match on
+        // the Display text.
         let result = state.caller.consensus_reads_typed(records);
         match result {
             Ok(group_output) => {
@@ -363,4 +402,90 @@ pub(crate) fn build_codec_consensus_step_kept_only(
         init,
         body,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::codec::Codec;
+    use clap::Parser;
+
+    /// The `CodecOptions -> CodecConsensusOptions` mapping inside `add_codec`
+    /// must carry every tuning flag. The
+    /// `test_codec_chain_matches_single_threaded` parity tests compare two
+    /// chain runs that BOTH go through this mapping, so they cannot catch a
+    /// field dropped or swapped inside it; this test exercises the mapping
+    /// directly, driven through `try_parse_from` + `to_codec_options()` (not
+    /// a hand-built `CodecOptions` literal) with every value non-default, so
+    /// a field read from the wrong source fails rather than coincidentally
+    /// matching a default. Mirrors `to_codec_options_carries_every_tuning_flag`
+    /// in `commands::codec`, which covers the other half of the pipeline
+    /// (CLI args -> `CodecOptions`).
+    #[test]
+    fn codec_consensus_options_carries_every_tuning_flag() {
+        let cmd = Codec::try_parse_from([
+            "codec",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--error-rate-pre-umi",
+            "42",
+            "--error-rate-post-umi",
+            "37",
+            "--min-input-base-quality",
+            "16",
+            "--output-per-base-tags=false",
+            "--trim=true",
+            "--min-consensus-base-quality",
+            "23",
+            "--tie-rule",
+            "ulp-relative",
+            "--min-reads",
+            "4",
+            "--max-reads",
+            "88",
+            "--min-duplex-length",
+            "9",
+            "--legacy-overlap-window",
+            "--single-strand-qual",
+            "12",
+            "--outer-bases-qual",
+            "15",
+            "--outer-bases-length",
+            "7",
+            "--max-duplex-disagreement-rate",
+            "0.25",
+            "--max-duplex-disagreements",
+            "6",
+        ])
+        .expect("parses");
+        let codec_options = cmd.to_codec_options();
+
+        let cell_tag =
+            noodles::sam::alignment::record::data::field::Tag::from(crate::sam::SamTag::CB);
+        let opts = codec_consensus_options(&codec_options, cell_tag);
+
+        assert_eq!(opts.min_input_base_quality, 16);
+        assert_eq!(opts.error_rate_pre_umi, 42);
+        assert_eq!(opts.error_rate_post_umi, 37);
+        assert_eq!(opts.min_reads_per_strand, 4);
+        assert_eq!(opts.max_reads_per_strand, Some(88));
+        assert_eq!(opts.min_duplex_length, 9);
+        assert_eq!(opts.single_strand_qual, Some(12));
+        assert_eq!(opts.outer_bases_qual, Some(15));
+        assert_eq!(opts.outer_bases_length, 7);
+        assert_eq!(opts.max_duplex_disagreements, 6);
+        assert!((opts.max_duplex_disagreement_rate - 0.25).abs() < f64::EPSILON);
+        assert!(opts.legacy_overlap_window, "--legacy-overlap-window must reach the mapping");
+        assert_eq!(opts.cell_tag, Some(cell_tag));
+        assert!(!opts.produce_per_base_tags, "an explicit false must not be lost");
+        assert!(opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 23);
+        assert_eq!(
+            opts.tie_rule,
+            fgumi_consensus::TieRule::UlpRelative,
+            "--tie-rule must reach the mapping"
+        );
+    }
 }

--- a/src/lib/pipeline/chains/commands/duplex.rs
+++ b/src/lib/pipeline/chains/commands/duplex.rs
@@ -13,9 +13,10 @@
 //!
 //! This module supplies the chain-builder pieces for the duplex stage; the
 //! chain is constructed via `ChainBuilder` /
-//! [`crate::pipeline::chains::build::build_for`]. `Duplex::execute` routes the
-//! `--threads N` path through this chain (via `execute_chain`), keeping the
-//! no-`--threads` in-process path as the parity oracle.
+//! [`crate::pipeline::chains::build::build_for`]. `Duplex::execute` routes
+//! every run through this chain (via `execute_chain`), with or without
+//! `--threads` — absent `--threads` runs the chain at a single worker, which
+//! is the in-process parity oracle for the multi-worker case.
 
 use std::io;
 use std::sync::Arc;
@@ -48,8 +49,7 @@ use crate::pipeline::steps::types::DecompressedBlock;
 // CollectedDuplexMetrics
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Per-thread accumulator for duplex consensus metrics (mirrors
-/// `commands::duplex::CollectedDuplexMetrics`).
+/// Per-thread accumulator for duplex consensus metrics.
 ///
 /// Merged into final aggregates after the pipeline completes; one instance
 /// per worker slot (see [`PerThreadAccumulator`]).
@@ -164,6 +164,51 @@ impl FinalizeHook for DuplexFinalizeHook {
 // opaque-return position and cannot name themselves.
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// The subset of `DuplexOptions` tuning knobs that `add_duplex` maps into
+/// [`DuplexConsensusCaptures`] for the per-worker `DuplexConsensusCaller`.
+///
+/// Extracted out of `ChainBuilder::add_duplex` (a single field-name-mismatch
+/// or swap away from a silent bug, since `DuplexConsensusCaptures` has no
+/// single "options" sub-struct the way simplex/codec do) so this mapping is
+/// unit-testable on its own: the `test_duplex_chain_matches_single_threaded`
+/// parity tests compare two chain runs (single- vs multi-worker) that BOTH go
+/// through this same mapping, so a field dropped or swapped inside it would
+/// make the two sides agree with each other and still pass. See
+/// `duplex_consensus_tuning_carries_every_tuning_flag` below, which mirrors
+/// `to_duplex_options_carries_every_tuning_flag`'s non-default-everywhere
+/// discipline for the other half of the CLI-args -> `DuplexOptions` ->
+/// `DuplexConsensusCaptures` pipeline.
+#[derive(Debug, PartialEq)]
+pub(crate) struct DuplexConsensusTuning {
+    pub(crate) min_reads: Vec<usize>,
+    pub(crate) min_input_base_quality: u8,
+    pub(crate) output_per_base_tags: bool,
+    pub(crate) trim: bool,
+    pub(crate) max_reads_per_strand: Option<usize>,
+    pub(crate) error_rate_pre_umi: u8,
+    pub(crate) error_rate_post_umi: u8,
+    pub(crate) tie_rule: fgumi_consensus::TieRule,
+    pub(crate) methylation_mode: fgumi_consensus::MethylationMode,
+}
+
+pub(crate) fn duplex_consensus_tuning(
+    duplex: &crate::commands::duplex::DuplexOptions,
+) -> DuplexConsensusTuning {
+    let consensus = duplex.consensus();
+    DuplexConsensusTuning {
+        min_reads: duplex.min_reads.clone(),
+        min_input_base_quality: consensus.min_input_base_quality,
+        output_per_base_tags: consensus.output_per_base_tags,
+        trim: consensus.trim,
+        max_reads_per_strand: duplex.max_reads_per_strand,
+        error_rate_pre_umi: consensus.error_rate_pre_umi,
+        error_rate_post_umi: consensus.error_rate_post_umi,
+        // `duplex.tie_rule` is already the resolved `TieRule` on `DuplexOptions`.
+        tie_rule: duplex.tie_rule,
+        methylation_mode: duplex.methylation_mode,
+    }
+}
+
 /// Captures passed into [`build_duplex_consensus_step_with_rejects`] / [`build_duplex_consensus_step_kept_only`] from `add_duplex`.
 ///
 /// Bundles all the cloned scalars and Arcs the closure needs so `add_duplex`
@@ -187,7 +232,7 @@ pub(crate) struct DuplexConsensusCaptures {
     pub(crate) error_rate_pre_umi: u8,
     pub(crate) error_rate_post_umi: u8,
     /// Resolved tie-breaking rule (`--tie-rule`). Threaded through so the chain
-    /// caller applies `.with_tie_rule(..)` exactly like both oracle paths.
+    /// caller applies `.with_tie_rule(..)`.
     pub(crate) tie_rule: fgumi_consensus::TieRule,
     pub(crate) cell_tag: noodles::sam::alignment::record::data::field::Tag,
     pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedDuplexMetrics>>,
@@ -235,10 +280,8 @@ fn make_duplex_consensus_init(
             error_rate_post_umi,
         )
         .expect("DuplexConsensusCaller::new failed during worker init")
-        // Apply the resolved `--tie-rule`, matching both oracle paths
-        // (`with_tie_rule` in Duplex::execute's single-threaded and legacy
-        // threaded callers). `TieRule` is `Copy`, so the `Fn` closure re-applies
-        // it on every per-worker init.
+        // Apply the resolved `--tie-rule`. `TieRule` is `Copy`, so the `Fn`
+        // closure re-applies it on every per-worker init.
         .with_tie_rule(tie_rule);
         if let Some((ref reference, ref ref_names)) = methylation_ref {
             caller.set_reference(Arc::clone(reference), Arc::clone(ref_names), methylation_mode);
@@ -489,4 +532,75 @@ pub(crate) fn build_duplex_consensus_step_kept_only(
         init,
         body,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::duplex::Duplex;
+    use clap::Parser;
+
+    /// The `DuplexOptions -> DuplexConsensusCaptures` scalar-tuning mapping
+    /// inside `add_duplex` must carry every tuning flag. The
+    /// `test_duplex_chain_matches_single_threaded` parity tests compare two
+    /// chain runs that BOTH go through this mapping, so they cannot catch a
+    /// field dropped or swapped inside it; this test exercises the mapping
+    /// directly, driven through `try_parse_from` + `to_duplex_options()` (not
+    /// a hand-built `DuplexOptions` literal) with every value non-default, so
+    /// a field read from the wrong source fails rather than coincidentally
+    /// matching a default. Mirrors `to_duplex_options_carries_every_tuning_flag`
+    /// in `commands::duplex`, which covers the other half of the pipeline
+    /// (CLI args -> `DuplexOptions`).
+    #[test]
+    fn duplex_consensus_tuning_carries_every_tuning_flag() {
+        let cmd = Duplex::try_parse_from([
+            "duplex",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--error-rate-pre-umi",
+            "41",
+            "--error-rate-post-umi",
+            "36",
+            "--min-input-base-quality",
+            "18",
+            "--output-per-base-tags=false",
+            "--trim=true",
+            "--min-consensus-base-quality",
+            "21",
+            "--tie-rule",
+            "ulp-relative",
+            "--min-reads",
+            "3,2,1",
+            "--max-reads-per-strand",
+            "55",
+            "--methylation-mode",
+            "em-seq",
+            "--ref",
+            "ref.fa",
+        ])
+        .expect("parses");
+        let duplex_options = cmd.to_duplex_options();
+
+        let tuning = duplex_consensus_tuning(&duplex_options);
+
+        assert_eq!(tuning.min_reads, vec![3, 2, 1]);
+        assert_eq!(tuning.min_input_base_quality, 18);
+        assert!(!tuning.output_per_base_tags, "an explicit false must not be lost");
+        assert!(tuning.trim);
+        assert_eq!(tuning.max_reads_per_strand, Some(55));
+        assert_eq!(tuning.error_rate_pre_umi, 41);
+        assert_eq!(tuning.error_rate_post_umi, 36);
+        assert_eq!(
+            tuning.tie_rule,
+            fgumi_consensus::TieRule::UlpRelative,
+            "--tie-rule must reach the mapping"
+        );
+        assert_eq!(
+            tuning.methylation_mode,
+            fgumi_consensus::MethylationMode::EmSeq,
+            "--methylation-mode must reach the mapping"
+        );
+    }
 }

--- a/src/lib/pipeline/chains/commands/simplex.rs
+++ b/src/lib/pipeline/chains/commands/simplex.rs
@@ -12,8 +12,9 @@
 //!
 //! This module supplies the chain-builder pieces for the simplex stage; the
 //! chain is constructed via `ChainBuilder` /
-//! [`crate::pipeline::chains::build::build_for`]. It is not yet wired as
-//! `Simplex::execute`'s live path.
+//! [`crate::pipeline::chains::build::build_for`]. It is the sole path for
+//! `Simplex::execute` (via `execute_chain`), with or without `--threads` —
+//! absent `--threads` runs the chain at a single worker.
 
 use std::io;
 use std::sync::Arc;
@@ -48,8 +49,7 @@ use crate::vanilla_consensus_caller::{VanillaUmiConsensusCaller, VanillaUmiConse
 // CollectedSimplexMetrics
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Per-thread accumulator for simplex consensus metrics (mirrors
-/// `commands::simplex::CollectedSimplexMetrics`).
+/// Per-thread accumulator for simplex consensus metrics.
 ///
 /// Merged into final aggregates after the pipeline completes; one instance
 /// per worker slot (see [`PerThreadAccumulator`]).
@@ -158,6 +158,40 @@ impl FinalizeHook for SimplexFinalizeHook {
 // opaque-return position and cannot name themselves.
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Maps `SimplexOptions` (the resolved options-bag entry `add_simplex`
+/// receives) into the `VanillaUmiConsensusOptions` the per-worker consensus
+/// caller is built from.
+///
+/// Extracted out of `ChainBuilder::add_simplex` so this mapping is
+/// unit-testable on its own: the `test_simplex_chain_matches_single_threaded`
+/// parity tests compare two chain runs (single- vs multi-worker) that BOTH go
+/// through this same mapping, so a field dropped or swapped inside it would
+/// make the two sides agree with each other and still pass. See
+/// `simplex_consensus_options_carries_every_tuning_flag` below, which mirrors
+/// `to_simplex_options_carries_every_tuning_flag`'s non-default-everywhere
+/// discipline for the other half of the CLI-args -> `SimplexOptions` ->
+/// `VanillaUmiConsensusOptions` pipeline.
+pub(crate) fn simplex_consensus_options(
+    simplex: &crate::commands::simplex::SimplexOptions,
+    cell_tag: noodles::sam::alignment::record::data::field::Tag,
+) -> VanillaUmiConsensusOptions {
+    let consensus = simplex.consensus();
+    VanillaUmiConsensusOptions {
+        tag: "MI".to_string(),
+        error_rate_pre_umi: consensus.error_rate_pre_umi,
+        error_rate_post_umi: consensus.error_rate_post_umi,
+        min_input_base_quality: consensus.min_input_base_quality,
+        min_reads: simplex.min_reads,
+        max_reads: simplex.max_reads,
+        produce_per_base_tags: consensus.output_per_base_tags,
+        trim: consensus.trim,
+        min_consensus_base_quality: consensus.min_consensus_base_quality,
+        cell_tag: Some(cell_tag),
+        methylation_mode: simplex.methylation_mode,
+        tie_rule: simplex.tie_rule,
+    }
+}
+
 /// Captures passed into [`build_simplex_consensus_step_with_rejects`] / [`build_simplex_consensus_step_kept_only`] from `add_simplex`.
 ///
 /// Bundles all the cloned scalars and Arcs the closure needs so `add_simplex`
@@ -254,11 +288,10 @@ fn run_simplex_consensus_batch(
 
         if let Some(ref mut oc) = state.overlapping {
             oc.reset_stats();
-            // A failure here must be fatal to match the single-thread fast path
-            // in `src/lib/commands/simplex.rs`, which propagates
-            // `apply_overlapping_consensus` errors with `?`. Downgrading to a
-            // `RejectionReason::Other` reject would make the same input fail
-            // without `--threads` but succeed with it.
+            // A failure here must be fatal so the absent-`--threads`
+            // (single-worker) and `--threads N` chain runs behave identically.
+            // Downgrading to a `RejectionReason::Other` reject would make the
+            // same input fail at one worker count but succeed at another.
             apply_overlapping_consensus(&mut raw_records, oc).map_err(|e| {
                 io::Error::other(format!("Overlapping consensus error for MI {mi}: {e}"))
             })?;
@@ -433,4 +466,81 @@ pub(crate) fn build_simplex_consensus_step_kept_only(
         init,
         body,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::simplex::Simplex;
+    use clap::Parser;
+
+    /// The `SimplexOptions -> VanillaUmiConsensusOptions` mapping inside
+    /// `add_simplex` must carry every tuning flag. The
+    /// `test_simplex_chain_matches_single_threaded` parity tests compare two
+    /// chain runs that BOTH go through this mapping, so they cannot catch a
+    /// field dropped or swapped inside it; this test exercises the mapping
+    /// directly, driven through `try_parse_from` + `to_simplex_options()` (not
+    /// a hand-built `SimplexOptions` literal) with every value non-default, so
+    /// a field read from the wrong source fails rather than coincidentally
+    /// matching a default. Mirrors
+    /// `to_simplex_options_carries_every_tuning_flag` in
+    /// `commands::simplex`, which covers the other half of the pipeline
+    /// (CLI args -> `SimplexOptions`).
+    #[test]
+    fn simplex_consensus_options_carries_every_tuning_flag() {
+        let cmd = Simplex::try_parse_from([
+            "simplex",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--error-rate-pre-umi",
+            "40",
+            "--error-rate-post-umi",
+            "35",
+            "--min-input-base-quality",
+            "17",
+            "--output-per-base-tags=false",
+            "--trim=true",
+            "--min-consensus-base-quality",
+            "19",
+            "--tie-rule",
+            "ulp-relative",
+            "--min-reads",
+            "3",
+            "--max-reads",
+            "77",
+            "--methylation-mode",
+            "em-seq",
+            "--ref",
+            "ref.fa",
+        ])
+        .expect("parses");
+        let simplex_options = cmd.to_simplex_options();
+
+        let cell_tag =
+            noodles::sam::alignment::record::data::field::Tag::from(crate::sam::SamTag::CB);
+        let opts = simplex_consensus_options(&simplex_options, cell_tag);
+
+        assert_eq!(opts.tag, "MI");
+        assert_eq!(opts.error_rate_pre_umi, 40);
+        assert_eq!(opts.error_rate_post_umi, 35);
+        assert_eq!(opts.min_input_base_quality, 17);
+        assert!(!opts.produce_per_base_tags, "an explicit false must not be lost");
+        assert!(opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 19);
+        assert_eq!(
+            opts.tie_rule,
+            fgumi_consensus::TieRule::UlpRelative,
+            "--tie-rule must reach the mapping"
+        );
+        assert_eq!(opts.min_reads, 3);
+        assert_eq!(opts.max_reads, Some(77));
+        assert_eq!(opts.cell_tag, Some(cell_tag));
+        assert_eq!(
+            opts.methylation_mode,
+            fgumi_consensus::MethylationMode::EmSeq,
+            "--methylation-mode must reach the mapping"
+        );
+    }
 }

--- a/src/lib/reference.rs
+++ b/src/lib/reference.rs
@@ -389,7 +389,7 @@ impl fgumi_sam::ReferenceProvider for ReferenceReader {
     }
 }
 
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 impl fgumi_consensus::methylation::RefBaseProvider for ReferenceReader {
     fn base_at_0based(&self, chrom: &str, pos: u64) -> Option<u8> {
         let sequence = self.sequences.get(chrom)?;

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -788,7 +788,7 @@ const fn saturating_refund(current: u64, bytes: u64) -> u64 {
 /// Default high-water mark for Q5, the processed queue (256 MiB).
 ///
 /// This is set lower than the Q3 mark (256 MiB vs 512 MiB) because items in Q5
-/// are typically larger (e.g., `SimplexProcessedBatch` with `RecordBuf` vectors).
+/// are typically larger (e.g., `CorrectProcessedBatch` with `RecordBuf` vectors).
 /// When Q5 memory reaches this mark, the Process step pauses to let
 /// downstream steps (Serialize, Compress, Write) catch up.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ const STYLES: Styles = Styles::styled()
     .placeholder(AnsiColor::Cyan.on_default());
 use env_logger::Env;
 use fgumi_lib::commands::clip::Clip;
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::codec::Codec;
 use fgumi_lib::commands::command::Command;
 #[cfg(feature = "compare")]
@@ -23,9 +23,9 @@ use fgumi_lib::commands::copy_umi::CopyUmi;
 use fgumi_lib::commands::correct::CorrectUmis;
 use fgumi_lib::commands::dedup::MarkDuplicates;
 use fgumi_lib::commands::downsample::Downsample;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::duplex::Duplex;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::duplex_metrics::DuplexMetrics;
 use fgumi_lib::commands::extract::Extract;
 use fgumi_lib::commands::fastq::Fastq;
@@ -35,9 +35,9 @@ use fgumi_lib::commands::merge::Merge;
 use fgumi_lib::commands::retag::Retag;
 use fgumi_lib::commands::review::Review;
 use fgumi_lib::commands::runall::RunAll;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::simplex::Simplex;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 use fgumi_lib::commands::simplex_metrics::SimplexMetrics;
 #[cfg(feature = "simulate")]
 use fgumi_lib::commands::simulate::Simulate;
@@ -48,16 +48,16 @@ use log::info;
 /// Commands that require feature flags to be enabled.
 /// Format: (`command_name`, `feature_name`)
 const FEATURE_GATED_COMMANDS: &[(&str, &str)] = &[
-    #[cfg(not(feature = "simplex"))]
-    ("simplex", "simplex"),
-    #[cfg(not(feature = "simplex"))]
-    ("simplex-metrics", "simplex"),
-    #[cfg(not(feature = "duplex"))]
-    ("duplex", "duplex"),
-    #[cfg(not(feature = "duplex"))]
-    ("duplex-metrics", "duplex"),
-    #[cfg(not(feature = "codec"))]
-    ("codec", "codec"),
+    #[cfg(not(feature = "consensus"))]
+    ("simplex", "consensus"),
+    #[cfg(not(feature = "consensus"))]
+    ("simplex-metrics", "consensus"),
+    #[cfg(not(feature = "consensus"))]
+    ("duplex", "consensus"),
+    #[cfg(not(feature = "consensus"))]
+    ("duplex-metrics", "consensus"),
+    #[cfg(not(feature = "consensus"))]
+    ("codec", "consensus"),
     #[cfg(not(feature = "compare"))]
     ("compare", "compare"),
     #[cfg(not(feature = "simulate"))]
@@ -120,13 +120,13 @@ enum Subcommand {
     Dedup(MarkDuplicates),
 
     // Consensus Calling
-    #[cfg(feature = "simplex")]
+    #[cfg(feature = "consensus")]
     #[command(display_order = 9)]
     Simplex(Simplex),
-    #[cfg(feature = "duplex")]
+    #[cfg(feature = "consensus")]
     #[command(display_order = 10)]
     Duplex(Duplex),
-    #[cfg(feature = "codec")]
+    #[cfg(feature = "consensus")]
     #[command(display_order = 11)]
     Codec(Codec),
 
@@ -135,10 +135,10 @@ enum Subcommand {
     Filter(Filter),
     #[command(display_order = 13)]
     Clip(Clip),
-    #[cfg(feature = "duplex")]
+    #[cfg(feature = "consensus")]
     #[command(display_order = 14)]
     DuplexMetrics(DuplexMetrics),
-    #[cfg(feature = "simplex")]
+    #[cfg(feature = "consensus")]
     #[command(display_order = 15)]
     SimplexMetrics(SimplexMetrics),
     #[command(display_order = 16)]
@@ -172,17 +172,17 @@ impl Subcommand {
             Self::Merge(cmd) => cmd.execute(command_line),
             Self::Group(cmd) => cmd.execute(command_line),
             Self::Dedup(cmd) => cmd.execute(command_line),
-            #[cfg(feature = "simplex")]
+            #[cfg(feature = "consensus")]
             Self::Simplex(cmd) => cmd.execute(command_line),
-            #[cfg(feature = "duplex")]
+            #[cfg(feature = "consensus")]
             Self::Duplex(cmd) => cmd.execute(command_line),
-            #[cfg(feature = "codec")]
+            #[cfg(feature = "consensus")]
             Self::Codec(cmd) => cmd.execute(command_line),
             Self::Filter(cmd) => cmd.execute(command_line),
             Self::Clip(cmd) => cmd.execute(command_line),
-            #[cfg(feature = "duplex")]
+            #[cfg(feature = "consensus")]
             Self::DuplexMetrics(cmd) => cmd.execute(command_line),
-            #[cfg(feature = "simplex")]
+            #[cfg(feature = "consensus")]
             Self::SimplexMetrics(cmd) => cmd.execute(command_line),
             Self::Review(cmd) => cmd.execute(command_line),
             Self::Downsample(cmd) => cmd.execute(command_line),

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -12,9 +12,9 @@ mod test_bgzf_eof;
 mod test_chain_bam_with_index;
 mod test_clip_command;
 mod test_clip_cutover_parity;
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 mod test_codec_command;
-#[cfg(feature = "codec")]
+#[cfg(feature = "consensus")]
 mod test_codec_pipeline;
 #[cfg(feature = "compare")]
 mod test_compare_bams;
@@ -22,14 +22,16 @@ mod test_compare_bams;
 mod test_compare_metrics_command;
 #[cfg(feature = "compare")]
 mod test_compare_mutation;
+#[cfg(feature = "consensus")]
+mod test_consensus_cutover_parity;
 mod test_consensus_downsampling;
 mod test_copy_umi_command;
 mod test_correct_command;
 mod test_dedup_command;
 mod test_downsample_command;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 mod test_duplex_command;
-#[cfg(feature = "duplex")]
+#[cfg(feature = "consensus")]
 mod test_duplex_metrics_command;
 #[cfg(all(feature = "compare", feature = "simulate"))]
 mod test_e2e_regression;
@@ -51,11 +53,11 @@ mod test_review_command;
 mod test_runall_chain_transitions;
 mod test_runall_command;
 mod test_sam_input;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 mod test_simplex_command;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 mod test_simplex_metrics_command;
-#[cfg(feature = "simplex")]
+#[cfg(feature = "consensus")]
 mod test_simplex_pipeline;
 mod test_simulate_sort;
 mod test_sort_correctness;

--- a/tests/integration/test_codec_command.rs
+++ b/tests/integration/test_codec_command.rs
@@ -1138,9 +1138,10 @@ fn create_offset_codec_pair(name: &str, umi: &str) -> (RawRecord, RawRecord) {
     (b1.build(), b2.build())
 }
 
-/// Verifies that the single-threaded `Codec::run` path recovers from a
-/// duplex-disagreement molecule via the typed `CodecConsensusError` instead
-/// of bailing — covers `src/lib/commands/codec.rs:383-397` (issue #338).
+/// Verifies that the absent-`--threads` (single-worker) chain path recovers
+/// from a duplex-disagreement molecule via the typed `CodecConsensusError`
+/// instead of bailing — covers `src/lib/commands/codec.rs:383-397` (issue
+/// #338).
 #[test]
 fn test_codec_command_recovers_from_duplex_disagreement() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -1180,16 +1181,11 @@ fn test_codec_command_recovers_from_duplex_disagreement() {
     assert_eq!(consensus_count, 0, "Disagreeing molecule should produce no consensus");
 }
 
-/// Verifies that the parallel `--threads` path recovers from a
+/// Verifies that the multi-worker `--threads` chain path recovers from a
 /// duplex-disagreement molecule via the typed `CodecConsensusError` — covers
-/// what the single-threaded test above does not exercise.
-///
-/// Since the R3.7 codec-command cutover, `default = ["consensus"]` means
-/// `--threads 2` here routes through the declarative chain builder
-/// (`Codec::execute_chain` / `add_codec`), not the legacy
-/// `Codec::execute_threads_mode`. This integration binary is built with the
-/// workspace default features, so that chain path is what this test exercises —
-/// a de-facto chain-path disagreement-recovery regression test.
+/// what the single-worker test above does not exercise (both route through
+/// `Codec::execute_chain` / `add_codec`; worker count is the only
+/// difference).
 #[test]
 fn test_codec_command_recovers_from_duplex_disagreement_threaded() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -1238,14 +1234,12 @@ fn test_codec_command_recovers_from_duplex_disagreement_threaded() {
     assert_eq!(consensus_count, 0, "Disagreeing molecule should produce no consensus");
 
     // Exercising --rejects forces the parallel-mode reject-collection path
-    // through the typed-disagreement arm (`is_duplex_disagreement()`) — on a
-    // consensus build that's the chain's `build_codec_consensus_step_with_rejects`
-    // step (`add_codec`); on a non-consensus build it's the legacy
-    // `execute_threads_mode`'s `flush_byte_records` call. CODEC3-08:
-    // `consensus_reads_typed` preserves the disagreeing molecule's raw records
-    // for the --rejects output before returning the recoverable error (fgbio
-    // routes these to its rejectsWriter), so the two input reads land in the
-    // rejects BAM on either path.
+    // through the typed-disagreement arm (`is_duplex_disagreement()`) in the
+    // chain's `build_codec_consensus_step_with_rejects` step (`add_codec`).
+    // CODEC3-08: `consensus_reads_typed` preserves the disagreeing molecule's
+    // raw records for the --rejects output before returning the recoverable
+    // error (fgbio routes these to its rejectsWriter), so the two input reads
+    // land in the rejects BAM.
     assert!(rejects_bam.exists(), "Rejects BAM file should be created");
 
     // Read the rejects back as raw BAM records so we can compare the *entire*
@@ -1392,13 +1386,17 @@ fn test_codec_ignores_half_mapped_pair_when_mapped_reads_present() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// R3.7 codec-command cutover: chain-vs-oracle parity tests
+// R3.7 codec-command cutover: chain worker-count determinism tests
 //
-// The no-`--threads` single-threaded fast path (`Codec::execute`) is the
-// in-process parity oracle; `--threads N` now routes onto the declarative
-// chain builder (`Codec::execute_chain` -> `add_codec`). These tests prove
-// byte/record identity between the two paths across the codec knobs, plus the
-// Task 2 (sort-order guard) and Task 2A (validation mirroring) hardening.
+// `Codec::execute` always routes onto the declarative chain builder
+// (`Codec::execute_chain` -> `add_codec`) on a `consensus`-feature build; the
+// legacy single-threaded fast path is retired. These tests diff a no-`--threads`
+// run (the chain at a single worker) against a `--threads N` run (N workers):
+// the "oracle" / "non-chain path" naming below now means the single-worker
+// chain, not the retired serial loop. They prove byte/record identity across the
+// codec knobs, plus the Task 2 (sort-order guard) and Task 2A (validation
+// mirroring) hardening. Byte-parity against the pre-removal serial binary lives
+// in `test_consensus_cutover_parity.rs`.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Parses and runs `codec` with the given input/output/extra args, panicking
@@ -1477,11 +1475,18 @@ fn test_codec_chain_matches_single_threaded() {
 }
 
 /// Knob-parity: set several non-default content-affecting codec knobs and assert
-/// the chain (`--threads 4`) output matches the single-threaded oracle
-/// record-for-record. Guards against `add_codec`'s hand-built
-/// `CodecConsensusOptions` dropping or mis-wiring a knob that the oracle's
-/// `to_codec_options()` honors — the default-only parity tests would pass green
-/// on such a drop, since both paths would then agree on the (identical) default.
+/// the chain (`--threads 4`) output matches the single-worker oracle
+/// record-for-record. Both sides route through `add_codec`'s
+/// `codec_consensus_options` mapping (worker count is the only difference),
+/// so this test alone cannot catch a knob that mapping drops or mis-wires —
+/// both sides would silently agree — which is why
+/// `codec_consensus_options_carries_every_tuning_flag`
+/// (`pipeline::chains::commands::codec`) exercises that mapping directly.
+/// This test instead guards that non-default values actually reach the
+/// consensus caller identically at every worker count; the default-only
+/// parity tests would pass green even if a knob's *value* (not the mapping)
+/// were silently ignored downstream, since both paths would then agree on the
+/// (identical) default.
 #[test]
 fn test_codec_chain_matches_single_threaded_with_nondefault_knobs() {
     let temp_dir = TempDir::new().unwrap();

--- a/tests/integration/test_consensus_cutover_parity.rs
+++ b/tests/integration/test_consensus_cutover_parity.rs
@@ -1,0 +1,844 @@
+//! Parity gate for the consensus trio's single-threaded-path retirement (C4):
+//! `Simplex::execute`, `Duplex::execute`, and `Codec::execute` no longer have a
+//! serial in-process loop reached when `--threads` is absent — they *always*
+//! route through the declarative chain builder, with or without `--threads`.
+//! This test proves that cutover lost nothing user-observable.
+//!
+//! Two independent things are checked here:
+//!
+//! 1. **The cutover actually happened** (`no_threads_routes_through_chain`).
+//!    A no-`--threads` run now emits the chain-only `"Total MI groups processed"`
+//!    summary line that the chain finalize hooks log; the retired serial tail
+//!    instead logged `"Total records processed"`. This is the genuine RED/GREEN
+//!    discriminator: before the removal a no-`--threads` run took the serial fast
+//!    path and printed the records-processed line; after it, the chain prints the
+//!    MI-groups line. (The `"Using pipeline with N threads"` banner is emitted by
+//!    the simplex/duplex chains but not the codec chain, so it is not a uniform
+//!    discriminator across the trio; the MI-groups summary line is.)
+//!
+//! 2. **Output parity with the pre-removal serial path** (`cutover_matches_baseline`).
+//!    The current build's consensus output — records (byte-identical, modulo the
+//!    `@PG` line) and the `--stats` TSV — must match the frozen pre-removal
+//!    serial baseline binary. The baseline path comes from `FGUMI_BASELINE_BIN`;
+//!    when it is unset (or names a missing file) the case degrades to a
+//!    self-consistency oracle (non-empty consensus output + a well-formed stats
+//!    TSV asserted directly) rather than skipping — the exact fallback discipline
+//!    of `test_sort_cutover_parity.rs`.
+//!
+//! **Not a RED/GREEN gate for the parity half.** Because the removed serial loop
+//! and the chain were already output-equivalent (proven in-process by the
+//! `test_*_chain_matches_single_threaded` suites), the baseline byte-parity check
+//! passes on both sides of the change — it guards equivalence, it does not observe
+//! a regression the cutover introduces. The chain-banner check in (1) is the part
+//! that flips RED→GREEN across the removal.
+//!
+//! Only compiled with the `consensus` feature (gated at the `mod` declaration
+//! in `main.rs`) — `simplex`/`duplex`/`codec` (and the chain machinery they
+//! depend on) only exist in a `consensus` build, so the cutover this test
+//! guards has no other configuration to run under.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use fgumi_lib::sam::SamTag;
+use fgumi_raw_bam::RawRecord;
+use rstest::rstest;
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::{create_minimal_header, create_umi_family};
+use crate::helpers::read_bam_output;
+
+/// The three consensus commands whose serial fast path this PR retires.
+#[derive(Clone, Copy, Debug)]
+enum ConsensusCmd {
+    Simplex,
+    Duplex,
+    Codec,
+}
+
+impl ConsensusCmd {
+    /// The subcommand name passed to the binary.
+    fn name(self) -> &'static str {
+        match self {
+            ConsensusCmd::Simplex => "simplex",
+            ConsensusCmd::Duplex => "duplex",
+            ConsensusCmd::Codec => "codec",
+        }
+    }
+
+    /// The `Starting …` banner the chain builder logs for this command, used to
+    /// assert the chain path ran (not just that some pipeline banner appeared).
+    fn starting_banner(self) -> &'static str {
+        match self {
+            ConsensusCmd::Simplex => "Starting Simplex",
+            ConsensusCmd::Duplex => "Starting Duplex",
+            ConsensusCmd::Codec => "Starting CODEC consensus calling",
+        }
+    }
+}
+
+/// Resolves the saved pre-removal serial baseline binary to compare against.
+///
+/// The path comes solely from `FGUMI_BASELINE_BIN`; when unset (or naming a
+/// missing file) this returns `None` — "no baseline oracle available", never a
+/// silent pass. Callers layer the baseline byte-parity check on top of the
+/// always-available self-consistency oracle; a missing baseline drops only the
+/// byte-parity half, it never skips the case. No hardcoded fallback: a baseline
+/// binary is host-specific and must never be a path committed into the repo.
+fn baseline_bin() -> Option<PathBuf> {
+    let path = PathBuf::from(std::env::var_os("FGUMI_BASELINE_BIN")?);
+    if path.is_file() {
+        return Some(path);
+    }
+    eprintln!(
+        "FGUMI_BASELINE_BIN={} does not name an existing file; baseline oracle unavailable",
+        path.display()
+    );
+    None
+}
+
+/// Removes every `@PG` line from a SAM header text blob.
+///
+/// Both the current build and the baseline binary stamp a single `@PG` line
+/// whose `VN` (git-describe version) and `CL` (command line, naming argv[0] — a
+/// different binary path for each side — and the per-run output path) necessarily
+/// differ between two independent invocations. Stripping the whole line is
+/// correct here because neither side emits more than one `@PG` for these inputs
+/// (the test BAMs carry no pre-existing `@PG`).
+fn strip_pg_lines(text: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+    let mut lines: Vec<&str> = text.split('\n').collect();
+    let had_trailing_newline = lines.last() == Some(&"");
+    if had_trailing_newline {
+        lines.pop();
+    }
+    lines.retain(|line| !line.starts_with("@PG"));
+    let mut out = lines.join("\n");
+    if had_trailing_newline {
+        out.push('\n');
+    }
+    out
+}
+
+/// Reads a BAM's raw BGZF stream, decompresses it, strips the `@PG` line(s) from
+/// the embedded SAM header text, and returns the resulting bytes (new header +
+/// unmodified `n_ref`/reference-list/record bytes).
+///
+/// Comparing the *decompressed* BAM binary — rather than `RecordBuf`-parsed
+/// records or raw file bytes — keeps everything except the `@PG` line an exact,
+/// uninterpreted byte comparison: BGZF block boundaries differ between the two
+/// writers even for identical logical content (so raw file bytes never match),
+/// while parsing into `RecordBuf` and re-encoding could mask a real tag-order or
+/// binary-layout regression by normalizing it away. Consensus output carries
+/// consensus quality/per-base tags whose exact byte layout is the contract, so
+/// that masking risk is exactly what must be avoided.
+fn decompressed_records_without_pg(path: &Path) -> Vec<u8> {
+    let file = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+    let mut reader = noodles::bgzf::io::Reader::new(std::io::BufReader::new(file));
+    let mut raw = Vec::new();
+    std::io::Read::read_to_end(&mut reader, &mut raw)
+        .unwrap_or_else(|e| panic!("decompress BGZF stream for {}: {e}", path.display()));
+
+    assert!(
+        raw.len() >= 8 && &raw[0..4] == b"BAM\x01",
+        "{} does not decompress to a BAM binary stream (missing magic)",
+        path.display()
+    );
+    let l_text = i32::from_le_bytes(raw[4..8].try_into().expect("4 bytes"));
+    let l_text = usize::try_from(l_text).expect("l_text is non-negative");
+    let text_start = 8;
+    let text_end = text_start + l_text;
+    assert!(raw.len() >= text_end, "{} header text runs past end of stream", path.display());
+
+    let text = String::from_utf8_lossy(&raw[text_start..text_end]);
+    let stripped_text = strip_pg_lines(&text);
+
+    let mut out = Vec::with_capacity(raw.len());
+    out.extend_from_slice(b"BAM\x01");
+    let new_l_text = i32::try_from(stripped_text.len()).expect("stripped header text fits i32");
+    out.extend_from_slice(&new_l_text.to_le_bytes());
+    out.extend_from_slice(stripped_text.as_bytes());
+    out.extend_from_slice(&raw[text_end..]); // n_ref, reference list, and all records, untouched
+    out
+}
+
+/// Writes an MI-grouped input BAM for `simplex`: several deep single-strand UMI
+/// families, each tagged with a distinct `MI`, deep enough to survive
+/// `--min-reads 2`.
+fn write_simplex_input(dir: &Path) -> PathBuf {
+    use noodles::sam::alignment::io::Write as _;
+    use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::Value;
+
+    let input = dir.join("in.bam");
+    let header = create_minimal_header("chr1", 10_000);
+    let mut writer =
+        noodles::bam::io::Writer::new(std::fs::File::create(&input).expect("create simplex input"));
+    writer.write_header(&header).expect("write header");
+
+    let families = [
+        ("1", create_umi_family("ACGT", 5, "fam1", "ACGTACGTAC", 30)),
+        ("2", create_umi_family("TGCA", 4, "fam2", "TTTTAAAAGG", 30)),
+        ("3", create_umi_family("GGCC", 3, "fam3", "CCCCGGGGTT", 30)),
+    ];
+    let mi_tag = Tag::from(fgumi_lib::sam::SamTag::MI);
+    for (mi, records) in families {
+        for raw in &records {
+            let mut record = crate::helpers::bam_generator::to_record_buf(raw);
+            record.data_mut().insert(mi_tag, Value::from(mi));
+            writer.write_alignment_record(&header, &record).expect("write record");
+        }
+    }
+    writer.try_finish().expect("finish simplex input");
+    input
+}
+
+/// Writes an AB/BA duplex input BAM for `duplex`: two double-stranded molecules,
+/// each with matched top/bottom strands deep enough for a duplex call.
+fn write_duplex_input(dir: &Path) -> PathBuf {
+    let input = dir.join("in.bam");
+    let molecules = vec![
+        crate::test_duplex_command::create_duplex_molecule("1", "ACGTACGT", 30, 100, 4),
+        crate::test_duplex_command::create_duplex_molecule("2", "TTGGCCAA", 30, 400, 3),
+    ];
+    crate::test_duplex_command::create_duplex_bam(&input, molecules);
+    input
+}
+
+/// Writes a CODEC input BAM for `codec`: one molecule of several overlapping
+/// read pairs sharing an `MI`, deep enough for a CODEC consensus call.
+fn write_codec_input(dir: &Path) -> PathBuf {
+    let input = dir.join("in.bam");
+    let mut pairs: Vec<(RawRecord, RawRecord)> = Vec::new();
+    for i in 0..4 {
+        pairs.push(crate::test_codec_command::create_codec_read_pair(
+            &format!("read{i}"),
+            b"ACGTACGT",
+            b"ACGTACGT",
+            &[30; 8],
+            &[30; 8],
+            100,
+            "UMI001",
+            None,
+        ));
+    }
+    crate::test_codec_command::create_codec_test_bam(&input, pairs);
+    input
+}
+
+/// Writes the appropriate input BAM for `cmd` and returns its path.
+fn write_input(cmd: ConsensusCmd, dir: &Path) -> PathBuf {
+    match cmd {
+        ConsensusCmd::Simplex => write_simplex_input(dir),
+        ConsensusCmd::Duplex => write_duplex_input(dir),
+        ConsensusCmd::Codec => write_codec_input(dir),
+    }
+}
+
+/// Runs `<bin> <cmd> -i <input> -o <output> [--stats <stats>] [--rejects <rejects>]
+/// --min-reads 2 --compression-level 1` (no `--threads`, so the current build takes
+/// the post-cutover chain path and the baseline takes its serial path) with
+/// `RUST_LOG=info`, and returns the process output for stderr assertions.
+fn run_consensus(
+    bin: &Path,
+    cmd: ConsensusCmd,
+    input: &Path,
+    output: &Path,
+    stats: Option<&Path>,
+    rejects: Option<&Path>,
+) -> std::process::Output {
+    let mut command = Command::new(bin);
+    command.env("RUST_LOG", "info").args([
+        OsStr::new(cmd.name()),
+        OsStr::new("-i"),
+        input.as_os_str(),
+        OsStr::new("-o"),
+        output.as_os_str(),
+        OsStr::new("--min-reads"),
+        OsStr::new("2"),
+        OsStr::new("--compression-level"),
+        OsStr::new("1"),
+    ]);
+    if let Some(stats) = stats {
+        command.args([OsStr::new("--stats"), stats.as_os_str()]);
+    }
+    if let Some(rejects) = rejects {
+        command.args([OsStr::new("--rejects"), rejects.as_os_str()]);
+    }
+    command
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn `{}` {}: {e}", bin.display(), cmd.name()))
+}
+
+/// A no-`--threads` run now routes through the declarative chain, whose finalize
+/// hooks log the `"Total MI groups processed"` summary line (and the chain
+/// builder logs the `Starting …` banner). The retired serial tail logged
+/// `"Total records processed"` instead, so the MI-groups line is the RED
+/// (pre-removal) → GREEN (post-removal) discriminator for the cutover.
+#[rstest]
+#[case::simplex(ConsensusCmd::Simplex)]
+#[case::duplex(ConsensusCmd::Duplex)]
+#[case::codec(ConsensusCmd::Codec)]
+fn no_threads_routes_through_chain(#[case] cmd: ConsensusCmd) {
+    let dir = TempDir::new().expect("temp dir");
+    let input = write_input(cmd, dir.path());
+    let output = dir.path().join("out.bam");
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let out = run_consensus(current_bin, cmd, &input, &output, None, None);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "no-threads {} must succeed; stderr:\n{stderr}", cmd.name());
+    assert!(
+        stderr.contains("Total MI groups processed"),
+        "a no-`--threads` {} must route through the chain (whose finalize hook logs \
+         `Total MI groups processed`); the serial path (which logged `Total records processed`) \
+         is retired. stderr:\n{stderr}",
+        cmd.name()
+    );
+    assert!(
+        !stderr.contains("Total records processed"),
+        "a no-`--threads` {} must NOT emit the retired serial tail's `Total records processed` \
+         line. stderr:\n{stderr}",
+        cmd.name()
+    );
+    assert!(
+        stderr.contains(cmd.starting_banner()),
+        "the chain must still emit the `{}` banner; stderr:\n{stderr}",
+        cmd.starting_banner()
+    );
+}
+
+/// Output parity of the post-cutover chain against the pre-removal serial
+/// baseline binary, across all three commands with and without `--stats` — plus
+/// the always-available self-consistency oracle when no baseline is set.
+#[rstest]
+#[case::simplex_no_stats(ConsensusCmd::Simplex, false)]
+#[case::simplex_with_stats(ConsensusCmd::Simplex, true)]
+#[case::duplex_no_stats(ConsensusCmd::Duplex, false)]
+#[case::duplex_with_stats(ConsensusCmd::Duplex, true)]
+#[case::codec_no_stats(ConsensusCmd::Codec, false)]
+#[case::codec_with_stats(ConsensusCmd::Codec, true)]
+fn cutover_matches_baseline(#[case] cmd: ConsensusCmd, #[case] with_stats: bool) {
+    let dir = TempDir::new().expect("temp dir");
+    let input = write_input(cmd, dir.path());
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current_tsv = dir.path().join("current.stats.tsv");
+    // Always exercise the `--rejects` fan-out path (a distinct output the chain
+    // writes) so a cutover regression in it is observable. These fixtures are
+    // all-agreeing and above `--min-reads 2`, so the rejects BAM is expected to
+    // be header-only (zero records) — asserted below.
+    let current_rejects = dir.path().join("current.rejects.bam");
+    let current_stats = with_stats.then(|| current_tsv.clone());
+    let current = run_consensus(
+        current_bin,
+        cmd,
+        &input,
+        &current_out,
+        current_stats.as_deref(),
+        Some(&current_rejects),
+    );
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(
+        current.status.success(),
+        "current {} must succeed; stderr:\n{current_stderr}",
+        cmd.name()
+    );
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let baseline_tsv = dir.path().join("baseline.stats.tsv");
+        let baseline_rejects = dir.path().join("baseline.rejects.bam");
+        let baseline_stats = with_stats.then(|| baseline_tsv.clone());
+        let base = run_consensus(
+            &baseline,
+            cmd,
+            &input,
+            &baseline_out,
+            baseline_stats.as_deref(),
+            Some(&baseline_rejects),
+        );
+        assert!(
+            base.status.success(),
+            "baseline {} failed; stderr:\n{}",
+            cmd.name(),
+            String::from_utf8_lossy(&base.stderr)
+        );
+
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "chain {} output diverges from the pre-removal serial baseline binary ({}) after \
+             stripping @PG — a real cutover parity bug, not something to relax",
+            cmd.name(),
+            baseline.display(),
+        );
+        // The rejects fan-out must match the serial baseline too (header + the
+        // empty-rejects case here); reject *record* parity on reject-producing
+        // input is pinned by the per-command suites (e.g. `test_duplex_chain_rejects_parity`).
+        assert_eq!(
+            decompressed_records_without_pg(&current_rejects),
+            decompressed_records_without_pg(&baseline_rejects),
+            "chain {} rejects output diverges from the serial baseline binary after stripping @PG",
+            cmd.name(),
+        );
+        if with_stats {
+            assert_eq!(
+                std::fs::read_to_string(&current_tsv).expect("current stats tsv"),
+                std::fs::read_to_string(&baseline_tsv).expect("baseline stats tsv"),
+                "chain {} --stats TSV diverges from the serial baseline binary",
+                cmd.name()
+            );
+        }
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_matches_baseline[{}]: FGUMI_BASELINE_BIN is unset or \
+             does not name an existing file — running self-consistency oracle instead",
+            cmd.name()
+        );
+        assert_self_consistent(cmd, &current_out, current_stats.as_deref(), Some(&current_rejects));
+    }
+}
+
+/// One consensus record's fully fixture-determined content, used as the
+/// self-consistency oracle's expectation. Every field is pinned to an exact
+/// value so a regression in any of them — not just `SEQ` — fails the test.
+struct ExpectedRecord {
+    /// Consensus read name (`<prefix>:<counter>`; the test prefix is empty, so
+    /// e.g. `:1`).
+    name: &'static str,
+    /// Consensus `SEQ` — the family/molecule's uniform sequence.
+    seq: &'static str,
+    /// Uniform per-base Phred quality carried across the whole read (the inputs
+    /// agree at every base, so the caller emits one capped value throughout).
+    qual: u8,
+    /// Exact SAM FLAG bits. Consensus reads are unmapped: a simplex/codec
+    /// fragment is `UNMAPPED` alone; each duplex template emits an
+    /// `UNMAPPED | MATE_UNMAPPED | SEGMENTED` pair with `FIRST_SEGMENT` (R1) or
+    /// `LAST_SEGMENT` (R2). Pinning the exact bits catches a regression in
+    /// pairing or the mapped/unmapped state that field-subset checks miss.
+    flags: u16,
+    /// Total consensus depth (`cD`): the number of raw reads supporting the
+    /// molecule. Also every entry of the per-base depth array.
+    total_depth: i64,
+    /// For duplex/codec, the per-strand `(aD, bD)` depths; `None` for simplex
+    /// (which instead carries the single-strand `cd` per-base depth array).
+    strand_depths: Option<(i64, i64)>,
+}
+
+/// `UNMAPPED` (0x4): the flag a simplex/codec consensus fragment carries.
+const F_UNMAPPED: u16 = 0x4;
+/// A duplex R1 consensus: `SEGMENTED | UNMAPPED | MATE_UNMAPPED | FIRST_SEGMENT`.
+const F_DUPLEX_R1: u16 = 0x1 | 0x4 | 0x8 | 0x40;
+/// A duplex R2 consensus: `SEGMENTED | UNMAPPED | MATE_UNMAPPED | LAST_SEGMENT`.
+const F_DUPLEX_R2: u16 = 0x1 | 0x4 | 0x8 | 0x80;
+
+/// The expected records for each command's fixture, confirmed by running the
+/// chain against each fixture and reading the output back (not by inspection):
+/// - Simplex (`write_simplex_input`): 3 MI groups (`fam1`/`fam2`/`fam3`) of
+///   depth 5/4/3, one consensus fragment each.
+/// - Duplex (`write_duplex_input`): 2 molecules (depth 8/6, split 4+4 / 3+3
+///   across strands), each yielding one consensus template (R1 + R2) → 4 records.
+/// - Codec (`write_codec_input`): 1 molecule (4 overlapping pairs sharing one
+///   `MI`, depth 8, split 4+4), one consensus fragment.
+fn expected_records(cmd: ConsensusCmd) -> Vec<ExpectedRecord> {
+    let rec = |name, seq: &'static str, qual, flags, total_depth, strand_depths| ExpectedRecord {
+        name,
+        seq,
+        qual,
+        flags,
+        total_depth,
+        strand_depths,
+    };
+    match cmd {
+        ConsensusCmd::Simplex => vec![
+            rec(":1", "ACGTACGTAC", 45, F_UNMAPPED, 5, None),
+            rec(":2", "TTTTAAAAGG", 45, F_UNMAPPED, 4, None),
+            rec(":3", "CCCCGGGGTT", 45, F_UNMAPPED, 3, None),
+        ],
+        ConsensusCmd::Duplex => vec![
+            rec(":1", "ACGTACGT", 90, F_DUPLEX_R1, 8, Some((4, 4))),
+            rec(":1", "ACGTACGT", 90, F_DUPLEX_R2, 8, Some((4, 4))),
+            rec(":2", "TTGGCCAA", 90, F_DUPLEX_R1, 6, Some((3, 3))),
+            rec(":2", "TTGGCCAA", 90, F_DUPLEX_R2, 6, Some((3, 3))),
+        ],
+        ConsensusCmd::Codec => vec![rec(":UMI001", "ACGTACGT", 90, F_UNMAPPED, 8, Some((4, 4)))],
+    }
+}
+
+/// The *complete* fixture-determined `--stats` TSV row set (`key` → exact
+/// `value` string) for each command — every row the tool emits, not a subset.
+/// Every raw read is used and none rejected, so all counts are fully determined
+/// by the fixture size and every rejection reason is `0`. [`assert_stats_rows`]
+/// asserts this map is exactly the emitted key set (a missing OR an unexpected
+/// row fails), so a regression that adds, drops, or mis-values any row — a new
+/// rejection reason, a renamed key — is caught.
+fn expected_stats(cmd: ConsensusCmd) -> &'static [(&'static str, &'static str)] {
+    match cmd {
+        ConsensusCmd::Simplex => &[
+            ("raw_reads_considered", "12"),
+            ("raw_reads_rejected", "0"),
+            ("raw_reads_used", "12"),
+            ("frac_raw_reads_used", "1.000000"),
+            ("raw_reads_rejected_for_insufficient_support", "0"),
+            ("raw_reads_rejected_for_minority_alignment", "0"),
+            ("raw_reads_rejected_for_orphan_consensus", "0"),
+            ("raw_reads_rejected_for_zero_bases_post_trimming", "0"),
+            ("consensus_reads_emitted", "3"),
+        ],
+        ConsensusCmd::Duplex => &[
+            ("raw_reads_considered", "28"),
+            ("raw_reads_rejected", "0"),
+            ("raw_reads_used", "28"),
+            ("frac_raw_reads_used", "1.000000"),
+            ("raw_reads_rejected_for_insufficient_support", "0"),
+            ("raw_reads_rejected_for_minority_alignment", "0"),
+            ("raw_reads_rejected_for_orphan_consensus", "0"),
+            ("raw_reads_rejected_for_zero_bases_post_trimming", "0"),
+            ("raw_reads_rejected_for_non_paired_reads", "0"),
+            ("raw_reads_rejected_for_single_strand_only", "0"),
+            ("raw_reads_rejected_for_potential_umi_collision", "0"),
+            ("consensus_reads_emitted", "4"),
+        ],
+        ConsensusCmd::Codec => &[
+            ("raw_reads_considered", "8"),
+            ("raw_reads_rejected", "0"),
+            ("raw_reads_used", "8"),
+            ("frac_raw_reads_used", "1.000000"),
+            ("raw_reads_rejected_for_insufficient_support", "0"),
+            ("raw_reads_rejected_for_minority_alignment", "0"),
+            ("raw_reads_rejected_for_orphan_consensus", "0"),
+            ("raw_reads_rejected_for_zero_bases_post_trimming", "0"),
+            ("raw_reads_rejected_for_non_paired_reads", "0"),
+            ("raw_reads_rejected_for_single_strand_only", "0"),
+            ("raw_reads_rejected_for_potential_umi_collision", "0"),
+            ("raw_reads_rejected_for_r1_r2_overlap_too_short", "0"),
+            ("raw_reads_rejected_for_indel_error_between_strands", "0"),
+            ("raw_reads_rejected_for_high_duplex_disagreement", "0"),
+            ("raw_reads_rejected_for_clip_overlap_failed", "0"),
+            ("raw_reads_rejected_for_not_primary_fr_pair", "0"),
+            ("consensus_reads_emitted", "1"),
+            ("consensus_reads_rejected_hdd", "0"),
+            ("consensus_bases_emitted", "8"),
+            ("consensus_duplex_bases_emitted", "8"),
+            ("duplex_disagreement_base_count", "0"),
+            ("duplex_disagreement_rate", "0.000000"),
+        ],
+    }
+}
+
+/// Reads a data-field integer tag (any SAM integer width) off a `RecordBuf` as
+/// `i64`. Panics if the tag is absent or not an integer.
+fn int_tag_of(record: &noodles::sam::alignment::RecordBuf, tag: SamTag) -> i64 {
+    use noodles::sam::alignment::record_buf::data::field::Value;
+    match record.data().get(&tag.to_noodles_tag()) {
+        Some(Value::Int8(n)) => i64::from(*n),
+        Some(Value::UInt8(n)) => i64::from(*n),
+        Some(Value::Int16(n)) => i64::from(*n),
+        Some(Value::UInt16(n)) => i64::from(*n),
+        Some(Value::Int32(n)) => i64::from(*n),
+        Some(Value::UInt32(n)) => i64::from(*n),
+        other => panic!("tag {tag:?} must be an integer, got {other:?}"),
+    }
+}
+
+/// Reads a data-field `Float` tag off a `RecordBuf`. Panics if absent or not a float.
+fn float_tag_of(record: &noodles::sam::alignment::RecordBuf, tag: SamTag) -> f32 {
+    use noodles::sam::alignment::record_buf::data::field::Value;
+    match record.data().get(&tag.to_noodles_tag()) {
+        Some(Value::Float(f)) => *f,
+        other => panic!("tag {tag:?} must be a float, got {other:?}"),
+    }
+}
+
+/// Reads a data-field `Int16` array tag off a `RecordBuf`. Panics if absent or
+/// not an `Int16` array (the per-base depth/error arrays fgumi emits).
+fn int16_array_tag_of(record: &noodles::sam::alignment::RecordBuf, tag: SamTag) -> Vec<i16> {
+    use noodles::sam::alignment::record_buf::data::field::Value;
+    use noodles::sam::alignment::record_buf::data::field::value::Array;
+    match record.data().get(&tag.to_noodles_tag()) {
+        Some(Value::Array(Array::Int16(values))) => values.clone(),
+        other => panic!("tag {tag:?} must be an Int16 array, got {other:?}"),
+    }
+}
+
+/// Always-available oracle used when no baseline binary is set: since
+/// `FGUMI_BASELINE_BIN` is unset in CI, this fallback is the ONLY oracle CI
+/// ever runs for this test. It asserts real content, not just "non-empty" or
+/// "SEQ": each record's exact read name, SAM FLAG bits, the unmapped-consensus
+/// alignment invariant (no position, MAPQ 0, empty CIGAR, no mate), `SEQ`,
+/// per-base qualities, command-specific consensus depth/error tags (scalar
+/// `cD`/`cE` plus the per-base `cd` or `ad`/`bd` arrays), and the complete
+/// data-tag key set; with `--stats`, the complete fixture-determined stats map
+/// (a missing OR unexpected row fails); and with `--rejects`, that the rejects
+/// fan-out BAM
+/// is header-only (zero records) — these fixtures are all-agreeing and above
+/// `--min-reads 2`, so every raw read is consumed and nothing is rejected, so a
+/// regression that spuriously fanned reads into rejects would fail here. (Reject
+/// *record* parity on reject-producing input is pinned by the per-command suites,
+/// e.g. `test_duplex_chain_rejects_parity`.) All expectations are pinned in
+/// [`expected_records`] / [`expected_stats`].
+fn assert_self_consistent(
+    cmd: ConsensusCmd,
+    output: &Path,
+    stats: Option<&Path>,
+    rejects: Option<&Path>,
+) {
+    let (_, out_records) = read_bam_output(output);
+
+    let expected = expected_records(cmd);
+
+    assert_eq!(
+        out_records.len(),
+        expected.len(),
+        "{} chain output must contain exactly {} consensus record(s) for this fixture; got {} \
+         record(s)",
+        cmd.name(),
+        expected.len(),
+        out_records.len()
+    );
+
+    for (i, (record, exp)) in out_records.iter().zip(&expected).enumerate() {
+        assert_consensus_record(cmd, &format!("{} consensus record {i}", cmd.name()), record, exp);
+    }
+
+    if let Some(path) = stats {
+        assert_stats_rows(cmd, path);
+    }
+
+    if let Some(path) = rejects {
+        let (_, rejects_records) = read_bam_output(path);
+        assert!(
+            rejects_records.is_empty(),
+            "{} rejects fan-out BAM must be header-only for an all-agreeing, above-min-reads \
+             fixture (nothing is rejected); got {} record(s)",
+            cmd.name(),
+            rejects_records.len()
+        );
+    }
+}
+
+/// Asserts one emitted consensus record against its fixture-determined
+/// expectation across every behaviorally relevant field: read name, exact SAM
+/// FLAG bits, the unmapped-consensus alignment invariant (no position, MAPQ 0,
+/// empty CIGAR, no mate reference/position), `SEQ`, uniform per-base qualities,
+/// the command-specific consensus depth/error tags (scalar `cD`/`cE` plus the
+/// per-base `cd` for simplex or `aD`/`bD`/`ad`/`bd` for duplex/codec), and the
+/// complete set of data-tag keys (so an added or dropped tag also fails). This
+/// keeps the CI-only fallback oracle from passing a regression in a field the
+/// value-level checks above do not name.
+fn assert_consensus_record(
+    cmd: ConsensusCmd,
+    label: &str,
+    record: &noodles::sam::alignment::RecordBuf,
+    exp: &ExpectedRecord,
+) {
+    // Read name — deterministic `<prefix>:<counter>` (the test prefix is empty).
+    let name =
+        record.name().map(|n| String::from_utf8_lossy(n.as_ref()).into_owned()).unwrap_or_default();
+    assert_eq!(name, exp.name, "{label} must carry the fixture-determined read name");
+
+    // FLAG — exact bits. Consensus reads are unmapped; duplex additionally pins
+    // the paired FIRST/LAST_SEGMENT roles. A subset check on individual fields
+    // would miss a regression that flipped pairing or the unmapped state.
+    assert_eq!(
+        u16::from(record.flags()),
+        exp.flags,
+        "{label} must carry FLAG bits {:#06x}; got {:#06x}",
+        exp.flags,
+        u16::from(record.flags())
+    );
+
+    // Alignment invariant — a consensus read is unmapped (constant across every
+    // record this test emits).
+    assert_unmapped_alignment_invariant(label, record);
+
+    // SEQ — the family/molecule's uniform sequence (every input read agrees).
+    let seq = String::from_utf8_lossy(record.sequence().as_ref()).into_owned();
+    assert_eq!(
+        seq, exp.seq,
+        "{label} must reproduce the fixture's known agreeing sequence (every input read agrees \
+         at every base, so the consensus is fully determined)"
+    );
+
+    // QUAL — one capped Phred value repeated across the whole read, since the
+    // inputs agree at every base. A regression that dropped or rescaled the
+    // consensus qualities (which SEQ-only checking cannot see) fails here.
+    let quals: Vec<u8> = record.quality_scores().as_ref().to_vec();
+    assert_eq!(
+        quals,
+        vec![exp.qual; exp.seq.len()],
+        "{label} must carry uniform Phred {} across all {} bases",
+        exp.qual,
+        exp.seq.len()
+    );
+
+    // Consensus depth/error tags — command-specific and fixture-determined.
+    assert_consensus_depth_tags(label, record, exp);
+
+    // Complete tag-key set — the value-level checks above assert a hand-picked
+    // subset; this pins the *whole* set of data tags the record carries, so a
+    // regression that adds or drops any tag (even one no assertion names) fails.
+    let got_keys = record_tag_keys(record);
+    let want_keys = {
+        let mut keys: Vec<String> =
+            expected_tag_keys(cmd).iter().map(|s| (*s).to_owned()).collect();
+        keys.sort();
+        keys
+    };
+    assert_eq!(
+        got_keys, want_keys,
+        "{label} must carry exactly the fixture-determined data tags {want_keys:?}; got {got_keys:?}"
+    );
+}
+
+/// Asserts the unmapped-consensus alignment invariant: no reference position,
+/// MAPQ 0, empty CIGAR, and no mate reference/position. Constant for every
+/// consensus record this test emits.
+fn assert_unmapped_alignment_invariant(label: &str, record: &noodles::sam::alignment::RecordBuf) {
+    assert!(
+        record.alignment_start().is_none(),
+        "{label} (unmapped consensus) must have no alignment position; got {:?}",
+        record.alignment_start()
+    );
+    assert_eq!(
+        record.mapping_quality().map_or(0, |m| m.get()),
+        0,
+        "{label} (unmapped consensus) must have MAPQ 0"
+    );
+    assert!(
+        record.cigar().as_ref().is_empty(),
+        "{label} (unmapped consensus) must have an empty CIGAR; got {:?}",
+        record.cigar()
+    );
+    assert!(
+        record.mate_reference_sequence_id().is_none(),
+        "{label} (unmapped consensus) must have no mate reference"
+    );
+    assert!(
+        record.mate_alignment_start().is_none(),
+        "{label} (unmapped consensus) must have no mate alignment position"
+    );
+}
+
+/// Asserts the fixture-determined consensus depth/error tags: the scalar total
+/// depth `cD` and zero error rate `cE`, plus either the single-strand per-base
+/// depth array `cd` (simplex) or the per-strand `aD`/`bD` scalars and `ad`/`bd`
+/// per-base arrays (duplex/codec).
+fn assert_consensus_depth_tags(
+    label: &str,
+    record: &noodles::sam::alignment::RecordBuf,
+    exp: &ExpectedRecord,
+) {
+    // `cD` is the total supporting-read depth; `cE` is the per-read error rate,
+    // which is exactly 0.0 because every input read agrees.
+    assert_eq!(
+        int_tag_of(record, SamTag::CD),
+        exp.total_depth,
+        "{label} must report total consensus depth (cD) == {}",
+        exp.total_depth
+    );
+    let cerr = float_tag_of(record, SamTag::CE);
+    assert!(
+        cerr.abs() < f32::EPSILON,
+        "{label} must report zero consensus error rate (cE) for an all-agreeing family; got {cerr}"
+    );
+
+    let base_array =
+        |depth: i64| vec![i16::try_from(depth).expect("depth fits i16"); exp.seq.len()];
+    match exp.strand_depths {
+        // Simplex: a single-strand caller carries the per-base depth array `cd`.
+        None => assert_eq!(
+            int16_array_tag_of(record, SamTag::CD_BASES),
+            base_array(exp.total_depth),
+            "{label} per-base depth array (cd) must be [{}; {}]",
+            exp.total_depth,
+            exp.seq.len()
+        ),
+        // Duplex/codec: the two single-strand consensuses carry `aD`/`bD` scalar
+        // depths and `ad`/`bd` per-base arrays.
+        Some((a, b)) => {
+            assert_eq!(
+                int_tag_of(record, SamTag::AD),
+                a,
+                "{label} must report A-strand depth (aD) == {a}"
+            );
+            assert_eq!(
+                int_tag_of(record, SamTag::BD),
+                b,
+                "{label} must report B-strand depth (bD) == {b}"
+            );
+            assert_eq!(
+                int16_array_tag_of(record, SamTag::AD_BASES),
+                base_array(a),
+                "{label} A-strand per-base depth array (ad) must be [{a}; {}]",
+                exp.seq.len()
+            );
+            assert_eq!(
+                int16_array_tag_of(record, SamTag::BD_BASES),
+                base_array(b),
+                "{label} B-strand per-base depth array (bd) must be [{b}; {}]",
+                exp.seq.len()
+            );
+        }
+    }
+}
+
+/// The sorted data-tag keys (two-character SAM tags) present on `record`.
+fn record_tag_keys(record: &noodles::sam::alignment::RecordBuf) -> Vec<String> {
+    let mut keys: Vec<String> = record
+        .data()
+        .iter()
+        .map(|(tag, _)| String::from_utf8_lossy(&<[u8; 2]>::from(tag)).into_owned())
+        .collect();
+    keys.sort();
+    keys
+}
+
+/// The complete set of data-tag keys a consensus record carries for each
+/// command's fixture, confirmed by reading the chain output back. Simplex
+/// records add the raw-UMI `RX` and the single-strand `cd`/`ce` per-base arrays;
+/// duplex and codec instead carry the matched per-strand `a*`/`b*` tags. Used to
+/// assert the *whole* tag set, not just the values the record-level checks name.
+fn expected_tag_keys(cmd: ConsensusCmd) -> &'static [&'static str] {
+    match cmd {
+        ConsensusCmd::Simplex => &["RG", "MI", "RX", "cD", "cM", "cE", "cd", "ce"],
+        // Duplex and codec emit the same 19-tag set (the codec fixture yields a
+        // fragment consensus, but with the identical per-strand tag surface).
+        ConsensusCmd::Duplex | ConsensusCmd::Codec => &[
+            "RG", "MI", "cD", "cM", "cE", "aD", "aM", "aE", "bD", "bM", "bE", "ac", "bc", "ad",
+            "bd", "ae", "be", "aq", "bq",
+        ],
+    }
+}
+
+/// Asserts the `--stats` TSV matches the *complete* fixture-determined map in
+/// [`expected_stats`]: every expected row is present with its exact value AND no
+/// unexpected row appears. Comparing the whole key set — not a subset — means a
+/// regression that adds a row (e.g. a new rejection reason), drops one, renames
+/// a key, or mis-values any of them fails the oracle rather than slipping past a
+/// hand-picked check.
+fn assert_stats_rows(cmd: ConsensusCmd, path: &Path) {
+    let tsv = std::fs::read_to_string(path).expect("read stats");
+    let rows: std::collections::BTreeMap<&str, &str> = tsv
+        .lines()
+        .skip(1) // header: `key\tvalue\tdescription`
+        .filter_map(|line| {
+            let mut cols = line.split('\t');
+            Some((cols.next()?, cols.next()?))
+        })
+        .collect();
+    let want: std::collections::BTreeMap<&str, &str> =
+        expected_stats(cmd).iter().copied().collect();
+    assert_eq!(
+        rows,
+        want,
+        "{} --stats TSV must be exactly the fixture-determined row set (a missing OR unexpected \
+         row fails); got:\n{tsv}",
+        cmd.name()
+    );
+}

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -1881,13 +1881,17 @@ fn test_duplex_ignores_unmapped_end_when_mapped_reads_present() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Chain-vs-single-threaded parity tests (R3.6 duplex cutover)
+// Chain worker-count determinism tests (R3.6 duplex cutover)
 //
-// `Duplex::execute`'s no-`--threads` single-threaded fast path is the
-// in-process parity oracle. `--threads N` on a `consensus`-feature build now
-// runs on the declarative chain builder (`ChainBuilder::add_duplex`). These
-// tests pin record/header parity between the two paths across duplex's knobs,
-// including the Task 1A overlapping-consensus single-strand fix.
+// `Duplex::execute` always runs on the declarative chain builder
+// (`ChainBuilder::add_duplex`) on a `consensus`-feature build; the legacy
+// single-threaded fast path is retired. These tests diff a no-`--threads` run
+// (the chain at a single worker) against a `--threads N` run (N workers): the
+// "single-threaded oracle" naming below now means the single-worker chain, not
+// the retired serial loop. They pin record/header parity across duplex's knobs,
+// including the Task 1A overlapping-consensus single-strand fix. Byte-parity
+// against the pre-removal serial binary lives in
+// `test_consensus_cutover_parity.rs`.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Run `duplex` with `extra` args appended to a base `-i/-o --min-reads

--- a/tests/integration/test_input_source_matrix.rs
+++ b/tests/integration/test_input_source_matrix.rs
@@ -143,7 +143,7 @@ const CONTRACTS: &[IoContract] = &[
         stdout: Required,
         output_depends_on_input: Required,
     },
-    #[cfg(feature = "simplex")]
+    #[cfg(feature = "consensus")]
     IoContract {
         command: "simplex",
         sam: Required,
@@ -151,7 +151,7 @@ const CONTRACTS: &[IoContract] = &[
         stdout: Required,
         output_depends_on_input: Required,
     },
-    #[cfg(feature = "duplex")]
+    #[cfg(feature = "consensus")]
     IoContract {
         command: "duplex",
         sam: Required,
@@ -159,7 +159,7 @@ const CONTRACTS: &[IoContract] = &[
         stdout: Required,
         output_depends_on_input: Required,
     },
-    #[cfg(feature = "codec")]
+    #[cfg(feature = "consensus")]
     IoContract {
         command: "codec",
         sam: Required,
@@ -211,7 +211,7 @@ const CONTRACTS: &[IoContract] = &[
         ),
         output_depends_on_input: NotApplicable("declares no axis this harness invokes"),
     },
-    #[cfg(feature = "duplex")]
+    #[cfg(feature = "consensus")]
     IoContract {
         command: "duplex-metrics",
         sam: Required,
@@ -219,7 +219,7 @@ const CONTRACTS: &[IoContract] = &[
         stdout: NotApplicable("`-o` names a prefix for several metrics files, not one stream"),
         output_depends_on_input: Required,
     },
-    #[cfg(feature = "simplex")]
+    #[cfg(feature = "consensus")]
     IoContract {
         command: "simplex-metrics",
         sam: Required,

--- a/tests/integration/test_simplex_command.rs
+++ b/tests/integration/test_simplex_command.rs
@@ -878,11 +878,15 @@ fn test_simplex_indel_at_overlap_boundary_still_calls_a_consensus() {
 }
 
 //////////////////////////////////////////////////////////////////////////////
-// Chain-path (`--threads`) parity tests
+// Chain-path worker-count determinism tests
 //
-// `simplex --threads N` routes through the declarative chain builder; the
-// no-`--threads` path keeps its own single-threaded fast path and is the
-// in-process parity oracle these tests diff against.
+// `simplex` always routes through the declarative chain builder (the legacy
+// single-threaded fast path is retired on a `consensus` build). These tests
+// diff a no-`--threads` run (the chain at a single worker) against a
+// `--threads N` run (the chain at N workers): the "non-chain path" / "oracle"
+// naming below now means the single-worker chain, not the retired serial loop.
+// Byte-parity against the pre-removal serial binary lives in
+// `test_consensus_cutover_parity.rs`.
 //////////////////////////////////////////////////////////////////////////////
 
 /// Read a BAM's records back as decoded `RecordBuf`s, for record-for-record


### PR DESCRIPTION
## What

Retire the legacy single-threaded execution paths in the `simplex`, `duplex`, and `codec` commands so the declarative chain builder is the **only** execution path for all three, completing the per-command legacy-path retirement for the consensus-calling trio. `execute()` keeps its reader-free pre-flight validation and then always dispatches to `execute_chain`, with or without `--threads`.

## Why these three needed a feature change (the crux)

Unlike the other C4 commands, the consensus trio's legacy paths were gated behind `#[cfg(not(feature = "consensus"))]`. The chain's consensus stages (`add_simplex`/`add_duplex`/`add_codec`) are gated all-or-nothing on the `consensus` umbrella feature, while the commands used to gate individually on `simplex`/`duplex`/`codec`. That let a reduced `--features simplex`-alone build compile the command without the chain machinery, so it needed a serial fallback there — code that was compiled and tested by **zero** CI jobs.

This PR collapses the three top-level features into a single `consensus` feature, so the commands are now all-present-or-all-absent, exactly matching the chain layer's all-or-nothing gating. That makes the serial fallback genuinely dead code — and deletes it (net −1200 lines).

> [!WARNING]
> **Breaking change (crate feature set only — no runtime behavior change).** Building the `fgumi` crate with `--features simplex`, `--features duplex`, or `--features codec` *alone* is no longer supported; use `--features consensus` (the default). The `fgumi-consensus` subcrate keeps its own granular `simplex`/`duplex`/`codec` features unchanged.

## Changes

- **`Cargo.toml`:** remove the individual `simplex`/`duplex`/`codec` features; `consensus = ["fgumi-consensus/simplex", "fgumi-consensus/duplex", "fgumi-consensus/codec"]`. `default`/`simulate` still pull `consensus`.
- **`commands/{simplex,duplex,codec}.rs`:** delete the legacy serial / `execute_threads_mode` paths, their dead batch types (`{Simplex,Duplex,Codec}ProcessedBatch`, `Collected*Metrics`), `recover_or_propagate_codec_error`, and the tests tied to the deleted types. Every individual-feature `cfg` across the crate is replaced with `feature = "consensus"`.
- **`pipeline/chains/{validate,builder}.rs`:** the `#[cfg(not(feature = "consensus"))]` stubs are left intact — they keep `pipeline::chains` compiling under `--no-default-features`.

## Parity analysis (done before deleting)

Every diagnostic the retired serial tail emitted is already produced by the chain (`ChainBuilder::add_{simplex,duplex,codec}` + the consensus finalize hooks): the `Starting …` banner + Input/Output lines, the `OperationTimer`, streaming progress, overlapping stats, the `--stats` TSV, and the summary (the chain logs `Total MI groups processed` where the serial tail logged `Total records processed`). No chain file needed a behavior change.

## Tests

- **`tests/integration/test_consensus_cutover_parity.rs`** — pins the no-`--threads` chain output against the frozen pre-removal serial baseline binary via `FGUMI_BASELINE_BIN` (records byte-identical modulo `@PG`, plus the `--stats` TSV) across all three commands with and without `--stats`, and asserts the chain-only `Total MI groups processed` summary (the RED→GREEN cutover discriminator). When `FGUMI_BASELINE_BIN` is unset (default CI), the self-consistency oracle now asserts **real content** — the exact consensus record count per command (simplex 3, duplex 4, codec 1) and each consensus record's `SEQ` against the fixtures' known agreeing sequences — not merely non-emptiness.
- **`add_*` option-mapping completeness** — the previously-inline options mappings are extracted into named functions (`simplex_consensus_options`, `duplex_consensus_tuning`, `codec_consensus_options`) that `add_simplex`/`add_duplex`/`add_codec` now call, each with a unit test (mirroring the existing `to_*_options_carries_every_tuning_flag`) asserting every tuning flag survives the mapping. This restores an independent oracle for the mapping now that both sides of the `*_chain_matches_single_threaded` tests route through it.
- Existing determinism tests retained as worker-count-invariance checks.

Full gate green: `cargo check` in all three feature configs (default, `--all-features`, `--no-default-features`), `ci-fmt`/`ci-lint`/`ci-doc`, and `ci-test` (9956 passed / 31 skipped) both with and without `FGUMI_BASELINE_BIN` set proving byte-parity. Part of the per-command R6-0 legacy-path retirements; no user-facing behavior change (no-`--threads` now runs the chain at a single worker).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes are none and are pinned by parity, consensus-record, statistics, filtering, reject, and worker-count tests; `unsafe` changes are none and no `CLAUDE.md` allowlist update applies; memory bounds, queue capacity, and thread/backpressure policy changes are none.

- Unified `simplex`, `duplex`, and `codec` execution on the declarative consensus chain.
- Replaced top-level command features with the `consensus` umbrella feature.
- Removed legacy serial and unified-pipeline paths.
- Added option-mapping and integration tests for output, statistics, consensus records, filtering, rejects, and worker-count parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->