### PR TITLE
refactor(copy-umi): retire the legacy single-threaded path; the chain is the only path

### DIFF
--- a/src/lib/commands/copy_umi.rs
+++ b/src/lib/commands/copy_umi.rs
@@ -25,13 +25,11 @@ use log::{info, warn};
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    add_pg_record, ensure_hd_record, reject_output_collisions,
+    reject_output_collisions,
 };
-use crate::logging::OperationTimer;
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::sam::SamTag;
 use crate::umi::read_name::normalize_read_name_umi;
-use fgumi_bam_io::{ProgressTracker, create_raw_bam_reader_with_opts, create_raw_bam_writer};
 use fgumi_raw_bam::{RawRecord, update_string_tag};
 
 /// Copy the UMI from a BAM read name into the RX tag.
@@ -139,8 +137,8 @@ pub(crate) struct RecordOutcome {
 
 /// Aggregated run counters, one instance per pipeline slot.
 ///
-/// Shared by the serial oracle and the chain finalize hooks, so the two paths
-/// reduce the same counters (`pub(crate)` fields for the chain step module).
+/// Reduced by the chain finalize hooks (`pub(crate)` fields for the chain step
+/// module).
 #[derive(Debug, Clone, Default)]
 pub(crate) struct CollectedCopyUmiMetrics {
     /// Records processed (all successful; a failure aborts the run).
@@ -282,9 +280,8 @@ pub(crate) fn validate_field_delimiter(c: char) -> Result<u8> {
         .with_context(|| format!("--field-delimiter must be a single ASCII character, got '{c}'"))
 }
 
-/// Write the single-row `--metrics` TSV from the reduced counters. Shared by the
-/// serial oracle and the chain's success-only metrics finalize hook so the two
-/// paths cannot drift.
+/// Write the single-row `--metrics` TSV from the reduced counters. Called by
+/// the chain's success-only metrics finalize hook.
 pub(crate) fn write_copy_umi_metrics(path: &Path, totals: &CollectedCopyUmiMetrics) -> Result<()> {
     let row = CopyUmiMetric {
         total_records: totals.total_records,
@@ -297,9 +294,8 @@ pub(crate) fn write_copy_umi_metrics(path: &Path, totals: &CollectedCopyUmiMetri
     Ok(())
 }
 
-/// Emit the overwrite warning (when any) and the `=== Summary ===` block. Shared
-/// by the serial oracle and the chain's summary finalize hook so the log content
-/// is byte-identical across the two paths.
+/// Emit the overwrite warning (when any) and the `=== Summary ===` block.
+/// Called by the chain's summary finalize hook.
 pub(crate) fn warn_and_log_copy_umi_summary(totals: &CollectedCopyUmiMetrics) {
     if totals.rx_overwritten > 0 {
         warn!("overwrote a pre-existing RX tag on {} record(s)", totals.rx_overwritten);
@@ -402,8 +398,8 @@ impl CopyUmiOptions {
 impl Command for CopyUmi {
     fn execute(&self, command_line: &str) -> Result<()> {
         self.io.validate()?;
-        // Fail fast on a non-ASCII delimiter before any reader opens; each path
-        // (serial oracle / chain) re-derives the validated byte itself.
+        // Fail fast on a non-ASCII delimiter before any reader opens; the chain's
+        // own `CopyUmiOptions::process_captures` re-derives the validated byte too.
         validate_field_delimiter(self.field_delimiter)?;
 
         // Reject two writers to one destination, and a write target aliasing input.
@@ -414,148 +410,16 @@ impl Command for CopyUmi {
         reject_output_collisions(&outputs)?;
         self.reject_write_aliasing_input()?;
 
-        if self.threading.threads.is_some() {
-            return self.execute_chain(command_line);
-        }
-
-        // No-`--threads` serial path: the in-process parity oracle.
-        let timer = OperationTimer::new("Copying UMIs from read names");
-        info!("Starting copy-umi");
-        info!("Input: {}", self.io.input.display());
-        info!("Output: {}", self.io.output.display());
-
-        // Without this, a scheduler/pipeline flag set here (e.g.
-        // `--deadlock-recover`) is silently ignored on the serial path with no
-        // diagnostic at all. This is NOT `common::warn_unwired_pipeline_flags`:
-        // that helper is chain-specific (its wording says "the chain engine ...",
-        // and it deliberately skips `--max-memory`/`--memory-reserve`/
-        // `--memory-per-thread` because the chain DOES honor them) — on this
-        // serial path there is no chain engine at all, so those queue-memory
-        // flags are inert here too and must be warned, with wording that is true
-        // for the single-threaded context.
-        self.warn_unwired_flags_on_serial_path();
-
-        let totals = self.run_single_threaded(command_line)?;
-        warn_and_log_copy_umi_summary(&totals);
-        if let Some(path) = &self.metrics {
-            write_copy_umi_metrics(path, &totals)?;
-        }
-        timer.log_completion(totals.total_records);
-        Ok(())
+        self.execute_chain(command_line)
     }
 }
 
 impl CopyUmi {
-    /// Warn about scheduler/pipeline-queue flags that have no effect on THIS
-    /// serial (no-`--threads`) path.
-    ///
-    /// Deliberately NOT `common::warn_unwired_pipeline_flags`: that helper is
-    /// chain-specific -- its wording ("the chain engine ...", "the typed-step
-    /// pipeline") describes a running chain, and it deliberately skips
-    /// `--max-memory`/`--memory-reserve`/`--memory-per-thread` because the chain
-    /// DOES honor them (they seed `PipelineConfig::queue_memory_total`). On this
-    /// serial path there is no chain and no queue to budget, so reusing that
-    /// helper would both assert a false rationale and fail to warn about the
-    /// queue-memory flags, which are genuinely inert here. Each flag is warned
-    /// only when set away from its default, mirroring how the chain-path helper
-    /// gates its own warnings.
-    fn warn_unwired_flags_on_serial_path(&self) {
-        let requested_scheduler = self.scheduler_opts.strategy();
-        if requested_scheduler != crate::unified_pipeline::scheduler::SchedulerStrategy::default() {
-            warn!(
-                "--scheduler has no effect on the single-threaded path: the serial \
-                 read -> copy-umi -> write loop does not use a pluggable scheduler \
-                 strategy, so the requested strategy ({requested_scheduler:?}) is \
-                 ignored (run with --threads to use the pipeline)"
-            );
-        }
-        if self.scheduler_opts.deadlock_recover_enabled() {
-            warn!(
-                "--deadlock-recover has no effect on the single-threaded path: there \
-                 is no pipeline to deadlock-detect or recover on, only a serial \
-                 read -> copy-umi -> write loop (run with --threads to use the \
-                 pipeline)"
-            );
-        }
-        let default_queue_memory = QueueMemoryOptions::default();
-        if self.queue_memory.max_memory != default_queue_memory.max_memory
-            || self.queue_memory.memory_reserve != default_queue_memory.memory_reserve
-            || self.queue_memory.memory_per_thread != default_queue_memory.memory_per_thread
-        {
-            warn!(
-                "--max-memory/--memory-reserve/--memory-per-thread have no effect on \
-                 the single-threaded path: there are no pipeline queues to budget on \
-                 a serial read -> copy-umi -> write loop (run with --threads to use \
-                 the pipeline)"
-            );
-        }
-    }
-
-    /// Serial no-`--threads` path: a read → copy-umi → write loop, and the
-    /// in-process parity oracle for the chain path. Uses `pipeline_reader_opts()`
-    /// so the CRC-check policy matches the chain, and `ensure_hd_record` +
-    /// `add_pg_record` so the header matches. A bad/empty UMI (or an existing RX
-    /// under `--fail-if-tag-present`) aborts the run via `?`, naming the read name.
-    ///
-    /// Parity: chain and oracle produce identical output on well-formed BAM, and
-    /// BOTH reject a framing-consistent-but-malformed record (`l_read_name` past
-    /// the record end) with a clean `InvalidData` error. This serial loop
-    /// validates each record via `validate_record_for_decode` before touching
-    /// read-name bytes, exactly as the chain path does through `DecodeRecords` —
-    /// without that guard the loop would panic in `read_name` on such a record,
-    /// a regression from the pre-cutover pipeline, which decoded and thus
-    /// validated.
-    fn run_single_threaded(&self, command_line: &str) -> Result<CollectedCopyUmiMetrics> {
-        let field_delimiter = validate_field_delimiter(self.field_delimiter)?;
-        let (mut reader, header) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
-        let header = ensure_hd_record(header)?;
-        let header = add_pg_record(header, command_line)?;
-        let mut writer =
-            create_raw_bam_writer(&self.io.output, &header, 1, self.compression.compression_level)?;
-
-        let mut totals = CollectedCopyUmiMetrics::default();
-        let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
-        let mut record = RawRecord::new();
-        while reader.read_record(&mut record)? != 0 {
-            // Validate record framing (record length + l_read_name bound) before
-            // touching read-name bytes, exactly as the `--threads` chain path does
-            // via `DecodeRecords`. Without this, a framing-consistent-but-malformed
-            // record (l_read_name past the record end) would panic here in
-            // `read_name` instead of failing with a clean error — a regression from
-            // the pre-cutover pipeline, which validated. Both paths now reject a
-            // malformed record with the same InvalidData error.
-            crate::pipeline::steps::parse::decode::validate_record_for_decode(record.as_ref())?;
-            let outcome = copy_umi_into_record(
-                &mut record,
-                field_delimiter,
-                self.reverse_complement_r_umis,
-                self.remove_umi,
-                self.fail_if_tag_present,
-            )?;
-            totals.total_records += 1;
-            if outcome.overwrote_rx {
-                totals.rx_overwritten += 1;
-            }
-            if outcome.trimmed_name {
-                totals.names_trimmed += 1;
-            }
-            writer.write_raw_record(record.as_ref())?;
-            progress.log_if_needed(1);
-        }
-        progress.log_final();
-        // Flush before returning so any write error surfaces here, not on drop.
-        writer.finish()?;
-        Ok(totals)
-    }
-
-    /// Run the copy-umi stage on the declarative chain builder (the `--threads N`
-    /// path). The no-`--threads` `CopyUmi::run_single_threaded` loop is the
-    /// in-process parity oracle. `add_copy_umi` re-emits the timer/banner/threading
-    /// logs and opens its own source, so — like dedup/group — this method only
-    /// builds and runs the chain. Copy-umi's `execute()` never emitted
-    /// `log_effective_check_crc`, so this does NOT call it either (adding it would
-    /// make the `--threads` path log a line the serial path never does).
+    /// Run the copy-umi stage on the declarative chain builder. `add_copy_umi`
+    /// re-emits the timer/banner/threading logs and opens its own source, so —
+    /// like dedup/group — this method only builds and runs the chain. Copy-umi's
+    /// `execute()` never emitted `log_effective_check_crc`, and neither does
+    /// `add_copy_umi`.
     fn execute_chain(&self, command_line: &str) -> Result<()> {
         use crate::pipeline::chains::{
             ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -4273,8 +4273,8 @@ impl<'a> ChainBuilder<'a> {
     /// Mirrors filter's single-no-rejects shape (no template grouping, no
     /// rejects, no sort-order guard). The header is `self.header` — already
     /// `ensure_hd`'d + `add_pg`'d in `ChainBuilder::new` — and is not reassigned
-    /// (a pure transform leaves the header shape unchanged). The no-`--threads`
-    /// serial path in `CopyUmi::execute` is the in-process parity oracle.
+    /// (a pure transform leaves the header shape unchanged). `CopyUmi::execute`
+    /// always runs through this chain — there is no other execution path.
     fn add_copy_umi(&mut self, position: StagePosition) -> Result<()> {
         use crate::commands::common::warn_unwired_pipeline_flags;
         use crate::logging::OperationTimer;
@@ -4340,16 +4340,15 @@ impl<'a> ChainBuilder<'a> {
         self.current_tail = Some(self.pipeline.append_step(step, tail));
 
         // Register the finalize hooks — BOTH on `finalize_on_success` (not the
-        // always-run `finalize`): the serial oracle `?`-aborts before its summary
-        // on a fail-fast error, so an always-run summary hook would log a partial
-        // summary the serial path never logs. The chain-level
-        // StageTimingFinalizeHook is inserted at index 0 by `build()`.
+        // always-run `finalize`): a bad record aborts the run before the pipeline
+        // drains, so an always-run summary hook would log a partial summary on a
+        // fail-fast error. The chain-level StageTimingFinalizeHook is inserted at
+        // index 0 by `build()`.
         //
         // Order matters: the SUMMARY hook is registered BEFORE the metrics hook so
-        // it runs first, matching the serial path (`warn_and_log_copy_umi_summary`
-        // then `write_copy_umi_metrics`). This keeps log parity on a `--metrics`
-        // write failure — the summary + completion-timer are already logged on both
-        // paths before the failing write, rather than being swallowed on the chain.
+        // it runs first (`warn_and_log_copy_umi_summary` then
+        // `write_copy_umi_metrics`) — the summary + completion-timer are logged
+        // before a `--metrics` write failure, rather than being swallowed.
         self.finalize_on_success
             .push(Box::new(CopyUmiFinalizeHook { accumulators: Arc::clone(&accumulators), timer }));
         if let Some(metrics_path) = copy_umi.metrics.clone() {
@@ -5194,6 +5193,43 @@ mod tests {
         spec.stage_opts.dedup = Some(dedup);
         let builder = chain_builder_for_stages(&spec);
         assert_eq!(builder.bam_group_key_config().umi_tag, expected_umi_tag);
+    }
+
+    /// `add_copy_umi` refuses an intermediate position: copy-umi is a terminal,
+    /// standalone per-record transform (`CopyUmi::execute` only ever composes it
+    /// as the sole, last stage), so composing it before another stage must bail
+    /// rather than build an unsupported chain. Exercises the guard directly — it
+    /// precedes the options/`current_tail` reads — pinning a defensive branch the
+    /// CLI never reaches.
+    #[test]
+    fn add_copy_umi_rejects_intermediate_position() {
+        let spec = empty_spec(vec![Stage::CopyUmi]);
+        let mut builder = chain_builder_for_stages(&spec);
+        let err = builder
+            .add_copy_umi(StagePosition::Intermediate)
+            .expect_err("intermediate copy-umi must be rejected");
+        assert!(
+            err.to_string().contains("intermediate copy-umi not implemented"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// `add_copy_umi` refuses a non-record-stream upstream tail: like filter/clip
+    /// it consumes a `DecodedRecordBatch`, so a tail emitting grouped templates
+    /// must bail rather than mis-wire the step onto an incompatible input.
+    /// Exercises the guard directly by seeding a `BamTemplateBatch` tail.
+    #[test]
+    fn add_copy_umi_rejects_non_record_stream_tail() {
+        let spec = empty_spec(vec![Stage::CopyUmi]);
+        let mut builder = chain_builder_for_stages(&spec);
+        builder.chain_tail_kind = ChainTailKind::BamTemplateBatch;
+        let err = builder
+            .add_copy_umi(StagePosition::Terminal)
+            .expect_err("copy-umi after a grouped-template tail must be rejected");
+        assert!(
+            err.to_string().contains("requires a record-stream input"),
+            "unexpected error: {err}"
+        );
     }
 
     /// Pin the per-phase thread resolution contract shared by the standalone and

--- a/src/lib/pipeline/chains/commands/copy_umi.rs
+++ b/src/lib/pipeline/chains/commands/copy_umi.rs
@@ -40,10 +40,9 @@ fn reduce(accumulators: &PerThreadAccumulator<CollectedCopyUmiMetrics>) -> Colle
 /// Success-only finalize hook: emits the overwrite warning + `=== Summary ===`
 /// block (via the shared [`warn_and_log_copy_umi_summary`]) and logs completion.
 ///
-/// Registered on `finalize_on_success` (NOT the always-run `finalize`): the
-/// serial oracle `?`-returns on the first bad record and never reaches its
-/// summary, so an always-run summary would log a partial summary on a fail-fast
-/// abort the serial path never logs.
+/// Registered on `finalize_on_success` (NOT the always-run `finalize`): a bad
+/// record aborts the run via `map_err` before the pipeline drains, so an
+/// always-run summary would log a partial summary on a fail-fast abort.
 pub(crate) struct CopyUmiFinalizeHook {
     pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedCopyUmiMetrics>>,
     pub(crate) timer: OperationTimer,
@@ -84,10 +83,10 @@ fn record_batch_metrics(
     names_trimmed: u64,
 ) {
     // Cross-thread heartbeat: workers run this concurrently, so the milestone
-    // counter is a shared `AtomicU64` rather than `fgumi_bam_io::ProgressTracker`
-    // (which the single-threaded serial oracle uses but is not built for
-    // concurrent workers). The finalize hooks read the record total from the
-    // accumulator, not from this counter — it drives only the periodic log.
+    // counter is a shared `AtomicU64` rather than `fgumi_bam_io::ProgressTracker`,
+    // which is built for a single reader thread, not concurrent workers. The
+    // finalize hooks read the record total from the accumulator, not from this
+    // counter — it drives only the periodic log.
     let prev = captures.progress.fetch_add(total_records, Ordering::Relaxed);
     if (prev + total_records) / 1_000_000 > prev / 1_000_000 {
         info!("Processed {} records", prev + total_records);
@@ -103,8 +102,12 @@ fn record_batch_metrics(
 ///
 /// Parallel, `ByItemOrdinal`. Every record is kept (no filtering, no rejects);
 /// the read-name UMI is copied into `RX` in place. A bad/empty UMI (or an
-/// existing RX under `--fail-if-tag-present`) aborts the run via
-/// `map_err(io::Error::other)?`, matching the pre-cutover pipeline `process_fn`.
+/// existing RX under `--fail-if-tag-present`) aborts the run, matching the
+/// pre-cutover pipeline `process_fn`. The error crosses an `io::Error`
+/// boundary (`map_err`) with its full `anyhow` cause chain flattened into the
+/// message via `{e:#}` first, so the pipeline's step-failure reconstruction
+/// (which reads only the `io::Error`'s top-level Display) still surfaces the
+/// inner cause, not just the outer "extracting UMI from read name" context.
 ///
 /// Returns the concrete `ProcessOrdered` (not `impl Step`), because the closure
 /// type embeds in opaque-return position and cannot name itself — the same
@@ -139,7 +142,14 @@ pub(crate) fn build_copy_umi_process_step(
                     captures.remove_umi,
                     captures.fail_if_tag_present,
                 )
-                .map_err(io::Error::other)?;
+                // `{e:#}` (anyhow's alternate Display) joins the full cause chain into
+                // one string before crossing the `io::Error` boundary: `io::Error`'s own
+                // Display only ever shows its wrapped error's top-level Display, so a
+                // bare `io::Error::other(e)` would silently drop the inner cause (e.g.
+                // "Invalid UMI ... illegal character ...") once the pipeline reconstructs
+                // a step failure from this `io::Error` — exactly the diagnostic the
+                // no-`--threads` path used to show before the chain became the only path.
+                .map_err(|e| io::Error::other(format!("{e:#}")))?;
                 if outcome.overwrote_rx {
                     rx_overwritten += 1;
                 }

--- a/tests/integration/helpers/copy_umi_fixtures.rs
+++ b/tests/integration/helpers/copy_umi_fixtures.rs
@@ -1,0 +1,86 @@
+//! Shared fixtures for the `copy-umi` command's integration tests
+//! (`test_copy_umi_command.rs`, `test_copy_umi_cutover_parity.rs`).
+
+use std::path::Path;
+
+use fgumi_lib::commands::copy_umi::CopyUmiMetric;
+use fgumi_raw_bam::{RawRecord, SamBuilder};
+
+use super::bam_generator::{create_minimal_header, transcode_bam_to_sam, write_bam};
+
+/// A minimal mapped record carrying the given read name (sequence/quals are fixed
+/// filler — `copy-umi` never touches them).
+pub fn record_named(name: &str) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(b"ACGT")
+        .qualities(&[30; 4])
+        .flags(0)
+        .ref_id(0)
+        .pos(99)
+        .mapq(60)
+        .cigar_ops(&[4 << 4]);
+    b.build()
+}
+
+/// As [`record_named`], but pre-populated with an `RX` tag to exercise the
+/// overwrite / `--fail-if-tag-present` policy.
+pub fn record_named_with_rx(name: &str, rx: &str) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(b"ACGT")
+        .qualities(&[30; 4])
+        .flags(0)
+        .ref_id(0)
+        .pos(99)
+        .mapq(60)
+        .cigar_ops(&[4 << 4])
+        .add_string_tag(fgumi_lib::sam::SamTag::RX, rx.as_bytes());
+    b.build()
+}
+
+/// Write `records` to a BAM in `dir` and return its path.
+pub fn write_input(dir: &Path, records: &[RawRecord]) -> std::path::PathBuf {
+    let path = dir.join("in.bam");
+    let header = create_minimal_header("chr1", 10_000);
+    write_bam(&path, &header, records);
+    path
+}
+
+/// Read (`name`, `RX`) for every record in a BAM by transcoding to SAM text.
+pub fn read_name_and_rx(dir: &Path, bam: &Path) -> Vec<(String, Option<String>)> {
+    let sam = dir.join("read_name_and_rx.sam");
+    transcode_bam_to_sam(bam, &sam);
+    std::fs::read_to_string(&sam)
+        .expect("read sam")
+        .lines()
+        .filter(|l| !l.starts_with('@'))
+        .map(|line| {
+            let fields: Vec<&str> = line.split('\t').collect();
+            let name = fields[0].to_string();
+            let rx = fields.iter().find_map(|f| f.strip_prefix("RX:Z:").map(str::to_string));
+            (name, rx)
+        })
+        .collect()
+}
+
+/// Reads the single-row `--metrics` TSV `copy-umi` writes, as a typed
+/// [`CopyUmiMetric`] (via `fgumi_metrics::read_metrics_auto`), rather than a
+/// stringly `HashMap`: a typed reader can't silently accept a column rename or
+/// a reordered header row the way a hand-parsed `header[i] -> value[i]` zip can.
+///
+/// # Panics
+/// Panics if the file cannot be read/parsed as a `CopyUmiMetric` TSV, or does
+/// not contain exactly one data row (`copy-umi --metrics` always writes one).
+pub fn read_copy_umi_metrics(path: &Path) -> CopyUmiMetric {
+    let mut rows = fgumi_metrics::read_metrics_auto::<_, CopyUmiMetric>(path)
+        .unwrap_or_else(|e| panic!("read copy-umi metrics {}: {e}", path.display()));
+    assert_eq!(
+        rows.len(),
+        1,
+        "copy-umi --metrics TSV at {} must contain exactly one data row, got {}",
+        path.display(),
+        rows.len()
+    );
+    rows.remove(0)
+}

--- a/tests/integration/helpers/mod.rs
+++ b/tests/integration/helpers/mod.rs
@@ -11,6 +11,7 @@ pub mod aligner;
 pub mod assertions;
 pub mod bam_generator;
 pub mod cli;
+pub mod copy_umi_fixtures;
 pub mod cutover;
 pub mod fastq;
 
@@ -18,6 +19,7 @@ pub use aligner::*;
 pub use assertions::*;
 pub use bam_generator::*;
 pub use cli::*;
+pub use copy_umi_fixtures::*;
 pub use cutover::*;
 pub use fastq::*;
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -26,6 +26,7 @@ mod test_compare_mutation;
 mod test_consensus_cutover_parity;
 mod test_consensus_downsampling;
 mod test_copy_umi_command;
+mod test_copy_umi_cutover_parity;
 mod test_correct_command;
 mod test_correct_cutover_parity;
 mod test_dedup_command;

--- a/tests/integration/test_copy_umi_command.rs
+++ b/tests/integration/test_copy_umi_command.rs
@@ -11,51 +11,13 @@ use fgumi_lib::commands::command::Command;
 use fgumi_lib::commands::copy_umi::CopyUmi;
 use fgumi_raw_bam::{RawRecord, SamBuilder};
 use rstest::rstest;
-use std::collections::HashMap;
 use std::path::Path;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, transcode_bam_to_sam, write_bam};
-use crate::helpers::cli::run_and_capture_logs;
-
-/// A minimal mapped record carrying the given read name (sequence/quals are fixed
-/// filler — `copy-umi` never touches them).
-fn record_named(name: &str) -> RawRecord {
-    let mut b = SamBuilder::new();
-    b.read_name(name.as_bytes())
-        .sequence(b"ACGT")
-        .qualities(&[30; 4])
-        .flags(0)
-        .ref_id(0)
-        .pos(99)
-        .mapq(60)
-        .cigar_ops(&[4 << 4]);
-    b.build()
-}
-
-/// As [`record_named`], but pre-populated with an `RX` tag to exercise the
-/// overwrite / fail-if-present policy.
-fn record_named_with_rx(name: &str, rx: &str) -> RawRecord {
-    let mut b = SamBuilder::new();
-    b.read_name(name.as_bytes())
-        .sequence(b"ACGT")
-        .qualities(&[30; 4])
-        .flags(0)
-        .ref_id(0)
-        .pos(99)
-        .mapq(60)
-        .cigar_ops(&[4 << 4])
-        .add_string_tag(fgumi_lib::sam::SamTag::RX, rx.as_bytes());
-    b.build()
-}
-
-/// Write `records` to a BAM in `dir` and return its path.
-fn write_input(dir: &Path, records: &[RawRecord]) -> std::path::PathBuf {
-    let path = dir.join("in.bam");
-    let header = create_minimal_header("chr1", 10_000);
-    write_bam(&path, &header, records);
-    path
-}
+use crate::helpers::{
+    read_copy_umi_metrics, read_name_and_rx, record_named, record_named_with_rx, write_input,
+};
 
 /// Parse + run `copy-umi -i input -o output [extra...]`.
 fn run_copy_umi(input: &Path, output: &Path, extra: &[&str]) -> anyhow::Result<()> {
@@ -69,23 +31,6 @@ fn run_copy_umi(input: &Path, output: &Path, extra: &[&str]) -> anyhow::Result<(
     args.extend(extra.iter().map(|s| (*s).to_string()));
     let cmd = CopyUmi::try_parse_from(args).expect("failed to parse copy-umi args");
     cmd.execute("copy-umi test")
-}
-
-/// Read (`name`, `RX`) for every record in a BAM by transcoding to SAM text.
-fn read_name_and_rx(dir: &Path, bam: &Path) -> Vec<(String, Option<String>)> {
-    let sam = dir.join("out.sam");
-    transcode_bam_to_sam(bam, &sam);
-    std::fs::read_to_string(&sam)
-        .expect("read sam")
-        .lines()
-        .filter(|l| !l.starts_with('@'))
-        .map(|line| {
-            let fields: Vec<&str> = line.split('\t').collect();
-            let name = fields[0].to_string();
-            let rx = fields.iter().find_map(|f| f.strip_prefix("RX:Z:").map(str::to_string));
-            (name, rx)
-        })
-        .collect()
 }
 
 // ============================================================================
@@ -168,12 +113,12 @@ fn overwrites_existing_rx_by_default() {
     assert_eq!(rows[0].1.as_deref(), Some("ACGT"), "stale RX should be replaced");
 }
 
-/// `--fail-if-tag-present` must abort on both the serial oracle and the
-/// `--threads` chain path — proving the flag is wired on the parallel path too,
-/// not just the serial one.
+/// `--fail-if-tag-present` must abort both with `--threads` unset (default
+/// thread count) and with `--threads N` set — both route through the same
+/// chain, so this proves the flag stays wired regardless of thread count.
 #[rstest]
-#[case::serial(&[][..])]
-#[case::chain(&["--threads", "2"][..])]
+#[case::default_threads(&[][..])]
+#[case::explicit_threads(&["--threads", "2"][..])]
 fn fail_if_tag_present_errors_on_existing_rx(#[case] thread_flags: &[&str]) {
     let dir = TempDir::new().unwrap();
     let input = write_input(dir.path(), &[record_named_with_rx("blah:ACGT", "STALEVAL")]);
@@ -189,26 +134,49 @@ fn fail_if_tag_present_errors_on_existing_rx(#[case] thread_flags: &[&str]) {
 }
 
 // ============================================================================
-// Fail-fast on malformed read names — each error must name its actual cause,
-// so an unrelated failure cannot pass the test.
+// Fail-fast on malformed read names. Each case pins every substring the error
+// must contain: the single-level errors (raised directly in
+// `copy_umi_into_record` with no `.with_context()` wrapper) are one message;
+// the two-level errors (a `normalize_read_name_umi` failure wrapped in
+// "extracting UMI from read name" context) must show BOTH that outer context
+// AND the inner cause. The process step's `.map_err` joins the full `anyhow`
+// cause chain into the `io::Error` it hands the pipeline (via `{e:#}`) before
+// the pipeline reconstructs a step failure from that `io::Error`'s `Display`,
+// so the inner cause survives the chain the same as it did pre-cutover.
 // ============================================================================
 
 #[rstest]
-#[case::single_field("NAME", "no ':'-delimited UMI field")]
-#[case::empty_last_field("1:2:3:", "empty UMI field")]
-#[case::illegal_char("NAME:CCKC", "illegal character")]
-#[case::coordinate_not_a_umi("inst:1:FC:1:1101:5:7:10799", "illegal character")]
-#[case::empty_after_normalization("blah:r", "normalizes to an empty UMI")]
-fn errors_on_malformed_name(#[case] name: &str, #[case] expected_msg: &str) {
+#[case::single_field("NAME", &["no ':'-delimited UMI field"])]
+#[case::empty_last_field("1:2:3:", &["empty UMI field"])]
+#[case::illegal_char(
+    "NAME:CCKC",
+    &["extracting UMI from read name 'NAME:CCKC'", "Invalid UMI", "illegal character"]
+)]
+#[case::coordinate_not_a_umi(
+    "inst:1:FC:1:1101:5:7:10799",
+    &[
+        "extracting UMI from read name 'inst:1:FC:1:1101:5:7:10799'",
+        "Invalid UMI",
+        "illegal character",
+    ]
+)]
+#[case::empty_after_normalization(
+    "blah:r",
+    &["extracting UMI from read name 'blah:r'", "normalizes to an empty UMI"]
+)]
+fn errors_on_malformed_name(#[case] name: &str, #[case] expected_substrings: &[&str]) {
     let dir = TempDir::new().unwrap();
     let input = write_input(dir.path(), &[record_named(name)]);
     let output = dir.path().join("out.bam");
     let err =
         run_copy_umi(&input, &output, &[]).expect_err(&format!("expected failure for '{name}'"));
-    assert!(
-        format!("{err:#}").contains(expected_msg),
-        "error for '{name}' should contain '{expected_msg}', got: {err:#}"
-    );
+    let msg = format!("{err:#}");
+    for expected in expected_substrings {
+        assert!(
+            msg.contains(expected),
+            "error for '{name}' should contain '{expected}', got: {msg}"
+        );
+    }
 }
 
 #[test]
@@ -251,23 +219,6 @@ fn idempotent_without_trim() {
 // Metrics
 // ============================================================================
 
-/// Read the single metrics row as a `column -> value` map.
-fn read_metrics_row(path: &Path) -> HashMap<String, String> {
-    let text = std::fs::read_to_string(path).expect("read metrics");
-    let mut lines = text.lines();
-    let header: Vec<String> =
-        lines.next().expect("header line").split('\t').map(str::to_string).collect();
-    let values: Vec<String> =
-        lines.next().expect("value line").split('\t').map(str::to_string).collect();
-    assert_eq!(
-        header.len(),
-        values.len(),
-        "metrics header and value rows must have equal column counts"
-    );
-    assert!(lines.next().is_none(), "metrics file must contain exactly one data row");
-    header.into_iter().zip(values).collect()
-}
-
 #[test]
 fn writes_metrics_row() {
     let dir = TempDir::new().unwrap();
@@ -284,11 +235,11 @@ fn writes_metrics_row() {
     run_copy_umi(&input, &output, &["-M", &metrics.display().to_string()])
         .expect("copy-umi failed");
 
-    let row = read_metrics_row(&metrics);
-    assert_eq!(row["total_records"], "3");
-    assert_eq!(row["rx_written"], "3");
-    assert_eq!(row["rx_overwritten"], "1");
-    assert_eq!(row["names_trimmed"], "0");
+    let row = read_copy_umi_metrics(&metrics);
+    assert_eq!(row.total_records, 3);
+    assert_eq!(row.rx_written, 3);
+    assert_eq!(row.rx_overwritten, 1);
+    assert_eq!(row.names_trimmed, 0);
 }
 
 #[test]
@@ -300,9 +251,9 @@ fn metrics_count_trimmed_names_under_remove_umi() {
     run_copy_umi(&input, &output, &["--remove-umi", "-M", &metrics.display().to_string()])
         .expect("copy-umi failed");
 
-    let row = read_metrics_row(&metrics);
-    assert_eq!(row["total_records"], "2");
-    assert_eq!(row["names_trimmed"], "2", "every record's name was trimmed");
+    let row = read_copy_umi_metrics(&metrics);
+    assert_eq!(row.total_records, 2);
+    assert_eq!(row.names_trimmed, 2, "every record's name was trimmed");
 }
 
 // ============================================================================
@@ -504,82 +455,14 @@ fn runs_on_multiple_threads() {
 }
 
 // ============================================================================
-// Unwired scheduler/pipeline flags must warn on BOTH the chain and serial paths
-// ============================================================================
-
-/// Unwired scheduler/pipeline-queue flags must warn on BOTH the `--threads N`
-/// chain path and the no-`--threads` serial path -- but with DIFFERENT wording,
-/// since the two paths are unwired for different reasons and the warning must
-/// stay true to whichever one is actually running:
-///
-/// * Chain path (`execute_chain` -> `add_copy_umi` ->
-///   `common::warn_unwired_pipeline_flags`): `--deadlock-recover`/`--scheduler`
-///   are inert because the typed-step engine has no pluggable scheduler and no
-///   deadlock-recovery mechanism to enable. `--max-memory` etc. are NOT warned
-///   here -- the chain DOES honor them (`PipelineConfig::queue_memory_total`).
-/// * Serial path (`CopyUmi::warn_unwired_flags_on_serial_path`): ALL THREE are
-///   inert, because there is no chain/pipeline at all on this path -- only a
-///   plain read -> copy-umi -> write loop with no scheduler, no deadlock
-///   detector, and no queues to budget.
-///
-/// `--max-memory`/`--scheduler` on the serial path is what regresses if
-/// `warn_unwired_flags_on_serial_path` is reverted to reusing
-/// `common::warn_unwired_pipeline_flags` (issue: that reuse asserted a false
-/// "chain engine" rationale on a path with no chain engine, AND silently
-/// skipped the queue-memory flags, which -- unlike on the chain path -- really
-/// are inert here).
-#[rstest]
-#[case::deadlock_recover_serial(
-    &["--deadlock-recover"],
-    &[],
-    "--deadlock-recover has no effect on the single-threaded path"
-)]
-#[case::deadlock_recover_threads(
-    &["--deadlock-recover"],
-    &["--threads", "1"],
-    "--deadlock-recover has no effect in the typed-step pipeline"
-)]
-#[case::scheduler_serial(
-    &["--scheduler", "fixed-priority"],
-    &[],
-    "--scheduler has no effect on the single-threaded path"
-)]
-#[case::scheduler_threads(
-    &["--scheduler", "fixed-priority"],
-    &["--threads", "1"],
-    "--scheduler has no effect in the typed-step pipeline"
-)]
-#[case::queue_memory_serial(
-    &["--max-memory", "100M"],
-    &[],
-    "--max-memory/--memory-reserve/--memory-per-thread have no effect on the \
-     single-threaded path"
-)]
-fn unwired_pipeline_flags_warn_with_path_appropriate_wording(
-    #[case] flag_args: &[&str],
-    #[case] thread_args: &[&str],
-    #[case] expected_substring: &str,
-) {
-    let dir = TempDir::new().unwrap();
-    let input = write_input(dir.path(), &[record_named("blah:AAAA")]);
-    let output = dir.path().join("out.bam");
-
-    let mut extra_args: Vec<&str> = flag_args.to_vec();
-    extra_args.extend_from_slice(thread_args);
-    let stderr = run_and_capture_logs("copy-umi", &input, &output, &extra_args);
-
-    assert!(
-        stderr.lines().any(|line| line.contains(expected_substring)),
-        "expected a line containing {expected_substring:?}; got:\n{stderr}"
-    );
-}
-
-// ============================================================================
-// Chain-vs-oracle parity (the R3 cutover contract)
+// Thread-count consistency (post-cutover: `execute()` always routes through
+// the chain builder)
 //
-// The no-`--threads` serial path (`run_single_threaded`) is the in-process
-// oracle; `--threads N` routes through the chain builder. `--threads 1` is a
-// distinct chain-at-single-worker path from both, so the matrix includes it.
+// `--threads` unset (the chain's default thread count) and `--threads N` for
+// several `N` all build and run the same `ChainSpec::single_stage(Stage::CopyUmi,
+// ..)`, so any divergence here is a real thread-count-dependent bug, not two
+// implementations disagreeing. Locals below are named `default_threads_*` for
+// the no-`--threads` run and `explicit_threads_*` for the `--threads N` run.
 // ============================================================================
 
 /// Build a copy-umi input of `n` records with `:`-delimited UMI read names.
@@ -600,36 +483,44 @@ fn build_parity_input(dir: &Path, n: usize) -> std::path::PathBuf {
 #[case::t1(1)]
 #[case::t2(2)]
 #[case::t4(4)]
-fn chain_matches_single_threaded(#[case] threads: u8) {
+fn chain_output_consistent_across_thread_counts(#[case] threads: u8) {
     let dir = TempDir::new().unwrap();
     let input = build_parity_input(dir.path(), 500);
 
-    let oracle_out = dir.path().join("oracle.bam");
-    run_copy_umi(&input, &oracle_out, &[]).expect("serial oracle run");
+    let default_threads_out = dir.path().join("default_threads.bam");
+    run_copy_umi(&input, &default_threads_out, &[]).expect("default-threads run");
 
-    let chain_out = dir.path().join("chain.bam");
-    run_copy_umi(&input, &chain_out, &["--threads", &threads.to_string()]).expect("chain run");
+    let explicit_threads_out = dir.path().join("explicit_threads.bam");
+    run_copy_umi(&input, &explicit_threads_out, &["--threads", &threads.to_string()])
+        .expect("explicit-threads run");
 
-    let (oracle_hdr, oracle_recs) = crate::helpers::read_bam_output(&oracle_out);
-    let (chain_hdr, chain_recs) = crate::helpers::read_bam_output(&chain_out);
-    assert_eq!(chain_hdr, oracle_hdr, "normalized header parity (threads={threads})");
-    assert_eq!(chain_recs, oracle_recs, "record parity (threads={threads})");
+    let (default_threads_hdr, default_threads_recs) =
+        crate::helpers::read_bam_output(&default_threads_out);
+    let (explicit_threads_hdr, explicit_threads_recs) =
+        crate::helpers::read_bam_output(&explicit_threads_out);
+    assert_eq!(
+        explicit_threads_hdr, default_threads_hdr,
+        "normalized header parity (threads={threads})"
+    );
+    assert_eq!(explicit_threads_recs, default_threads_recs, "record parity (threads={threads})");
     // Non-vacuous: every record survived and carries the copied RX.
-    assert_eq!(chain_recs.len(), 500, "all records emitted");
+    assert_eq!(explicit_threads_recs.len(), 500, "all records emitted");
 }
 
-/// Every non-default, output-producing knob must be wired identically on the
-/// chain (`--threads`) path and the serial oracle. The default-flag parity test
-/// above exercises none of them, so a knob dropped or mis-wired on the parallel
-/// path would go unnoticed. The input carries `r`-prefixed and dual UMIs so both
+/// Every non-default, output-producing knob must produce identical output with
+/// `--threads` unset and with `--threads N` set. The default-flag consistency
+/// test above exercises none of them, so a knob dropped or mis-wired at a
+/// non-default thread count would go unnoticed. The input carries `r`-prefixed
+/// and dual UMIs so both
 /// `--remove-umi` (name trim) and `--reverse-complement-r-umis false` (strip vs
-/// reverse-complement) change the output — if the chain dropped a flag, its
-/// records would diverge from the oracle's.
-/// The `expected` case column is the absolute `(read_name, RX)` the oracle must
-/// produce for each of the three input records under the case's flags. Pinning
-/// these fixed values — not just chain-vs-oracle parity — is what catches a bug
-/// present on *both* paths (e.g. a flag mis-parsed in shared code): parity alone
-/// would still pass. Verified against the command's observed output; note
+/// reverse-complement) change the output — if a non-default thread count
+/// dropped a flag, its records would diverge from the default-threads run's.
+/// The `expected` case column is the absolute `(read_name, RX)` the
+/// default-threads run must produce for each of the three input records under
+/// the case's flags. Pinning these fixed values — not just cross-thread-count
+/// consistency — is what catches a bug present at *every* thread count (e.g. a
+/// flag mis-parsed in shared code): consistency alone would still pass.
+/// Verified against the command's observed output; note
 /// `--reverse-complement-r-umis false` still maps the `+` dual-UMI delimiter to
 /// `-` (it only disables the `r`-prefix reverse-complement), so the strip case
 /// yields `AAAA-CCCC`, not `AAAA+CCCC`.
@@ -658,7 +549,7 @@ fn chain_matches_single_threaded(#[case] threads: u8) {
         ("inst:1:FC:1:1101:5:9", "TTTT"),
     ],
 )]
-fn chain_matches_oracle_with_nondefault_options(
+fn nondefault_options_consistent_across_thread_counts(
     #[case] option_flags: &[&str],
     #[case] expected: &[(&str, &str)],
 ) {
@@ -670,36 +561,46 @@ fn chain_matches_oracle_with_nondefault_options(
     ];
     let input = write_input(dir.path(), &records);
 
-    let oracle_out = dir.path().join("oracle.bam");
-    run_copy_umi(&input, &oracle_out, option_flags).expect("serial oracle run");
+    let default_threads_out = dir.path().join("default_threads.bam");
+    run_copy_umi(&input, &default_threads_out, option_flags).expect("default-threads run");
 
-    let mut chain_flags = option_flags.to_vec();
-    chain_flags.extend_from_slice(&["--threads", "4"]);
-    let chain_out = dir.path().join("chain.bam");
-    run_copy_umi(&input, &chain_out, &chain_flags).expect("chain run");
+    let mut explicit_threads_flags = option_flags.to_vec();
+    explicit_threads_flags.extend_from_slice(&["--threads", "4"]);
+    let explicit_threads_out = dir.path().join("explicit_threads.bam");
+    run_copy_umi(&input, &explicit_threads_out, &explicit_threads_flags)
+        .expect("explicit-threads run");
 
-    // Absolute anchor: the oracle must produce exactly these names+RX. A flag
-    // dropped in shared code would change these, even though chain==oracle held.
-    let oracle_name_rx = read_name_and_rx(dir.path(), &oracle_out);
+    // Absolute anchor: the default-threads run must produce exactly these
+    // names+RX. A flag dropped in shared code would change these, even though
+    // cross-thread-count consistency held.
+    let default_threads_name_rx = read_name_and_rx(dir.path(), &default_threads_out);
     let expected_name_rx: Vec<(String, Option<String>)> =
         expected.iter().map(|(name, rx)| ((*name).to_string(), Some((*rx).to_string()))).collect();
     assert_eq!(
-        oracle_name_rx, expected_name_rx,
-        "oracle (name, RX) must match the pinned expected values (flags={option_flags:?})",
+        default_threads_name_rx, expected_name_rx,
+        "default-threads (name, RX) must match the pinned expected values (flags={option_flags:?})",
     );
 
-    let (oracle_hdr, oracle_recs) = crate::helpers::read_bam_output(&oracle_out);
-    let (chain_hdr, chain_recs) = crate::helpers::read_bam_output(&chain_out);
-    assert_eq!(chain_hdr, oracle_hdr, "normalized header parity (flags={option_flags:?})");
-    assert_eq!(chain_recs, oracle_recs, "record parity (flags={option_flags:?})");
-    assert_eq!(chain_recs.len(), 3, "all records emitted (flags={option_flags:?})");
+    let (default_threads_hdr, default_threads_recs) =
+        crate::helpers::read_bam_output(&default_threads_out);
+    let (explicit_threads_hdr, explicit_threads_recs) =
+        crate::helpers::read_bam_output(&explicit_threads_out);
+    assert_eq!(
+        explicit_threads_hdr, default_threads_hdr,
+        "normalized header parity (flags={option_flags:?})"
+    );
+    assert_eq!(
+        explicit_threads_recs, default_threads_recs,
+        "record parity (flags={option_flags:?})"
+    );
+    assert_eq!(explicit_threads_recs.len(), 3, "all records emitted (flags={option_flags:?})");
 }
 
-/// `--metrics` TSV must be byte-identical between the serial oracle and the
-/// chain. `fgumi_metrics::write_metrics` embeds no timestamp, so a raw byte
-/// compare is stable.
+/// `--metrics` TSV must be byte-identical with `--threads` unset and with
+/// `--threads N` set. `fgumi_metrics::write_metrics` embeds no timestamp, so a
+/// raw byte compare is stable.
 #[test]
-fn chain_metrics_match_single_threaded() {
+fn chain_metrics_consistent_across_thread_counts() {
     let dir = TempDir::new().unwrap();
     // Include a record with a pre-existing RX so `rx_overwritten` is non-zero.
     let mut records: Vec<RawRecord> =
@@ -707,34 +608,44 @@ fn chain_metrics_match_single_threaded() {
     records.push(record_named_with_rx("q:99:TTTT", "AAAA"));
     let input = write_input(dir.path(), &records);
 
-    let oracle_out = dir.path().join("oracle.bam");
-    let oracle_metrics = dir.path().join("oracle.tsv");
-    run_copy_umi(&input, &oracle_out, &["-M", &oracle_metrics.display().to_string()])
-        .expect("serial run");
-
-    let chain_out = dir.path().join("chain.bam");
-    let chain_metrics = dir.path().join("chain.tsv");
+    let default_threads_out = dir.path().join("default_threads.bam");
+    let default_threads_metrics = dir.path().join("default_threads.tsv");
     run_copy_umi(
         &input,
-        &chain_out,
-        &["--threads", "4", "-M", &chain_metrics.display().to_string()],
+        &default_threads_out,
+        &["-M", &default_threads_metrics.display().to_string()],
     )
-    .expect("chain run");
+    .expect("default-threads run");
 
-    let oracle_tsv = std::fs::read(&oracle_metrics).expect("read oracle metrics");
-    let chain_tsv = std::fs::read(&chain_metrics).expect("read chain metrics");
-    assert_eq!(chain_tsv, oracle_tsv, "the --metrics TSV must be byte-identical across paths");
+    let explicit_threads_out = dir.path().join("explicit_threads.bam");
+    let explicit_threads_metrics = dir.path().join("explicit_threads.tsv");
+    run_copy_umi(
+        &input,
+        &explicit_threads_out,
+        &["--threads", "4", "-M", &explicit_threads_metrics.display().to_string()],
+    )
+    .expect("explicit-threads run");
+
+    let default_threads_tsv =
+        std::fs::read(&default_threads_metrics).expect("read default-threads metrics");
+    let explicit_threads_tsv =
+        std::fs::read(&explicit_threads_metrics).expect("read explicit-threads metrics");
+    assert_eq!(
+        explicit_threads_tsv, default_threads_tsv,
+        "the --metrics TSV must be byte-identical across thread counts"
+    );
 
     // Absolute anchor: pin the metrics row to fixed expected counts, not just
-    // chain==oracle parity. 50 fresh names + 1 with a pre-existing RX = 51
-    // records; every record gets an RX (rx_written 51), the one carrying a stale
-    // RX is overwritten (rx_overwritten 1), and no `--remove-umi` means no name
-    // trims (names_trimmed 0). Shared miscounting would slip past a byte compare.
-    let row = read_metrics_row(&oracle_metrics);
-    assert_eq!(row.get("total_records").map(String::as_str), Some("51"), "row: {row:?}");
-    assert_eq!(row.get("rx_written").map(String::as_str), Some("51"), "row: {row:?}");
-    assert_eq!(row.get("rx_overwritten").map(String::as_str), Some("1"), "row: {row:?}");
-    assert_eq!(row.get("names_trimmed").map(String::as_str), Some("0"), "row: {row:?}");
+    // cross-thread-count consistency. 50 fresh names + 1 with a pre-existing RX =
+    // 51 records; every record gets an RX (rx_written 51), the one carrying a
+    // stale RX is overwritten (rx_overwritten 1), and no `--remove-umi` means no
+    // name trims (names_trimmed 0). A miscounting shared by both thread counts
+    // would slip past a byte compare.
+    let row = read_copy_umi_metrics(&default_threads_metrics);
+    assert_eq!(row.total_records, 51, "row: {row:?}");
+    assert_eq!(row.rx_written, 51, "row: {row:?}");
+    assert_eq!(row.rx_overwritten, 1, "row: {row:?}");
+    assert_eq!(row.names_trimmed, 0, "row: {row:?}");
 }
 
 /// Fail-fast under `--threads`: one record with an empty last field aborts the
@@ -753,45 +664,60 @@ fn fail_fast_under_threads_single_bad_record() {
 }
 
 /// Two-level fail-fast: an illegal-character UMI is a
-/// `with_context`-wrapped error. Both paths must abort naming the read name and
-/// the outer "extracting UMI from read name" context. The serial oracle also
-/// preserves the inner reason (full `anyhow` chain); the chain path's
-/// `reconstruct` flattens to Display-only, so the inner reason is not asserted on
-/// the chain path — this documents the framework flattening rather than asserting
-/// a parity that does not hold.
+/// `with_context`-wrapped error. Both `--threads` unset and `--threads N` set
+/// must abort naming the read name, the outer "extracting UMI from read name"
+/// context, AND the inner cause ("Invalid UMI" / "illegal character") — the
+/// process step's `.map_err` flattens the full `anyhow` chain into the
+/// `io::Error` it hands the pipeline via `{e:#}`, so the inner cause is not
+/// lost crossing that boundary.
 #[test]
-fn two_level_fail_fast_names_read_name_on_both_paths() {
+fn two_level_fail_fast_names_read_name_across_thread_counts() {
     let dir = TempDir::new().unwrap();
     let bad = "q:1:ZZZZ"; // Z is outside ACGTN-, so normalization fails.
     let input = write_input(dir.path(), &[record_named(bad)]);
 
-    let serial_out = dir.path().join("serial.bam");
-    let serial_err = run_copy_umi(&input, &serial_out, &[])
-        .expect_err("illegal UMI char must abort the serial run");
-    let serial_msg = format!("{serial_err:#}");
-    assert!(serial_msg.contains(bad), "serial names the read name; got: {serial_msg}");
+    let default_threads_out = dir.path().join("default_threads.bam");
+    let default_threads_err = run_copy_umi(&input, &default_threads_out, &[])
+        .expect_err("illegal UMI char must abort the default-threads run");
+    let default_threads_msg = format!("{default_threads_err:#}");
     assert!(
-        serial_msg.contains("extracting UMI from read name"),
-        "serial carries the outer context; got: {serial_msg}"
+        default_threads_msg.contains(bad),
+        "default-threads run names the read name; got: {default_threads_msg}"
+    );
+    assert!(
+        default_threads_msg.contains("extracting UMI from read name"),
+        "default-threads run carries the outer context; got: {default_threads_msg}"
+    );
+    assert!(
+        default_threads_msg.contains("Invalid UMI")
+            && default_threads_msg.contains("illegal character"),
+        "default-threads run carries the inner cause; got: {default_threads_msg}"
     );
 
-    let chain_out = dir.path().join("chain.bam");
-    let chain_err = run_copy_umi(&input, &chain_out, &["--threads", "2"])
-        .expect_err("illegal UMI char must abort the chain run");
-    let chain_msg = format!("{chain_err:#}");
-    assert!(chain_msg.contains(bad), "chain names the read name; got: {chain_msg}");
+    let explicit_threads_out = dir.path().join("explicit_threads.bam");
+    let explicit_threads_err = run_copy_umi(&input, &explicit_threads_out, &["--threads", "2"])
+        .expect_err("illegal UMI char must abort the explicit-threads run");
+    let explicit_threads_msg = format!("{explicit_threads_err:#}");
     assert!(
-        chain_msg.contains("extracting UMI from read name"),
-        "chain carries the outer context; got: {chain_msg}"
+        explicit_threads_msg.contains(bad),
+        "explicit-threads run names the read name; got: {explicit_threads_msg}"
+    );
+    assert!(
+        explicit_threads_msg.contains("extracting UMI from read name"),
+        "explicit-threads run carries the outer context; got: {explicit_threads_msg}"
+    );
+    assert!(
+        explicit_threads_msg.contains("Invalid UMI")
+            && explicit_threads_msg.contains("illegal character"),
+        "explicit-threads run carries the inner cause; got: {explicit_threads_msg}"
     );
 }
 
-/// Header-less input: both the chain and the serial oracle synthesize
+/// Header-less input: `--threads` unset and `--threads N` set both synthesize
 /// `@HD VN:1.6 SO:unsorted` and stay in header parity (`ChainBuilder::new`
-/// calls `ensure_hd_record`, so the chain path
-/// synthesizes @HD just like the oracle).
+/// calls `ensure_hd_record` regardless of thread count).
 #[test]
-fn chain_and_oracle_synthesize_hd_for_headerless_input() {
+fn synthesizes_hd_for_headerless_input_across_thread_counts() {
     use noodles::sam::Header as SamHeader;
     use noodles::sam::header::record::value::{Map, map::ReferenceSequence};
     use std::num::NonZeroUsize;
@@ -808,20 +734,21 @@ fn chain_and_oracle_synthesize_hd_for_headerless_input() {
     let input = dir.path().join("headerless.bam");
     write_bam(&input, &header, &[record_named("q:1:ACGT")]);
 
-    let oracle_out = dir.path().join("oracle.bam");
-    run_copy_umi(&input, &oracle_out, &[]).expect("serial run");
-    let chain_out = dir.path().join("chain.bam");
-    run_copy_umi(&input, &chain_out, &["--threads", "2"]).expect("chain run");
+    let default_threads_out = dir.path().join("default_threads.bam");
+    run_copy_umi(&input, &default_threads_out, &[]).expect("default-threads run");
+    let explicit_threads_out = dir.path().join("explicit_threads.bam");
+    run_copy_umi(&input, &explicit_threads_out, &["--threads", "2"]).expect("explicit-threads run");
 
-    let (oracle_hdr, _) = crate::helpers::read_bam_output(&oracle_out);
-    let (chain_hdr, _) = crate::helpers::read_bam_output(&chain_out);
-    assert!(oracle_hdr.header().is_some(), "serial synthesizes @HD");
-    assert!(chain_hdr.header().is_some(), "chain synthesizes @HD");
-    assert_eq!(chain_hdr, oracle_hdr, "header-less-input @HD parity");
+    let (default_threads_hdr, _) = crate::helpers::read_bam_output(&default_threads_out);
+    let (explicit_threads_hdr, _) = crate::helpers::read_bam_output(&explicit_threads_out);
+    assert!(default_threads_hdr.header().is_some(), "default-threads run synthesizes @HD");
+    assert!(explicit_threads_hdr.header().is_some(), "explicit-threads run synthesizes @HD");
+    assert_eq!(explicit_threads_hdr, default_threads_hdr, "header-less-input @HD parity");
 
-    // Absolute anchor: pin the exact synthesized @HD contract on BOTH paths, not
-    // just their equality — otherwise both could synthesize the same *wrong* @HD
-    // and pass. `ChainBuilder::new`/the oracle synthesize `@HD VN:1.6 SO:unsorted`.
+    // Absolute anchor: pin the exact synthesized @HD contract at BOTH thread
+    // counts, not just their equality — otherwise both could synthesize the
+    // same *wrong* @HD and pass. `ChainBuilder::new` synthesizes
+    // `@HD VN:1.6 SO:unsorted` regardless of thread count.
     let hd_line = |bam: &Path, tag: &str| -> String {
         let sam = dir.path().join(format!("{tag}.sam"));
         transcode_bam_to_sam(bam, &sam);
@@ -832,7 +759,9 @@ fn chain_and_oracle_synthesize_hd_for_headerless_input() {
             .unwrap_or_else(|| panic!("{tag} output must carry an @HD line"))
             .to_string()
     };
-    for (tag, bam) in [("oracle", &oracle_out), ("chain", &chain_out)] {
+    for (tag, bam) in
+        [("default_threads", &default_threads_out), ("explicit_threads", &explicit_threads_out)]
+    {
         let hd = hd_line(bam, tag);
         assert!(hd.contains("VN:1.6"), "{tag} @HD must declare VN:1.6, got: {hd}");
         assert!(hd.contains("SO:unsorted"), "{tag} @HD must declare SO:unsorted, got: {hd}");
@@ -840,12 +769,10 @@ fn chain_and_oracle_synthesize_hd_for_headerless_input() {
 }
 
 // ============================================================================
-// CRC-policy parity: the serial oracle (no `--threads`) and the
-// chain (`--threads N`) derive `verify_crc` from independent sources — the
-// serial path from `self.io.pipeline_reader_opts()`, the chain from
-// `spec.verify_crc` — so pin them equal: both must honor `--check-crc` /
-// `--no-check-crc` identically (default verify-on for file input rejects a
-// corrupted block; `--no-check-crc` accepts it).
+// CRC-policy consistency: `--threads` unset and `--threads N` both derive
+// `verify_crc` from `spec.verify_crc` in the same chain, so both must honor
+// `--check-crc` / `--no-check-crc` identically (default verify-on for file
+// input rejects a corrupted block; `--no-check-crc` accepts it).
 // ============================================================================
 
 /// Flip a byte in the last BGZF block's CRC32 footer, so decoding that block
@@ -869,27 +796,27 @@ fn corrupt_last_block_crc(path: &Path) {
     std::fs::write(path, bytes).expect("write corrupted bam");
 }
 
-/// Both the serial oracle and the `--threads` chain must honor the CRC policy
+/// Both `--threads` unset and `--threads N` set must honor the CRC policy
 /// identically: the default (verify-on for file input) rejects a corrupted BGZF
 /// block, while `--no-check-crc` accepts it and completes.
 #[rstest]
-#[case::serial(&[][..])]
-#[case::chain(&["--threads", "4"][..])]
-fn crc_policy_parity_serial_and_chain(#[case] path_flags: &[&str]) {
+#[case::default_threads(&[][..])]
+#[case::explicit_threads(&["--threads", "4"][..])]
+fn crc_policy_consistent_across_thread_counts(#[case] path_flags: &[&str]) {
     let dir = TempDir::new().unwrap();
     // 6000 records span several BGZF blocks, so the corrupted last block is a
     // record block, not the header's.
     let input = build_parity_input(dir.path(), 6000);
     corrupt_last_block_crc(&input);
 
-    // Default policy: both paths reject the corrupted block.
+    // Default policy: both thread counts reject the corrupted block.
     let out_reject = dir.path().join("reject.bam");
     assert!(
         run_copy_umi(&input, &out_reject, path_flags).is_err(),
         "default CRC policy must reject a corrupted block (flags={path_flags:?})"
     );
 
-    // `--no-check-crc`: both paths accept the corrupted block and complete.
+    // `--no-check-crc`: both thread counts accept the corrupted block and complete.
     let out_accept = dir.path().join("accept.bam");
     let mut accept_flags = path_flags.to_vec();
     accept_flags.push("--no-check-crc");
@@ -921,11 +848,12 @@ fn crc_policy_parity_serial_and_chain(#[case] path_flags: &[&str]) {
 
 // ============================================================================
 // Malformed-record safety: a framing-consistent-but-malformed record (an
-// `l_read_name` that runs past the record end) must fail with a CLEAN error on
-// BOTH the serial oracle and the `--threads` chain — never panic. Before the
-// serial path revalidated framing, `copy_umi_into_record`'s `read_name()` slice
-// would panic (index out of bounds) on such a record, a regression from the
-// pre-cutover pipeline, which decoded (and thus validated) every record.
+// `l_read_name` that runs past the record end) must fail with a CLEAN error
+// with `--threads` unset and with `--threads N` set — never panic.
+// `copy_umi_into_record`'s `read_name()` slice would panic (index out of
+// bounds) on such a record if it were reached unvalidated; the chain's
+// `DecodeRecords` validates framing before `copy_umi_into_record` ever sees
+// the record, on every thread count.
 // ============================================================================
 
 /// Write a one-record BAM whose record has a corrupted `l_read_name` (claims a
@@ -946,9 +874,9 @@ fn write_malformed_l_read_name_bam(dir: &Path) -> std::path::PathBuf {
 }
 
 #[rstest]
-#[case::serial(&[][..])]
-#[case::chain(&["--threads", "2"][..])]
-fn malformed_record_errors_cleanly_on_both_paths(#[case] thread_flags: &[&str]) {
+#[case::default_threads(&[][..])]
+#[case::explicit_threads(&["--threads", "2"][..])]
+fn malformed_record_errors_cleanly_across_thread_counts(#[case] thread_flags: &[&str]) {
     let dir = TempDir::new().unwrap();
     let input = write_malformed_l_read_name_bam(dir.path());
     let output = dir.path().join("out.bam");
@@ -956,6 +884,6 @@ fn malformed_record_errors_cleanly_on_both_paths(#[case] thread_flags: &[&str]) 
         .expect_err("a malformed l_read_name record must error, not panic");
     assert!(
         format!("{err:#}").contains("read-name region runs past record end"),
-        "expected the clean framing error on both paths (flags={thread_flags:?}), got: {err:#}"
+        "expected the clean framing error at every thread count (flags={thread_flags:?}), got: {err:#}"
     );
 }

--- a/tests/integration/test_copy_umi_cutover_parity.rs
+++ b/tests/integration/test_copy_umi_cutover_parity.rs
@@ -1,0 +1,655 @@
+//! Cutover parity test for `fgumi copy-umi`.
+//!
+//! `CopyUmi::execute` used to gate on `--threads`: unset ran a serial
+//! read->copy-umi->write loop (`run_single_threaded`), set routed through the
+//! declarative chain builder. The cutover deletes the serial path so `execute()`
+//! always runs through the chain (`execute_chain`) regardless of `--threads`.
+//! `copy-umi` itself is unchanged by the cutover -- only which code path
+//! `execute()` reaches is -- so the pre-cutover binary is a valid oracle for the
+//! post-cutover binary's output.
+//!
+//! This pins the current (chain-only) binary's output against the frozen
+//! pre-cutover baseline binary named by `FGUMI_BASELINE_BIN`: BAM output must be
+//! byte-identical modulo the `@PG` header line, and the `--metrics` TSV (which
+//! embeds no timestamp) must be byte-identical outright. When `FGUMI_BASELINE_BIN`
+//! is unset (the default in CI), the baseline half is skipped but the case still
+//! runs a non-vacuous self-consistency oracle: it asserts the destination `RX`
+//! tag is present and equals the *normalized* (not raw) source UMI, using fixed
+//! expected values pinned independently in `umi::read_name`'s own unit tests
+//! (`rAAAA+CCCC` -> `TTTT-CCCC`, etc.) -- a passthrough that copied the read-name
+//! field verbatim, or dropped the `r`-prefix reverse-complement / `+`->`-`
+//! translation, would fail this even with no baseline binary available.
+
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Command;
+
+use fgumi_raw_bam::{RawRecord, SamBuilder};
+use rstest::rstest;
+use tempfile::TempDir;
+
+use crate::helpers::{
+    read_bam_output, read_copy_umi_metrics, read_name_and_rx, record_named, record_named_with_rx,
+    write_input,
+};
+
+/// Resolves the frozen pre-cutover baseline binary to compare against.
+///
+/// Comes solely from `FGUMI_BASELINE_BIN`; unset (or naming a missing file)
+/// returns `None` -- "no baseline oracle available", never a passing result.
+/// Callers layer the baseline byte-parity check on top of the always-available
+/// self-consistency oracle; a missing baseline only drops the byte-parity half.
+/// No hardcoded fallback: a baseline binary is host-specific and must never be a
+/// path committed into the repo.
+fn baseline_bin() -> Option<std::path::PathBuf> {
+    let path = std::path::PathBuf::from(std::env::var_os("FGUMI_BASELINE_BIN")?);
+    if path.is_file() {
+        return Some(path);
+    }
+    eprintln!(
+        "FGUMI_BASELINE_BIN={} does not name an existing file; baseline oracle unavailable",
+        path.display()
+    );
+    None
+}
+
+/// Removes every `@PG` line from a SAM header text blob.
+///
+/// Both the cutover build and the baseline binary stamp a single `@PG` line
+/// whose `VN` (git-describe version) and `CL` (command line, naming a different
+/// binary path and output path per side) necessarily differ between two
+/// independent invocations. Stripping the whole line is simplest and correct
+/// here because neither side emits more than one `@PG` record for this input.
+fn strip_pg_lines(text: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+    let mut lines: Vec<&str> = text.split('\n').collect();
+    let had_trailing_newline = lines.last() == Some(&"");
+    if had_trailing_newline {
+        lines.pop();
+    }
+    lines.retain(|line| !line.starts_with("@PG"));
+    let mut out = lines.join("\n");
+    if had_trailing_newline {
+        out.push('\n');
+    }
+    out
+}
+
+/// Reads a BAM file's raw BGZF stream, decompresses it, strips the `@PG`
+/// line(s) from the embedded SAM header text, and returns the resulting bytes
+/// (new header + unmodified `n_ref`/reference-list/record bytes).
+///
+/// Operates on the decompressed BAM binary format directly (not
+/// `RecordBuf`-parsed records) so everything except the `@PG` line is an exact,
+/// uninterpreted byte comparison -- BGZF block boundaries and compression
+/// levels differ between the two writers even when the logical content is
+/// identical, so raw file bytes never match, and a re-encode through noodles
+/// risks masking a real tag-order or binary-layout regression by normalizing it
+/// away. Mirrors `test_sort_cutover_parity.rs`'s helper of the same name.
+fn decompressed_records_without_pg(path: &Path) -> Vec<u8> {
+    let file = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+    let mut reader = noodles::bgzf::io::Reader::new(std::io::BufReader::new(file));
+    let mut raw = Vec::new();
+    std::io::Read::read_to_end(&mut reader, &mut raw)
+        .unwrap_or_else(|e| panic!("decompress BGZF stream for {}: {e}", path.display()));
+
+    assert!(
+        raw.len() >= 8 && &raw[0..4] == b"BAM\x01",
+        "{} does not decompress to a BAM binary stream (missing magic)",
+        path.display()
+    );
+    let l_text = i32::from_le_bytes(raw[4..8].try_into().expect("4 bytes"));
+    let l_text = usize::try_from(l_text).expect("l_text is non-negative");
+    let text_start = 8;
+    let text_end = text_start + l_text;
+    assert!(raw.len() >= text_end, "{} header text runs past end of stream", path.display());
+
+    let text = String::from_utf8_lossy(&raw[text_start..text_end]);
+    let stripped_text = strip_pg_lines(&text);
+
+    let mut out = Vec::with_capacity(raw.len());
+    out.extend_from_slice(b"BAM\x01");
+    let new_l_text = i32::try_from(stripped_text.len()).expect("stripped header text fits i32");
+    out.extend_from_slice(&new_l_text.to_le_bytes());
+    out.extend_from_slice(stripped_text.as_bytes());
+    out.extend_from_slice(&raw[text_end..]); // n_ref, reference list, and all records, untouched
+    out
+}
+
+/// Asserts `copy-umi` preserved every alignment-bearing field of every record
+/// against the `input` fixture: it rewrites only the read name and the `RX` tag,
+/// so SEQ, QUAL, FLAG, RNAME, POS, MAPQ, CIGAR, the mate reference id, the mate
+/// position, the template length (TLEN), and every non-`RX` auxiliary tag —
+/// plus the header's reference sequences — must round-trip unchanged. This
+/// upgrades the always-on (baseline-free) oracle from a name/`RX`-only check to
+/// full-record identity, so a shared chain regression that corrupts a record
+/// body is caught in CI where `FGUMI_BASELINE_BIN` is unset. Only the read name,
+/// the `RX` tag, and the `@PG` header line are excluded — those are the parts
+/// `copy-umi` is expected to change (the name/`RX` transformation itself is
+/// asserted separately by each caller).
+fn assert_alignment_fields_preserved(input: &Path, output: &Path) {
+    // The one aux tag `copy-umi` writes; every other tag must survive verbatim.
+    let rx_tag = fgumi_lib::sam::SamTag::RX.to_noodles_tag();
+    let (mut in_header, in_recs) = read_bam_output(input);
+    let (mut out_header, out_recs) = read_bam_output(output);
+    assert_eq!(out_recs.len(), in_recs.len(), "record count must round-trip");
+    // Every header record except `@PG` must round-trip: `copy-umi` stamps its
+    // own `@PG` line, so clear the programs on both sides and compare the whole
+    // header. A reference-sequences-only check would let a dropped or altered
+    // `@HD` (or `@RG`/`@CO`) pass in the baseline-free CI path; comparing the
+    // full header modulo `@PG` closes that gap.
+    in_header.programs_mut().as_mut().clear();
+    out_header.programs_mut().as_mut().clear();
+    assert_eq!(
+        out_header, in_header,
+        "copy-umi must preserve every non-@PG header record (@HD, @SQ, @RG, @CO)"
+    );
+    for (i, (out, inp)) in out_recs.iter().zip(&in_recs).enumerate() {
+        assert_eq!(out.sequence().as_ref(), inp.sequence().as_ref(), "record {i} SEQ must survive");
+        assert_eq!(
+            out.quality_scores().as_ref(),
+            inp.quality_scores().as_ref(),
+            "record {i} QUAL must survive"
+        );
+        assert_eq!(out.flags(), inp.flags(), "record {i} FLAG must survive");
+        assert_eq!(
+            out.reference_sequence_id(),
+            inp.reference_sequence_id(),
+            "record {i} RNAME must survive"
+        );
+        assert_eq!(out.alignment_start(), inp.alignment_start(), "record {i} POS must survive");
+        assert_eq!(out.mapping_quality(), inp.mapping_quality(), "record {i} MAPQ must survive");
+        let out_cigar: Vec<_> =
+            out.cigar().as_ref().iter().map(|op| (op.kind(), op.len())).collect();
+        let in_cigar: Vec<_> =
+            inp.cigar().as_ref().iter().map(|op| (op.kind(), op.len())).collect();
+        assert_eq!(out_cigar, in_cigar, "record {i} CIGAR must survive");
+        assert_eq!(
+            out.mate_reference_sequence_id(),
+            inp.mate_reference_sequence_id(),
+            "record {i} mate RNAME (mate reference id) must survive"
+        );
+        assert_eq!(
+            out.mate_alignment_start(),
+            inp.mate_alignment_start(),
+            "record {i} mate POS must survive"
+        );
+        assert_eq!(
+            out.template_length(),
+            inp.template_length(),
+            "record {i} TLEN (template length) must survive"
+        );
+        // Every auxiliary tag except `RX` (the one `copy-umi` writes) must
+        // survive verbatim, in order.
+        let out_aux: Vec<_> = out.data().iter().filter(|(tag, _)| *tag != rx_tag).collect();
+        let in_aux: Vec<_> = inp.data().iter().filter(|(tag, _)| *tag != rx_tag).collect();
+        assert_eq!(out_aux, in_aux, "record {i} non-RX auxiliary tags must survive");
+    }
+}
+
+/// Runs `<bin> copy-umi -i <input> -o <output> [extra...]`. Returns `Ok(())` on
+/// success or `Err(stderr)` on failure -- never panics on a non-zero exit, so
+/// callers can assert on either outcome.
+fn run_copy_umi(bin: &Path, input: &Path, output: &Path, extra: &[&str]) -> Result<(), String> {
+    let out = Command::new(bin)
+        .args([OsStr::new("copy-umi"), OsStr::new("-i"), input.as_os_str()])
+        .args([OsStr::new("-o"), output.as_os_str()])
+        .args(extra.iter().map(OsStr::new))
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn `{}`: {e}", bin.display()));
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).into_owned())
+    }
+}
+
+/// The 28-byte BGZF end-of-file marker (an empty gzip block). A fully written
+/// BGZF stream ends with it; a run that aborts mid-stream (e.g. a
+/// `--fail-if-tag-present` rejection) never finalizes the writer, so the partial
+/// output it leaves lacks it.
+const BGZF_EOF_MARKER: [u8; 28] = [
+    0x1f, 0x8b, 0x08, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x06, 0x00, 0x42, 0x43, 0x02, 0x00,
+    0x1b, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+];
+
+/// True if `path` ends with the BGZF EOF marker, i.e. the writer finalized the
+/// stream. A partial BAM from an aborted run returns false.
+fn has_bgzf_eof_marker(path: &Path) -> bool {
+    let bytes = std::fs::read(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    bytes.ends_with(&BGZF_EOF_MARKER)
+}
+
+/// Reads whatever *complete* records a possibly-truncated BAM contains, tolerating
+/// a missing EOF marker or a partial trailing block. A header-only partial BAM
+/// (the shape a failed `copy-umi` run leaves) yields an empty vec rather than a
+/// panic, so callers can assert the aborted run published fewer records than it read.
+fn recover_records_lenient(path: &Path) -> Vec<noodles::sam::alignment::RecordBuf> {
+    let mut reader = noodles::bam::io::Reader::new(std::io::BufReader::new(
+        std::fs::File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display())),
+    ));
+    // A truncated or absent header is a legitimate shape for an aborted run's
+    // partial BAM; report zero recovered records rather than panicking, so
+    // `failed_output_state` stays comparable for zero-byte / header-truncated output.
+    let Ok(header) = reader.read_header() else {
+        return Vec::new();
+    };
+    let mut records = Vec::new();
+    for result in reader.record_bufs(&header) {
+        match result {
+            Ok(record) => records.push(record),
+            // A truncated tail is the expected shape of a failed run's partial
+            // BAM; stop at the first unreadable record instead of failing.
+            Err(_) => break,
+        }
+    }
+    records
+}
+
+/// The observable post-failure state of a `copy-umi` output path: whether the
+/// file exists, whether its BGZF stream was finalized (EOF marker present), and
+/// how many complete records survived. Comparing this between the cutover and the
+/// frozen baseline binary is how the failure test pins output-state parity, not
+/// just the stderr message.
+#[derive(Debug, PartialEq, Eq)]
+struct FailedOutputState {
+    exists: bool,
+    finalized: bool,
+    recovered_records: usize,
+}
+
+fn failed_output_state(path: &Path) -> FailedOutputState {
+    if !path.exists() {
+        return FailedOutputState { exists: false, finalized: false, recovered_records: 0 };
+    }
+    FailedOutputState {
+        exists: true,
+        finalized: has_bgzf_eof_marker(path),
+        recovered_records: recover_records_lenient(path).len(),
+    }
+}
+
+// ============================================================================
+// Records + fixed expected (name, RX) values.
+//
+// The raw last-field UMI text (after the `:` delimiter) for each record, and
+// the RX each must normalize to under `--reverse-complement-r-umis` true
+// (fgbio default) vs. false, are pinned independently of this cutover: they
+// are the exact values `umi::read_name::normalize_read_name_umi`'s own unit
+// tests assert (`rAAAA+CCCC` -> `TTTT-CCCC` under revcomp, `AAAA-CCCC` under
+// strip-only, etc.) A passthrough implementation that copied the raw field
+// verbatim, or dropped the `+`->`-` translation or the `r`-prefix handling,
+// diverges from these on every record but the first.
+// ============================================================================
+
+/// `(name_prefix, raw_umi_field)` pairs; the read name is `"{prefix}:{raw}"`.
+const RECORD_SPECS: &[(&str, &str)] = &[
+    ("read0", "ACGT"),
+    ("read1", "rAAAA"),
+    ("read2", "ACGT+CAGA"),
+    ("read3", "rAAAA+CCCC"),
+    ("read4", "rAAAA+rCCCC"),
+];
+
+/// Expected RX per `RECORD_SPECS` entry, in order, under
+/// `--reverse-complement-r-umis` true (the default) or false (strip-only).
+fn expected_rx(reverse_complement: bool) -> Vec<&'static str> {
+    if reverse_complement {
+        vec!["ACGT", "TTTT", "ACGT-CAGA", "TTTT-CCCC", "TTTT-GGGG"]
+    } else {
+        vec!["ACGT", "AAAA", "ACGT-CAGA", "AAAA-CCCC", "AAAA-CCCC"]
+    }
+}
+
+/// Builds a parity fixture record: the same minimal alignment body as
+/// [`record_named`], but with the mate reference id, mate position, template
+/// length (TLEN), and a non-`RX` `NM:i` auxiliary tag populated with concrete,
+/// per-record, non-default values.
+///
+/// `record_named` leaves all of these at their BAM defaults (mate ref/pos = -1,
+/// TLEN = 0, no aux tags), so the always-on / baseline-free oracle
+/// ([`assert_alignment_fields_preserved`]) could not observe a `copy-umi` chain
+/// regression that dropped or corrupted them — a dropped mate ref/pos, TLEN, or
+/// aux tag would compare "default == default" on both sides and pass silently.
+/// Populating them here makes such a regression actually diverge input vs.
+/// output. `copy-umi` rewrites only the read name and the `RX` tag, so every
+/// field set here must round-trip unchanged.
+fn record_with_mate_and_aux(name: &str, mate_pos: i32, tlen: i32, nm: i32) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(b"ACGT")
+        .qualities(&[30; 4])
+        .flags(0)
+        .ref_id(0)
+        .pos(99)
+        .mapq(60)
+        .cigar_ops(&[4 << 4])
+        .mate_ref_id(0)
+        .mate_pos(mate_pos)
+        .template_length(tlen)
+        .add_int_tag(fgumi_lib::sam::SamTag::NM, nm);
+    b.build()
+}
+
+fn parity_records() -> Vec<RawRecord> {
+    RECORD_SPECS
+        .iter()
+        .enumerate()
+        .map(|(i, (prefix, raw))| {
+            let i = i32::try_from(i).expect("fixture index fits i32");
+            // Distinct, non-default values per record so a dropped/corrupted
+            // field diverges rather than aliasing another record's value.
+            record_with_mate_and_aux(&format!("{prefix}:{raw}"), 200 + i, 300 + i, 1 + i)
+        })
+        .collect()
+}
+
+// ============================================================================
+// Main matrix: every non-default, output-affecting flag combination, byte-
+// pinned against the baseline binary where available, and self-consistency-
+// checked against fixed expected (name, RX) values regardless.
+// ============================================================================
+
+#[rstest]
+#[case::default(&[][..], false, true)]
+#[case::remove_umi(&["--remove-umi"][..], true, true)]
+#[case::strip_r(&["--reverse-complement-r-umis", "false"][..], false, false)]
+#[case::remove_and_strip(&["--remove-umi", "--reverse-complement-r-umis", "false"][..], true, false)]
+fn cutover_matches_baseline_and_self_consistency(
+    #[case] flags: &[&str],
+    #[case] removes_umi: bool,
+    #[case] reverse_complement: bool,
+) {
+    let dir = TempDir::new().expect("create temp dir");
+    let input = write_input(dir.path(), &parity_records());
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current_metrics = dir.path().join("current.tsv");
+    let mut current_flags = flags.to_vec();
+    let metrics_arg = current_metrics.display().to_string();
+    current_flags.extend_from_slice(&["-M", &metrics_arg]);
+    run_copy_umi(current_bin, &input, &current_out, &current_flags)
+        .unwrap_or_else(|e| panic!("current binary copy-umi failed (flags={flags:?}): {e}"));
+
+    // Self-consistency oracle: always runs, proving THIS run actually copied and
+    // normalized the UMI (not a passthrough), regardless of baseline availability.
+    let name_rx = read_name_and_rx(dir.path(), &current_out);
+    let expected_rx_vals = expected_rx(reverse_complement);
+    assert_eq!(name_rx.len(), RECORD_SPECS.len(), "record count must round-trip (flags={flags:?})");
+    for (i, ((name, rx), (prefix, _raw))) in name_rx.iter().zip(RECORD_SPECS.iter()).enumerate() {
+        let expected_name = if removes_umi {
+            (*prefix).to_string()
+        } else {
+            format!("{prefix}:{}", RECORD_SPECS[i].1)
+        };
+        assert_eq!(name, &expected_name, "record {i} name mismatch (flags={flags:?})");
+        assert_eq!(
+            rx.as_deref(),
+            Some(expected_rx_vals[i]),
+            "record {i} RX mismatch (flags={flags:?}): expected {}, a passthrough or a dropped \
+             normalization step would diverge here",
+            expected_rx_vals[i]
+        );
+    }
+
+    // Full-record oracle (always on, baseline or not): copy-umi must leave every
+    // alignment-bearing field and the header refs untouched — only name + RX change.
+    assert_alignment_fields_preserved(&input, &current_out);
+
+    let metrics = read_copy_umi_metrics(&current_metrics);
+    assert_eq!(metrics.total_records, 5, "flags={flags:?}");
+    assert_eq!(metrics.rx_written, 5, "flags={flags:?}");
+    assert_eq!(metrics.rx_overwritten, 0, "flags={flags:?}");
+    let expected_trimmed: u64 = if removes_umi { 5 } else { 0 };
+    assert_eq!(metrics.names_trimmed, expected_trimmed, "flags={flags:?}");
+
+    match baseline_bin() {
+        Some(baseline_bin_path) => {
+            let baseline_out = dir.path().join("baseline.bam");
+            let baseline_metrics = dir.path().join("baseline.tsv");
+            let mut baseline_flags = flags.to_vec();
+            let baseline_metrics_arg = baseline_metrics.display().to_string();
+            baseline_flags.extend_from_slice(&["-M", &baseline_metrics_arg]);
+            run_copy_umi(&baseline_bin_path, &input, &baseline_out, &baseline_flags)
+                .unwrap_or_else(|e| {
+                    panic!("baseline binary copy-umi failed (flags={flags:?}): {e}")
+                });
+
+            assert_eq!(
+                decompressed_records_without_pg(&current_out),
+                decompressed_records_without_pg(&baseline_out),
+                "cutover output for flags={flags:?} diverges from the pre-cutover baseline binary \
+                 ({}) after stripping the @PG header line -- this is a real cutover parity bug, \
+                 not something to relax the assertion for",
+                baseline_bin_path.display(),
+            );
+            assert_eq!(
+                std::fs::read(&current_metrics).expect("read current metrics"),
+                std::fs::read(&baseline_metrics).expect("read baseline metrics"),
+                "the --metrics TSV must be byte-identical between the cutover and the baseline \
+                 binary (flags={flags:?})"
+            );
+        }
+        None => {
+            eprintln!(
+                "SKIP baseline half of cutover_matches_baseline_and_self_consistency[{flags:?}]: \
+                 FGUMI_BASELINE_BIN is unset or does not name an existing file"
+            );
+        }
+    }
+}
+
+// ============================================================================
+// RX overwrite: a pre-existing RX tag must be overwritten (default policy) and
+// counted, or reject the run under `--fail-if-tag-present` -- both byte-pinned
+// against the baseline where available.
+// ============================================================================
+
+fn overwrite_records() -> Vec<RawRecord> {
+    vec![record_named("plain:ACGT"), record_named_with_rx("stale:rAAAA", "GATTACA")]
+}
+
+#[test]
+fn cutover_overwrites_existing_rx_and_counts_it() {
+    let dir = TempDir::new().expect("create temp dir");
+    let input = write_input(dir.path(), &overwrite_records());
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current_metrics = dir.path().join("current.tsv");
+    run_copy_umi(
+        current_bin,
+        &input,
+        &current_out,
+        &["-M", current_metrics.to_str().expect("valid utf8 path")],
+    )
+    .expect("current binary copy-umi (overwrite) should succeed");
+
+    let name_rx = read_name_and_rx(dir.path(), &current_out);
+    assert_eq!(
+        name_rx,
+        vec![
+            ("plain:ACGT".to_string(), Some("ACGT".to_string())),
+            ("stale:rAAAA".to_string(), Some("TTTT".to_string())),
+        ],
+        "the pre-existing RX on record 1 must be overwritten with the freshly-copied UMI"
+    );
+
+    // Full-record oracle (always on): only name + RX change on the overwrite path.
+    assert_alignment_fields_preserved(&input, &current_out);
+
+    let metrics = read_copy_umi_metrics(&current_metrics);
+    assert_eq!(metrics.total_records, 2);
+    assert_eq!(metrics.rx_overwritten, 1);
+
+    if let Some(baseline_bin_path) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let baseline_metrics = dir.path().join("baseline.tsv");
+        run_copy_umi(
+            &baseline_bin_path,
+            &input,
+            &baseline_out,
+            &["-M", baseline_metrics.to_str().expect("valid utf8 path")],
+        )
+        .expect("baseline binary copy-umi (overwrite) should succeed");
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "overwrite-scenario output diverges from the baseline binary after stripping @PG"
+        );
+        assert_eq!(
+            std::fs::read(&current_metrics).expect("read current metrics"),
+            std::fs::read(&baseline_metrics).expect("read baseline metrics"),
+            "the --metrics TSV must be byte-identical between the cutover and the baseline binary"
+        );
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_overwrites_existing_rx_and_counts_it: \
+             FGUMI_BASELINE_BIN is unset or does not name an existing file"
+        );
+    }
+}
+
+/// `--fail-if-tag-present` must reject a record already carrying an `RX` tag,
+/// on both the cutover binary and (where available) the baseline binary, with
+/// the same error substring.
+#[test]
+fn cutover_fail_if_tag_present_rejects_existing_rx() {
+    let dir = TempDir::new().expect("create temp dir");
+    let input = write_input(dir.path(), &overwrite_records());
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let err = run_copy_umi(current_bin, &input, &current_out, &["--fail-if-tag-present"])
+        .expect_err("--fail-if-tag-present must reject a pre-existing RX tag");
+    assert!(
+        err.contains("already has an RX tag"),
+        "expected the fail-if-tag-present error to name the reason; got: {err}"
+    );
+
+    // Output-state half of the contract (stderr is the other half): the rejection
+    // aborts the run mid-stream, so the chain builder documents it leaves a partial
+    // BAM. Pin that — the writer must not have finalized the BGZF stream, and must
+    // not have published a complete copy of the input (which would mean the output
+    // path silently ignored --fail-if-tag-present even though stderr reported it).
+    let current_state = failed_output_state(&current_out);
+    assert!(
+        current_state.exists,
+        "a failed copy-umi run must leave its (partial) output path behind, not remove it"
+    );
+    assert!(
+        !current_state.finalized,
+        "a failed copy-umi run must not finalize the BGZF stream (a partial BAM is \
+         expected); {} ends with the BGZF EOF marker",
+        current_out.display()
+    );
+    assert!(
+        current_state.recovered_records < overwrite_records().len(),
+        "a --fail-if-tag-present rejection must not publish a complete output; recovered \
+         {} of {} records",
+        current_state.recovered_records,
+        overwrite_records().len()
+    );
+
+    if let Some(baseline_bin_path) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let baseline_err =
+            run_copy_umi(&baseline_bin_path, &input, &baseline_out, &["--fail-if-tag-present"])
+                .expect_err("baseline binary must also reject a pre-existing RX tag");
+        assert!(
+            baseline_err.contains("already has an RX tag"),
+            "baseline binary's --fail-if-tag-present error differs; got: {baseline_err}"
+        );
+        // Parity extends to the partial BAM the aborted run leaves behind, not just
+        // the error message: the cutover must leave the same post-failure output
+        // state (existence, finalization, surviving record count) as the frozen
+        // pre-cutover binary.
+        assert_eq!(
+            failed_output_state(&baseline_out),
+            current_state,
+            "cutover and baseline must leave the same post-failure output state"
+        );
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_fail_if_tag_present_rejects_existing_rx: \
+             FGUMI_BASELINE_BIN is unset or does not name an existing file"
+        );
+    }
+}
+
+/// `failed_output_state` must stay total for every shape an aborted run can leave
+/// — including a zero-byte or header-truncated output — rather than panicking in
+/// `recover_records_lenient`. `failed_output_state` is the value both sides of the
+/// baseline-parity `assert_eq!` need, so a panic here would take the whole parity
+/// comparison down, not just the record count.
+#[rstest]
+#[case::empty(&[])]
+#[case::truncated_header(b"BAM\x01\x00\x00")]
+#[case::garbage(b"not a bam at all")]
+fn failed_output_state_is_total_on_partial_output(#[case] bytes: &[u8]) {
+    let dir = TempDir::new().expect("create temp dir");
+    let path = dir.path().join("partial.bam");
+    std::fs::write(&path, bytes).expect("write partial output");
+
+    // No panic, and the header-less shape reports the expected comparable state:
+    // the file exists, the stream was never finalized, and no complete record
+    // survived.
+    let state = failed_output_state(&path);
+    assert_eq!(
+        state,
+        FailedOutputState { exists: true, finalized: false, recovered_records: 0 },
+        "a zero-byte / truncated-header partial output must yield a comparable \
+         header-less state, not a panic"
+    );
+}
+
+// ============================================================================
+// Custom `--field-delimiter`.
+// ============================================================================
+
+#[test]
+fn cutover_custom_field_delimiter_matches_baseline_and_self_consistency() {
+    let dir = TempDir::new().expect("create temp dir");
+    let records: Vec<RawRecord> = [("read0", "ACGT"), ("read1", "rAAAA+CCCC")]
+        .iter()
+        .map(|(prefix, raw)| record_named(&format!("{prefix}_{raw}")))
+        .collect();
+    let input = write_input(dir.path(), &records);
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    run_copy_umi(current_bin, &input, &current_out, &["--field-delimiter", "_"])
+        .expect("current binary copy-umi (custom delimiter) should succeed");
+
+    let name_rx = read_name_and_rx(dir.path(), &current_out);
+    assert_eq!(
+        name_rx,
+        vec![
+            ("read0_ACGT".to_string(), Some("ACGT".to_string())),
+            ("read1_rAAAA+CCCC".to_string(), Some("TTTT-CCCC".to_string())),
+        ],
+        "a `_`-delimited last field must be located and normalized identically to `:`"
+    );
+
+    // Full-record oracle (always on): only name + RX change under a custom delimiter.
+    assert_alignment_fields_preserved(&input, &current_out);
+
+    if let Some(baseline_bin_path) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        run_copy_umi(&baseline_bin_path, &input, &baseline_out, &["--field-delimiter", "_"])
+            .expect("baseline binary copy-umi (custom delimiter) should succeed");
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "custom-field-delimiter output diverges from the baseline binary after stripping @PG"
+        );
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_custom_field_delimiter_matches_baseline_and_self_consistency: \
+             FGUMI_BASELINE_BIN is unset or does not name an existing file"
+        );
+    }
+}


### PR DESCRIPTION
## What

Retire the legacy single-threaded `fgumi copy-umi` path so the declarative chain builder is the **only** execution path. `execute()` keeps its reader-free pre-flight validation and then always dispatches to the chain (`Stage::CopyUmi`), with or without `--threads`. Deleted `CopyUmi::run_single_threaded` and its now-dead serial-only imports. Output is byte-identical (modulo `@PG`).

## Parity analysis (done before deleting)

Every diagnostic the serial path emitted is already produced by the chain (`ChainBuilder::add_copy_umi` + its finalize hooks): the `Starting copy-umi`/Input/Output banner, `OperationTimer`, the periodic progress heartbeat, the `=== Summary ===` block + overwrite warning (shared `warn_and_log_copy_umi_summary`), the `--metrics` TSV (shared `write_copy_umi_metrics`), and `@HD`/`@PG` handling. `CollectedCopyUmiMetrics` is retained — the chain finalize hooks use it. Nothing needed adding.

## Error-diagnostic parity restored

Deleting the serial path made the chain the only path, and the chain step converted the UMI-normalization `anyhow::Error` with `io::Error::other`, whose `Display` renders only anyhow's top context — so a malformed-name failure lost its inner cause (e.g. `illegal character 'K'`) on the **default** no-`--threads` invocation, which previously showed it. Fixed by flattening the full cause chain before it crosses the `io::Error` boundary (`io::Error::other(format!("{e:#}"))`). Verified against the frozen baseline binary: the no-`--threads` chain error now carries the same `extracting UMI from read name '…'` context **and** the inner `Invalid UMI '…' (illegal character '…')` cause. The `errors_on_malformed_name` and two-level fail-fast tests assert both levels again.

## Tests

- `tests/integration/test_copy_umi_cutover_parity.rs` — pins the no-`--threads` chain output against the frozen pre-removal serial baseline via `FGUMI_BASELINE_BIN` (records byte-identical modulo `@PG`, plus the `--metrics` TSV) across default / `--remove-umi` / `--reverse-complement-r-umis` / combined, RX-overwrite + `--fail-if-tag-present` rejection, and a custom `--field-delimiter`. When `FGUMI_BASELINE_BIN` is unset (default CI), the self-consistency oracle asserts the exact copied `RX` values (e.g. `rAAAA+CCCC` → `TTTT-CCCC`, from `read_name`'s own unit tests) — a passthrough or a dropped reverse-complement/strip step fails it.
- The `serial`/`oracle` two-path framing in `test_copy_umi_command.rs` (case labels, function names, locals) is renamed to thread-count-consistency wording, since there is now one path exercised at different worker counts.
- Shared fixture helpers moved to `tests/integration/helpers/copy_umi_fixtures.rs`; the `--metrics` TSV is now read via the typed `fgumi_metrics` reader against `CopyUmiMetric` rather than hand-parsed.

Full gate green: `cargo check` in all three feature configs (default, `--all-features`, `--no-default-features`), `ci-fmt`/`ci-lint`/`ci-doc`, and `ci-test` (9994 passed / 31 skipped) both with and without `FGUMI_BASELINE_BIN` set proving byte-parity. Part of the per-command R6-0 legacy-path retirements; no user-facing behavior change (no-`--threads` now runs the chain at a single worker).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes only in `copy-umi`, pinned by frozen-baseline and parity tests; grouping, consensus, sort order, and corrected UMIs: none; `unsafe`: none, and `CLAUDE.md` needs no update; memory bounds, queue capacity, and backpressure: none; thread policy changes because all runs use the chain configuration.

- Removed the legacy serial `copy-umi` path.
- Routed all execution through `Stage::CopyUmi`.
- Preserved diagnostics, metrics, output, and `@HD`/`@PG` handling.
- Preserved complete UMI-normalization cause chains across the `io::Error` boundary.
- Added coverage for parity, RX transformations, errors, options, CRC handling, malformed records, headers, metrics, and thread counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->