### PR TITLE
refactor(dedup,group): retire the legacy single-threaded paths; the chain is the only path

### DIFF
--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -19,43 +19,33 @@
 
 use std::io;
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::assigner::{PairedUmiAssigner, Strategy, UmiAssigner};
-use crate::grouper::{RawPositionGroup, RecordPositionGrouper, build_templates_from_records};
-use crate::logging::OperationTimer;
+use crate::grouper::{RawPositionGroup, build_templates_from_records};
 use crate::metrics::group::FamilySizeMetrics;
 use crate::metrics::{DeduplicationCounts, DeduplicationMetrics, DuplicationLadderMetrics};
 use crate::metrics::{TemplateFilterCounts, TemplateFilterReason};
 use crate::read_info::LibraryIndex;
 use crate::sam::SamTag;
-use crate::sam::is_template_coordinate_sorted;
 use crate::template::Template;
 use crate::template_filter::{
     TemplateFilterConfig, filter_template, template_has_malformed_record,
     template_is_fully_unmapped,
 };
-use crate::unified_pipeline::{
-    BatchWeight, GroupKeyConfig, Grouper, MemoryEstimate,
-    run_bam_pipeline_from_reader_with_mi_assign,
-};
+use crate::unified_pipeline::{BatchWeight, MemoryEstimate};
 use ahash::AHashMap;
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
-use fgumi_bam_io::create_bam_reader_for_pipeline_with_opts;
 use fgumi_umi::IndexThreshold;
 
 use log::info;
 use noodles::sam::Header;
-use noodles::sam::alignment::record::data::field::Tag;
-use parking_lot::Mutex;
 
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    build_pipeline_config, is_r1_genomically_earlier_raw,
+    is_r1_genomically_earlier_raw,
 };
 use crate::sam::TC_TAG;
 use fgumi_raw_bam;
@@ -250,11 +240,8 @@ pub(crate) fn resolve_sample(header: &Header, override_sample: Option<&str>) -> 
 
 /// Metrics collected per position group, aggregated after pipeline completion.
 ///
-/// The single aggregator shape for both dedup paths: `Dedup::execute` reduces
-/// one shared `Mutex`-guarded instance, and the chain's `DedupFinalizeHook`
-/// reduces per-thread slots of it (aliased as `CollectedDedupMetrics`). Keeping
-/// one type guarantees the two paths cannot emit different metric fields for the
-/// same input.
+/// The chain's `DedupFinalizeHook` reduces per-thread slots of this type
+/// (aliased as `CollectedDedupMetrics`).
 #[derive(Default, Debug)]
 pub(crate) struct CollectedDedupCounts {
     /// Dedup-specific counts, aggregated per library (keyed by
@@ -279,14 +266,14 @@ pub(crate) struct CollectedDedupCounts {
 /// A saturation curve plots "after N templates processed, in coordinate
 /// order, what cumulative fraction were duplicates" — so [`Self::record`]
 /// MUST be called in strict serial/coordinate order, one call per position
-/// group. It is wired into the `mi_assign_fn` hook installed on the pipeline
-/// (`run_bam_pipeline_from_reader_with_mi_assign`), which the pipeline
-/// harness runs in serial order by the MI Assign zone before each item's
-/// `serialize_fn`. `dedup` installs this hook unconditionally — not gated on
+/// group. It is wired into the chain's `MiAssignDedup` step (see
+/// `pipeline::chains::commands::dedup::build_mi_assign_step`), which the
+/// pipeline runs in serial order by the MI Assign zone before each item's
+/// serialize step. `dedup` installs this hook unconditionally — not gated on
 /// `--no-umi`, strategy, or any other flag — so it runs for every position
 /// group in every mode, making it the correct accumulation point. Do NOT
-/// accumulate this in `serialize_fn`: that closure also runs once per group,
-/// but workers execute it in parallel completion order, not coordinate order.
+/// accumulate this in the serialize step: that also runs once per group, but
+/// workers execute it in parallel completion order, not coordinate order.
 #[derive(Default)]
 pub(crate) struct DuplicationLadderRecorder {
     /// Snapshot interval in cumulative templates (`--ladder-interval`).
@@ -1328,6 +1315,9 @@ pub struct MarkDuplicates {
 }
 
 impl Command for MarkDuplicates {
+    /// Execute the tool. After reader-free pre-flight validation, this always
+    /// dispatches to `execute_chain` — the declarative chain builder is the
+    /// only execution path.
     fn execute(&self, command_line: &str) -> Result<()> {
         // Reject two outputs resolving to one destination before any writer opens.
         let mut outputs: Vec<(&std::path::Path, &str)> =
@@ -1353,22 +1343,11 @@ impl Command for MarkDuplicates {
             bail!("--no-umi cannot be used with --strategy paired");
         }
 
-        // Handle --no-umi mode: force identity strategy. The effective-strategy
-        // computation itself must run on both paths (validate_index_threshold
-        // below consumes it), but the override log is gated to the non-chain
-        // path: the --threads chain re-emits it via add_dedup, so logging here
-        // too would double-log.
-        let (effective_strategy, no_umi_edits_override) = if self.no_umi {
-            if !matches!(self.strategy, Strategy::Identity) && self.threading.threads.is_none() {
-                info!("--no-umi mode: overriding strategy to identity");
-            }
-            (Strategy::Identity, true)
-        } else {
-            (self.strategy, false)
-        };
-
-        // Identity strategy requires edits=0, others use the configured value
-        // Also force edits=0 in no-umi mode
+        // Resolve the effective strategy/edits (identity forces edits=0; `--no-umi`
+        // forces identity) purely to validate `--index-threshold` below. The
+        // override notice itself is logged once, by `add_dedup`.
+        let (effective_strategy, no_umi_edits_override) =
+            if self.no_umi { (Strategy::Identity, true) } else { (self.strategy, false) };
         let effective_edits =
             if no_umi_edits_override || matches!(effective_strategy, Strategy::Identity) {
                 0
@@ -1387,369 +1366,37 @@ impl Command for MarkDuplicates {
         // Validate the input exists (stdin paths are exempt).
         self.io.validate()?;
 
-        // --threads N: run the dedup stage on the declarative chain builder.
-        // Dispatch here — after the reader-free pre-flight validations above
-        // (output collisions, strategy/min-umi combos, index-threshold,
-        // input existence), which must run for both paths — but BEFORE the
-        // timer/banner/reader below. `execute_chain` → `add_dedup` re-emits the
-        // timer, banner, and threading log lines and opens its own source, so
-        // running them here too would double-log and pre-consume stdin
-        // (breaking stdin + --threads). The no-`--threads` path keeps the
-        // hand-rolled unified pipeline below.
-        if self.threading.threads.is_some() {
-            return self.execute_chain(command_line);
-        }
-
-        let min_mapq: u8 = self.min_map_q.unwrap_or(0);
-
-        let timer = OperationTimer::new("Marking duplicates");
-
-        info!("Starting dedup");
-        info!("Input: {}", self.io.input.display());
-        info!("Output: {}", self.io.output.display());
-        info!("Strategy: {effective_strategy:?}");
-        info!("Edits: {effective_edits}");
-        info!("Remove duplicates: {}", self.remove_duplicates);
-        if self.no_umi {
-            info!("No-UMI mode: deduplicating by position only");
-        }
-        crate::commands::common::log_index_threshold(
-            effective_strategy,
-            effective_edits,
-            self.index_threshold,
-        );
-        info!("{}", self.threading.log_message());
-        self.io.log_effective_check_crc();
-
-        // Open input BAM
-        let reader_opts = self.io.pipeline_reader_opts();
-        let (reader, header) =
-            create_bam_reader_for_pipeline_with_opts(&self.io.input, reader_opts)?;
-
-        if !is_template_coordinate_sorted(&header) {
-            bail!(
-                "Input BAM must be template-coordinate sorted (header must advertise \
-                 SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
-                 To prepare your BAM file, run:\n  \
-                 fgumi zipper -i mapped.bam -u unmapped.bam -r reference.fa -o merged.bam\n  \
-                 fgumi sort -i merged.bam -o sorted.bam --order template-coordinate"
-            );
-        }
-        info!("Template-coordinate sorted");
-
-        // Add @PG record
-        let header = crate::commands::common::add_pg_record(header, command_line)?;
-
-        // Tag constants per SAM specification
-        let raw_tag = SamTag::RX;
-        let cell_tag = Tag::from(SamTag::CB);
-        let assign_tag_bytes: [u8; 2] = *SamTag::MI;
-
-        let filter_config = TemplateFilterConfig {
-            umi_tag: *raw_tag,
-            min_mapq,
-            include_non_pf: self.include_non_pf_reads,
-            min_umi_length: self.min_umi_length,
-            no_umi: self.no_umi,
-            // Always false: --include-unmapped splits no-mapped-read templates off
-            // *before* the filter runs (see `template_is_unmapped_passthrough`), so
-            // an unmapped template reaching the filter is always a rejection.
-            allow_unmapped: false,
-        };
-
-        // Shared state for collecting metrics
-        let collected_metrics: Arc<Mutex<CollectedDedupCounts>> =
-            Arc::new(Mutex::new(CollectedDedupCounts::default()));
-
-        // Clone values needed by closures
-        let strategy = effective_strategy;
-        let index_threshold = self.index_threshold;
-        let min_umi_length = self.min_umi_length;
-        let no_umi = self.no_umi;
-        let include_unmapped = self.include_unmapped;
-        let remove_duplicates = self.remove_duplicates;
-        let collected_metrics_clone = Arc::clone(&collected_metrics);
-
-        // Configure pipeline
-        let num_threads = self.threading.num_threads();
-        let mut pipeline_config = build_pipeline_config(
-            &self.scheduler_opts,
-            &self.compression,
-            &self.queue_memory,
-            &self.io,
-            num_threads,
-        )?;
-        info!("Scheduler: {:?}", self.scheduler_opts.strategy());
-        info!("Using pipeline with {num_threads} threads");
-
-        let library_index = LibraryIndex::from_header(&header);
-        // `GroupKeyConfig::new` takes `library_index` by value; keep a clone so
-        // the metrics writer can still map `library_idx -> name` after the
-        // pipeline consumes the original.
-        let library_index_for_metrics = library_index.clone();
-        // Resolve the metrics `sample` value now, while `header` is still
-        // available — the pipeline consumes `header` by value below.
-        let sample_for_metrics = resolve_sample(&header, self.sample.as_deref());
-        // Cache the UMI tag's value position on each DecodedRecord so the
-        // Process step's UMI-assignment pass can slice the value without
-        // re-scanning aux data (issue #334). In `--no-umi` mode the
-        // assignment site emits `String::new()` and never reads the cache,
-        // so populating it during decode would be pure overhead.
-        let group_key_config = GroupKeyConfig::new(library_index, cell_tag);
-        pipeline_config.group_key_config = Some(if self.no_umi {
-            group_key_config
-        } else {
-            group_key_config.with_umi_tag(*raw_tag)
-        });
-
-        // Cumulative MoleculeId counter, advanced **only** by the
-        // serial-ordered MI Assign hook installed below. Mirrors the
-        // pattern used by `fgumi group`; see
-        // `docs/design/deterministic-mi-numbering.md` for why this lives
-        // in the hook rather than in `serialize_fn`. The `Arc` is owned
-        // by the hook closure; nothing outside the closure needs to read
-        // its final value.
-        let next_mi_base_for_hook = Arc::new(AtomicU64::new(0));
-
-        // Duplication saturation ladder recorder (--duplication-ladder). `None`
-        // when the flag is off, so the hook below does zero added work
-        // (a single `Option` check, no lock, no allocation) — see the ordering
-        // note on `DuplicationLadderRecorder` for why this must be populated
-        // from the serial MI Assign hook rather than `serialize_fn`.
-        let duplication_ladder_recorder: Option<Arc<Mutex<DuplicationLadderRecorder>>> = self
-            .duplication_ladder
-            .as_ref()
-            .map(|_| Arc::new(Mutex::new(DuplicationLadderRecorder::new(self.ladder_interval))));
-        let duplication_ladder_recorder_for_hook = duplication_ladder_recorder.clone();
-
-        // Run the pipeline
-        let _records_processed = run_bam_pipeline_from_reader_with_mi_assign(
-            pipeline_config,
-            reader,
-            header,
-            &self.io.output,
-            None,
-            // Grouper factory - use with_secondary_supplementary to include all reads.
-            // With --verify, gate on strict template-coordinate order (the factory
-            // receives the header, which supplies library-ordinal mapping for keys).
-            {
-                let verify = self.verify;
-                move |header: &Header| {
-                    let mut grouper = RecordPositionGrouper::with_secondary_supplementary();
-                    if verify {
-                        grouper.enable_verify(header);
-                    }
-                    Box::new(grouper) as Box<dyn Grouper<Group = RawPositionGroup> + Send>
-                }
-            },
-            // Process function (parallel) — builds templates from raw records
-            move |group: RawPositionGroup| -> io::Result<ProcessedDedupGroup> {
-                let assigner = strategy.new_assigner_full(effective_edits, 1, index_threshold);
-                process_position_group(
-                    group,
-                    &filter_config,
-                    assigner.as_ref(),
-                    raw_tag,
-                    min_umi_length,
-                    no_umi,
-                    include_unmapped,
-                )
-            },
-            // Serialize function (parallel, output ordered by serial numbers)
-            move |processed: ProcessedDedupGroup,
-                  _header: &Header,
-                  output: &mut Vec<u8>|
-                  -> io::Result<u64> {
-                // Collect metrics
-                {
-                    let mut agg = collected_metrics_clone.lock();
-                    agg.dedup_counts_by_library
-                        .entry(processed.library_idx)
-                        .or_default()
-                        .merge(&processed.dedup_counts);
-                    for (size, count) in &processed.family_sizes {
-                        *agg.family_sizes.entry(*size).or_insert(0) += count;
-                    }
-                }
-
-                let input_record_count = processed.input_record_count;
-
-                // Templates already carry their final global `MoleculeId`s
-                // because the MI Assign hook (installed below) ran in
-                // serial order before this closure was called, so we pass
-                // `base_mi = 0` to `write_with_offset`.
-                // Pre-allocate output buffer: ~2 records/template × ~400 bytes/record
-                output.reserve(processed.templates.len() * 2 * 400);
-                let mut scratch = Vec::with_capacity(512);
-                let mut mi_buf = String::with_capacity(16);
-                for template in &processed.templates {
-                    let mi = template.mi;
-                    let has_mi = mi.is_assigned();
-                    if has_mi {
-                        mi.write_with_offset(0, &mut mi_buf);
-                    }
-                    for raw in template.records() {
-                        // Skip duplicates if remove mode
-                        if remove_duplicates
-                            && (RawRecordView::new(raw).flags() & DUPLICATE_FLAG) != 0
-                        {
-                            continue;
-                        }
-                        if has_mi {
-                            scratch.clear();
-                            scratch.extend_from_slice(raw);
-                            fgumi_raw_bam::update_string_tag(
-                                &mut scratch,
-                                assign_tag_bytes,
-                                mi_buf.as_bytes(),
-                            );
-                            let block_size = scratch.len() as u32;
-                            output.extend_from_slice(&block_size.to_le_bytes());
-                            output.extend_from_slice(&scratch);
-                        } else {
-                            let block_size = raw.len() as u32;
-                            output.extend_from_slice(&block_size.to_le_bytes());
-                            output.extend_from_slice(raw);
-                        }
-                    }
-                }
-
-                Ok(input_record_count)
-            },
-            // mi_assign_fn: called in serial order by the MI Assign zone
-            // before each item's `serialize_fn`. Folds a cumulative offset
-            // into every template's local `MoleculeId`. Advances the counter
-            // by `distinct_mi_count` so the offset matches what `serialize_fn`
-            // emits even when families contain multiple templates.
-            //
-            // `fetch_update` + `checked_add` so wraparound is detected and surfaced
-            // rather than silently reusing MI integers (which would defeat
-            // `MoleculeId::with_offset`'s own overflow check on the per-template add).
-            move |_ord, processed: &mut ProcessedDedupGroup| {
-                let base = next_mi_base_for_hook
-                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-                        current.checked_add(processed.distinct_mi_count)
-                    })
-                    .map_err(|_| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            "MoleculeId offset overflow: cumulative MI counter exceeded u64::MAX",
-                        )
-                    })?;
-                for template in &mut processed.templates {
-                    template.mi = template.mi.with_offset(base);
-                }
-
-                // Accumulate the duplication saturation ladder here, in this
-                // same serial/coordinate-order hook — not in `serialize_fn`,
-                // which runs in parallel completion order. See the ordering
-                // note on `DuplicationLadderRecorder`. `dedup_counts` belongs
-                // entirely to `processed.library_idx` (a position group is
-                // always single-library).
-                if let Some(recorder) = &duplication_ladder_recorder_for_hook {
-                    recorder.lock().record(processed.library_idx, &processed.dedup_counts);
-                }
-
-                Ok(())
-            },
-        )?;
-
-        // Aggregate metrics
-        let aggregated = Arc::try_unwrap(collected_metrics)
-            .expect("bug: metrics Arc still shared after pipeline join")
-            .into_inner();
-        let final_counts_by_library = aggregated.dedup_counts_by_library;
-        let final_family_sizes = aggregated.family_sizes;
-
-        // Total across all libraries: used both for the summary log / `tc`-tag
-        // check below and as the metrics file's aggregate "All Reads" row.
-        let mut final_counts = DedupCounts::default();
-        for library_counts in final_counts_by_library.values() {
-            final_counts.merge(library_counts);
-        }
-
-        // Write metrics file
-        if let Some(metrics_path) = &self.metrics {
-            write_dedup_metrics(
-                &final_counts_by_library,
-                &final_counts,
-                &library_index_for_metrics,
-                &sample_for_metrics,
-                metrics_path,
-            )?;
-        }
-
-        // Write family size histogram
-        if let Some(histogram_path) = &self.family_size_histogram {
-            write_family_size_histogram(&final_family_sizes, histogram_path)?;
-        }
-
-        // Write duplication saturation ladder
-        if let Some(path) = &self.duplication_ladder {
-            let mut recorder = Arc::try_unwrap(duplication_ladder_recorder.expect(
-                "bug: duplication_ladder_recorder must be Some when --duplication-ladder is set",
-            ))
-            .unwrap_or_else(|_| {
-                panic!("bug: duplication ladder recorder Arc still shared after pipeline join")
-            })
-            .into_inner();
-            recorder.finish();
-            write_duplication_ladder(&recorder, &library_index_for_metrics, path)?;
-        }
-
-        // Log summary
-        info!(
-            "Deduplication complete: {} templates ({} unique, {} duplicates, {:.2}% duplicate rate)",
-            final_counts.total_templates,
-            final_counts.unique_templates,
-            final_counts.duplicate_templates,
-            final_counts.duplicate_rate() * 100.0
-        );
-
-        if final_counts.missing_tc_tag > 0 {
-            bail!(
-                "{} secondary/supplementary reads are missing the `tc` tag.\n\n\
-                The `tc` tag is required for correct UMI-aware deduplication of \
-                secondary and supplementary alignments. This tag is added by \
-                `fgumi zipper` during the merge of unmapped and mapped BAMs.\n\n\
-                To fix this, re-run your pipeline starting from `fgumi zipper`:\n  \
-                fgumi zipper -i aligned.bam --unmapped unmapped.bam -r reference.fa -o merged.bam\n  \
-                fgumi sort -i merged.bam -o sorted.bam --order template-coordinate\n  \
-                fgumi dedup -i sorted.bam -o deduped.bam",
-                final_counts.missing_tc_tag
-            );
-        }
-
-        log_filtered_templates(&final_counts.filter_counts);
-
-        timer.log_completion(final_counts.total_reads);
-
-        Ok(())
+        // Run the dedup stage on the declarative chain builder — the only
+        // execution path. Dispatch after the reader-free pre-flight validations
+        // above (output collisions, strategy/min-umi combos, index-threshold,
+        // input existence); `execute_chain` opens its own source and re-emits
+        // the timer, banner (Starting/Input/Output/Strategy/Edits/etc.), and
+        // threading log lines via `add_dedup`. One line the retired
+        // `unified_pipeline` path logged and `add_dedup` does not is
+        // `Scheduler: <strategy>` — the chain has no equivalent per-pipeline
+        // scheduler-strategy diagnostic; this is a pre-existing chain gap
+        // (already true of every other `--threads N` dedup run before this
+        // change), not something this cutover newly drops.
+        self.execute_chain(command_line)
     }
 }
 
 impl MarkDuplicates {
-    /// Run the dedup stage on the declarative chain builder (the `--threads N`
-    /// path).
+    /// Run the dedup stage on the declarative chain builder — the only
+    /// execution path for `dedup`.
     ///
-    /// Replaces the hand-rolled unified-pipeline construction in `execute` for
-    /// the threaded case. The chain opens its own source, validates the
-    /// template-coordinate sort order, injects `@PG`, assigns `MoleculeId`s
-    /// deterministically, writes the output BAM, and writes the metrics /
-    /// family-size histogram / duplication ladder via its finalize hook — all
-    /// through the same shared helpers as the non-chain path, so the two
-    /// orchestrations stay in parity. The no-`--threads` path keeps its own
-    /// unified pipeline in `execute`, which is the in-process parity oracle for
-    /// this one (see `test_dedup_chain_matches_single_threaded`).
+    /// The chain opens its own source, validates the template-coordinate sort
+    /// order, injects `@PG`, assigns `MoleculeId`s deterministically, writes
+    /// the output BAM, and writes the metrics / family-size histogram /
+    /// duplication ladder via its finalize hook.
     fn execute_chain(&self, command_line: &str) -> Result<()> {
         use crate::pipeline::chains::{
             ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
         };
 
         // `add_dedup` re-emits the timer/banner/threading log lines but not the
-        // CRC-verify status; emit it here so the --threads path reports it once,
-        // matching the non-chain path. (dedup has no memory-debug knobs, so
-        // unlike group there is no warn block to add here.)
+        // CRC-verify status; emit it here so it is reported once. (dedup has no
+        // memory-debug knobs, so unlike group there is no warn block to add here.)
         self.io.log_effective_check_crc();
 
         let stage_opts = StageOptionsBag { dedup: Some(self.clone()), ..Default::default() };
@@ -1839,12 +1486,8 @@ pub(crate) fn write_family_size_histogram(
     Ok(())
 }
 
-/// Writes the `--duplication-ladder` TSV: one row per (library, snapshot),
-/// sorted deterministically by library name then ascending `templates_seen`.
 /// Log the "Filtered out N templates before marking" diagnostic, if any were
-/// rejected. Called by both the non-chain `execute` tail and the chain's
-/// `DedupFinalizeHook` so `--threads` and no-`--threads` report filtered
-/// templates identically.
+/// rejected. Called by the chain's `DedupFinalizeHook`.
 ///
 /// `--metrics` is optional, so this must not be the only channel reporting
 /// dropped templates: a run that filters everything otherwise logs a bare
@@ -1864,6 +1507,8 @@ pub(crate) fn log_filtered_templates(filter_counts: &TemplateFilterCounts) {
     }
 }
 
+/// Writes the `--duplication-ladder` TSV: one row per (library, snapshot),
+/// sorted deterministically by library name then ascending `templates_seen`.
 pub(crate) fn write_duplication_ladder(
     recorder: &DuplicationLadderRecorder,
     library_index: &LibraryIndex,
@@ -1894,11 +1539,8 @@ pub(crate) fn write_duplication_ladder(
 // Tests
 //////////////////////////////////////////////////////////////////////////////
 
-/// Metrics collected per position group, aggregated after pipeline completion.
-///
-/// The chain finalize hook's aggregator is the same shape as the non-chain
-/// path's; alias the two so a metric field added to one is shared by both (they
-/// differ only in the reduction site — per-thread slots vs one shared `Mutex`).
+/// Alias for [`CollectedDedupCounts`] under the name the chain finalize hook
+/// (`DedupFinalizeHook`) uses for its per-thread accumulator slots.
 pub(crate) use self::CollectedDedupCounts as CollectedDedupMetrics;
 
 /// A batch of `ProcessedDedupGroup`s carrying a monotonic ordinal so the

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -6,35 +6,19 @@ use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
     is_r1_genomically_earlier_raw,
 };
-use crate::grouper::{RawPositionGroup, RecordPositionGrouper, build_templates_from_records};
-use crate::logging::{OperationTimer, log_umi_grouping_summary};
 use crate::metrics::TemplateFilterCounts;
 use crate::metrics::group::UmiGroupingMetrics;
-use crate::read_info::LibraryIndex;
-use crate::sam::SamTag;
 use crate::template::Template;
-use crate::template_filter::{TemplateFilterConfig, filter_template};
 use crate::umi::parallel_assigner::{
     ParallelAdjacencyAssigner, ParallelEditAssigner, ParallelIdentityAssigner,
     ParallelPairedAssigner,
 };
-use crate::unified_pipeline::DecodedRecord;
-use crate::unified_pipeline::Grouper;
-use crate::unified_pipeline::compute_group_key_from_raw;
 use ahash::AHashMap;
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
-use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::{
-    PipelineReaderOpts, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
-    create_raw_bam_reader_from_stream_with_opts,
-};
-use fgumi_raw_bam::RawRecord;
 use fgumi_umi::IndexThreshold;
 use log::{info, warn};
-use noodles::sam::Header;
-use noodles::sam::alignment::record::data::field::Tag;
 use std::path::{Path, PathBuf};
 
 // UmiGroupingMetrics and FamilySizeMetrics are imported from crate::metrics
@@ -188,9 +172,9 @@ fn parallel_threshold(strategy: Strategy, opt: &ParallelMinTemplates) -> usize {
 
 /// Decide whether a position group should use the parallel UMI assigner.
 ///
-/// Shared by the streaming pipeline path (`Command::execute`) and the
-/// single-threaded path (`process_and_write_position_group`) so the two stay
-/// in lockstep. Two independent triggers enable the parallel path:
+/// Used by the chain builder's group process step (see
+/// `pipeline::chains::commands::group`). Two independent triggers enable the
+/// parallel path:
 ///
 /// 1. `allow_unmapped` is set (the `--allow-unmapped` flag). Such workflows
 ///    (e.g. ribosome display) are essentially all-unmapped reads forming one
@@ -212,13 +196,12 @@ pub(crate) fn should_use_parallel(
 
 /// Construct a UMI assigner, choosing between the parallel and sequential
 /// variants based on `use_parallel`. Centralizes the four-arm strategy match
-/// shared by `Command::execute` (streaming pipeline path) and
-/// `process_and_write_position_group` (single-threaded path).
+/// used by the chain builder's group process step.
 ///
 /// A parallel assigner is only built when `num_threads > 1`: a one-thread rayon
 /// pool delivers no parallelism while still paying pool-construction overhead,
-/// so `--threads 1` and `execute_single_threaded` (which passes `threads = 1`)
-/// always fall back to the sequential assigner regardless of `use_parallel`.
+/// so `--threads 1` always falls back to the sequential assigner regardless of
+/// `use_parallel`.
 pub(crate) fn create_umi_assigner(
     strategy: Strategy,
     effective_edits: u32,
@@ -841,7 +824,7 @@ impl GroupReadsByUmi {
 
 /// Build [`UmiGroupingMetrics`] from filter metrics and family size counts.
 ///
-/// Shared by both the pipeline and single-threaded execution paths.
+/// Used by the chain builder's group finalize hook.
 pub(crate) fn build_grouping_metrics(
     filter_counts: &TemplateFilterCounts,
     family_size_counter: &AHashMap<usize, u64>,
@@ -885,8 +868,9 @@ pub(crate) fn build_grouping_metrics(
 }
 
 impl Command for GroupReadsByUmi {
-    /// Execute the tool using the 7-step unified pipeline.
-    #[allow(clippy::too_many_lines)]
+    /// Execute the tool. After reader-free pre-flight validation, this always
+    /// dispatches to `execute_chain` — the declarative chain builder is the
+    /// only execution path.
     fn execute(&self, command_line: &str) -> Result<()> {
         // Reject two outputs resolving to one destination before any writer opens
         // (e.g. a `--metrics PREFIX` file, or `-f`/`-g`, landing on `--output`).
@@ -919,7 +903,10 @@ impl Command for GroupReadsByUmi {
             bail!("--no-umi cannot be used with --strategy paired");
         }
 
-        // Handle --no-umi mode: force identity strategy
+        // Handle --no-umi mode: force identity strategy. Logged here rather than
+        // in `add_group`: `execute_chain` passes the chain only the already-
+        // resolved `effective_strategy`/`effective_edits` (via `to_group_options`),
+        // so this override notice has no other place to fire.
         if self.no_umi && !matches!(self.strategy, Strategy::Identity) {
             info!("--no-umi mode: overriding strategy to identity");
         }
@@ -936,133 +923,41 @@ impl Command for GroupReadsByUmi {
         // Validate the input exists (stdin paths are exempt).
         self.io.validate()?;
 
-        // Set minimum mapping quality
-        let min_mapq: u8 = self.resolved_min_map_q();
-
-        // --threads N: run the group stage on the declarative chain builder.
-        // Dispatch BEFORE the timer/banner/reader below: the chain re-emits the
-        // timer and banner via `add_group` and opens its own source, so running
-        // them here too would double-log and pre-consume stdin. CRC-verify status
-        // (which `add_group` does not log) is emitted by `execute_chain` instead.
-        if self.threading.threads.is_some() {
-            return self.execute_chain(command_line);
-        }
-
-        // Initialize tracking infrastructure
-        let timer = OperationTimer::new("Grouping reads by UMI");
-
-        info!("Starting group");
-        info!("Input: {}", self.io.input.display());
-        info!("Output: {}", self.io.output.display());
-        info!("Strategy: {effective_strategy:?}");
-        info!("Edits: {effective_edits}");
-        if self.no_umi {
-            info!("No-UMI mode: grouping by position only");
-        }
-        crate::commands::common::log_index_threshold(
-            effective_strategy,
-            effective_edits,
-            self.index_threshold,
-        );
-        if self.allow_unmapped {
-            info!("Allow unmapped: enabled (unmapped templates will be grouped by UMI only)");
-            warn!(
-                "WARNING: All unmapped reads are placed in a single position group. \
-                 Reads with identical/similar UMIs will be grouped together even if they \
-                 originate from different genomic locations."
-            );
-            if matches!(self.strategy, Strategy::Edit | Strategy::Adjacency | Strategy::Paired) {
-                warn!(
-                    "WARNING: For paired UMIs (e.g., ACGT-TGCA), edit distance is computed \
-                     on the concatenated sequence with dashes removed. With --edits {}, \
-                     only {} mismatch(es) allowed across ALL bases.",
-                    self.edits, self.edits
-                );
-            }
-        }
-
-        // Log threading configuration
-        info!("{}", self.threading.log_message());
-        self.io.log_effective_check_crc();
-
-        // ============================================================
-        // Single-threaded fast path (no --threads flag; --threads N returned
-        // to execute_chain above, before this banner/timer block).
-        // ============================================================
-        // Open input BAM using a streaming-capable reader (required for stdin).
-        info!("Reading input BAM");
-        let reader_opts = self.io.pipeline_reader_opts();
-        let (reader, header) =
-            create_bam_reader_for_pipeline_with_opts(&self.io.input, reader_opts)?;
-
-        // Validate the input's record ordering (template-coordinate, or
-        // query-grouped under --allow-unmapped) and emit the accompanying
-        // info/warn logging. Shared with the chain builder's `add_group` so the
-        // two paths cannot drift — see `require_group_input_ordering`.
-        crate::commands::common::require_group_input_ordering(&header, self.allow_unmapped)?;
-
-        // Add @PG record with PP chaining to input's last program.
-        let header = crate::commands::common::add_pg_record(header, command_line)?;
-
-        // Tag constants per SAM specification — all derived from SamTag.
-        let raw_tag: [u8; 2] = *SamTag::RX;
-        let assign_tag_bytes: [u8; 2] = *SamTag::MI;
-        let cell_tag = Tag::from(SamTag::CB);
-
-        // Create filter configuration.
-        let filter_config = TemplateFilterConfig {
-            umi_tag: raw_tag,
-            min_mapq,
-            include_non_pf: self.include_non_pf_reads,
-            min_umi_length: self.min_umi_length,
-            no_umi: self.no_umi,
-            allow_unmapped: self.allow_unmapped,
-        };
-
-        self.execute_single_threaded(
-            reader,
-            reader_opts.verify_crc,
-            &header,
-            effective_strategy,
-            effective_edits,
-            raw_tag,
-            assign_tag_bytes,
-            cell_tag,
-            &filter_config,
-            &timer,
-        )
+        // Run the group stage on the declarative chain builder — the only
+        // execution path. Dispatch after the reader-free pre-flight validations
+        // above (output collisions, strategy/min-umi combos, index-threshold,
+        // input existence); `execute_chain` opens its own source and re-emits
+        // the timer/banner/threading log lines via `add_group`.
+        self.execute_chain(command_line)
     }
 }
 
 impl GroupReadsByUmi {
-    /// Run the group stage on the declarative chain builder (the `--threads N`
-    /// path).
+    /// Run the group stage on the declarative chain builder — the only
+    /// execution path for `group`.
     ///
-    /// Replaces the former hand-rolled unified-pipeline construction. The chain
-    /// opens its own source, injects `@PG`, validates record ordering, assigns
-    /// `MoleculeId`s deterministically, writes the output BAM, and writes the
-    /// grouping metrics via its finalize hook — all through the same shared
-    /// helpers (`require_group_input_ordering`, `add_pg_record`,
-    /// `write_metrics_for_chain`) as the single-threaded path, so the two
-    /// orchestrations of the group stage stay in parity.
+    /// The chain opens its own source, injects `@PG`, validates record
+    /// ordering, assigns `MoleculeId`s deterministically, writes the output
+    /// BAM, and writes the grouping metrics via its finalize hook, through the
+    /// shared helpers `require_group_input_ordering`, `add_pg_record`, and
+    /// `write_metrics_for_chain`.
     fn execute_chain(&self, command_line: &str) -> Result<()> {
         use crate::pipeline::chains::{
             ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
         };
 
         // The chain's `add_group` re-emits the timer/banner/threading log lines
-        // but not the CRC-verify status; emit it here so the --threads path
-        // reports it once, matching the single-threaded path.
+        // but not the CRC-verify status; emit it here so it is reported once.
         self.io.log_effective_check_crc();
 
         // The chain engine does not carry the legacy unified-pipeline memory
-        // monitor, so the memory-debug knobs the old --threads path honored have
-        // no effect here. Warn rather than silently no-op; FGUMI_PIPELINE_STATS
+        // monitor, so the memory-debug knobs the retired non-chain path honored
+        // have no effect here. Warn rather than silently no-op; FGUMI_PIPELINE_STATS
         // is the chain's equivalent stats hook.
         #[cfg(feature = "memory-debug")]
         if self.debug_memory {
             warn!(
-                "--debug-memory is not supported on the --threads chain path and is ignored; \
+                "--debug-memory is not supported by the chain builder and is ignored; \
                  set FGUMI_PIPELINE_STATS=1 for chain pipeline stats"
             );
         }
@@ -1070,9 +965,7 @@ impl GroupReadsByUmi {
         // feature, so warn about it in every build rather than only when
         // `memory-debug` is compiled in.
         if std::env::var("FGUMI_SHORT_CIRCUIT").is_ok_and(|v| !v.is_empty()) {
-            warn!(
-                "FGUMI_SHORT_CIRCUIT is not supported on the --threads chain path and is ignored"
-            );
+            warn!("FGUMI_SHORT_CIRCUIT is not supported by the chain builder and is ignored");
         }
 
         let stage_opts =
@@ -1088,341 +981,6 @@ impl GroupReadsByUmi {
         let spec = ChainSpec::single_stage(Stage::Group, stage_opts, &ctx);
         build_for(spec)?.run()
     }
-
-    /// Execute in single-threaded mode for `--threads 1`.
-    ///
-    /// This provides a simpler, streaming implementation that avoids pipeline overhead
-    /// while maintaining identical output to the multi-threaded mode.
-    #[allow(clippy::too_many_arguments)]
-    fn execute_single_threaded(
-        &self,
-        reader: Box<dyn std::io::Read + Send>,
-        verify_crc: bool,
-        header: &Header,
-        effective_strategy: Strategy,
-        effective_edits: u32,
-        raw_tag: [u8; 2],
-        assign_tag_bytes: [u8; 2],
-        cell_tag: Tag,
-        filter_config: &TemplateFilterConfig,
-        timer: &OperationTimer,
-    ) -> Result<()> {
-        info!("Using single-threaded mode");
-
-        // Reuse the already-opened reader (required for stdin support) and skip
-        // past the BAM header to reach records. Decode through fgumi-bgzf so
-        // `--no-check-crc` takes effect on this fast path too (#800); raw-byte
-        // mode avoids the noodles decode/encode round-trip (~15% CPU savings).
-        // The re-parsed header is discarded — the caller already holds `header`.
-        let reader_opts = PipelineReaderOpts { verify_crc, ..PipelineReaderOpts::default() };
-        let (mut raw_reader, _skipped_header) =
-            create_raw_bam_reader_from_stream_with_opts(reader, reader_opts)?;
-
-        // Create output writer (single-threaded for strict thread control)
-        let mut writer =
-            create_bam_writer(&self.io.output, header, 1, self.compression.compression_level)?;
-
-        // Build library index for GroupKey computation
-        let library_index = LibraryIndex::from_header(header);
-
-        // Create RecordPositionGrouper (same grouper used in pipeline mode).
-        // With --verify, gate on strict template-coordinate order as records stream.
-        let mut grouper = RecordPositionGrouper::new();
-        if self.verify {
-            grouper.enable_verify(header);
-        }
-
-        // Metrics accumulators (no lock-free queue needed in single-threaded mode)
-        let mut total_filter_counts = TemplateFilterCounts::new();
-        let mut family_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
-        let mut position_group_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
-        let mut next_mi_base: u64 = 0;
-
-        // Progress tracking
-        let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
-
-        // Iterate over all records in raw-byte mode
-        let mut raw_rec = RawRecord::new();
-        loop {
-            let bytes_read = raw_reader.read_record(&mut raw_rec)?;
-            if bytes_read == 0 {
-                break; // EOF
-            }
-
-            // Compute GroupKey directly from raw bytes — no noodles decode needed.
-            // This caller does not need UMI position caching (the group command's
-            // hot path goes through `decode_records`, which threads the umi_tag).
-            let (key, _umi_position) =
-                compute_group_key_from_raw(&raw_rec, &library_index, Some(cell_tag), None);
-            let decoded = DecodedRecord::from_raw_bytes(raw_rec.clone(), key);
-
-            // Feed to RecordPositionGrouper - may emit a completed group
-            if let Some(group) = grouper.add_record(decoded)? {
-                Self::process_and_write_position_group(
-                    group,
-                    filter_config,
-                    effective_strategy,
-                    effective_edits,
-                    self.index_threshold,
-                    1, // Single-threaded mode
-                    self.parallel_group_min_templates.as_ref(),
-                    raw_tag,
-                    assign_tag_bytes,
-                    &mut total_filter_counts,
-                    &mut family_size_counter,
-                    &mut position_group_size_counter,
-                    &mut next_mi_base,
-                    header,
-                    &mut writer,
-                )?;
-            }
-
-            progress.log_if_needed(1);
-        }
-
-        // Finish grouper - emit final group
-        if let Some(final_group) = grouper.finish()? {
-            Self::process_and_write_position_group(
-                final_group,
-                filter_config,
-                effective_strategy,
-                effective_edits,
-                self.index_threshold,
-                1, // Single-threaded mode
-                self.parallel_group_min_templates.as_ref(),
-                raw_tag,
-                assign_tag_bytes,
-                &mut total_filter_counts,
-                &mut family_size_counter,
-                &mut position_group_size_counter,
-                &mut next_mi_base,
-                header,
-                &mut writer,
-            )?;
-        }
-
-        progress.log_final();
-
-        // Finish writer
-        writer.into_inner().finish().context("Failed to finish output BAM")?;
-        info!("Wrote output to {}", self.io.output.display());
-
-        let metrics = build_grouping_metrics(&total_filter_counts, &family_size_counter);
-        log_umi_grouping_summary(&metrics);
-
-        // Write all metrics (individual flags and --metrics prefix)
-        self.write_all_metrics(&metrics, &family_size_counter, &position_group_size_counter)?;
-
-        // Log completion with timing
-        timer.log_completion(metrics.accepted_records);
-
-        info!("group completed successfully");
-        Ok(())
-    }
-
-    /// Process a single position group: build templates, filter, assign UMIs, and write output.
-    /// Used by `execute_single_threaded` for streaming processing.
-    ///
-    /// Operates on raw-byte records end-to-end: zero-allocation filter and direct raw-byte
-    /// MI-tag injection, no noodles decode/encode.
-    #[allow(clippy::too_many_arguments)]
-    fn process_and_write_position_group(
-        group: RawPositionGroup,
-        filter_config: &TemplateFilterConfig,
-        strategy: Strategy,
-        effective_edits: u32,
-        index_threshold: IndexThreshold,
-        threads: usize,
-        parallel_group_min_templates: Option<&ParallelMinTemplates>,
-        raw_tag: [u8; 2],
-        assign_tag_bytes: [u8; 2],
-        total_filter_counts: &mut TemplateFilterCounts,
-        family_size_counter: &mut AHashMap<usize, u64>,
-        position_group_size_counter: &mut AHashMap<usize, u64>,
-        next_mi_base: &mut u64,
-        _header: &Header,
-        writer: &mut fgumi_bam_io::BamWriter,
-    ) -> Result<()> {
-        // Build templates from raw records
-        let all_templates = build_templates_from_records(group.records)?;
-
-        let mut filter_counts = TemplateFilterCounts::new();
-
-        // Filter templates
-        let filtered_templates: Vec<Template> = all_templates
-            .into_iter()
-            .filter(|t| filter_template(t, filter_config, &mut filter_counts))
-            .collect();
-
-        total_filter_counts.merge(&filter_counts);
-
-        if filtered_templates.is_empty() {
-            return Ok(());
-        }
-
-        // Create UMI assigner. See `should_use_parallel` for the full
-        // rationale; this is the equivalent decision on the single-threaded
-        // path, kept in lockstep with the streaming path via the shared helper.
-        let use_parallel = should_use_parallel(
-            filter_config.allow_unmapped,
-            filtered_templates.len(),
-            strategy,
-            parallel_group_min_templates,
-        );
-        let assigner =
-            create_umi_assigner(strategy, effective_edits, index_threshold, threads, use_parallel);
-
-        // Assign UMI groups. A failure means this position group's reads cannot be
-        // grouped at all — an unparseable UMI for the chosen strategy, a missing
-        // `RX` tag, mixed UMI lengths — so fail the run rather than skipping the
-        // group. Skipping silently dropped every read in it while still exiting 0.
-        // Kept in lockstep with the streaming path's equivalent check.
-        let mut templates = filtered_templates;
-        assign_umi_groups_impl(
-            &mut templates,
-            assigner.as_ref(),
-            raw_tag,
-            filter_config.min_umi_length,
-            filter_config.no_umi,
-        )
-        .context("Failed to assign UMI groups")?;
-
-        // Sort templates directly by (MI index, name) - avoids Vec<Vec<Template>> allocation
-        templates.sort_by(|a, b| {
-            let a_idx = a.mi.to_vec_index();
-            let b_idx = b.mi.to_vec_index();
-            a_idx.cmp(&b_idx).then_with(|| a.name.cmp(&b.name))
-        });
-
-        // Count family sizes and position group size in one pass through sorted templates
-        if !templates.is_empty() {
-            let mut current_mi = templates[0].mi.to_vec_index();
-            let mut current_count = 1usize;
-            let mut num_families = 0usize;
-
-            for template in templates.iter().skip(1) {
-                let mi = template.mi.to_vec_index();
-                if mi == current_mi {
-                    current_count += 1;
-                } else {
-                    // Finish previous MI group
-                    if current_mi.is_some() {
-                        *family_size_counter.entry(current_count).or_insert(0) += 1;
-                        num_families += 1;
-                    }
-                    current_mi = mi;
-                    current_count = 1;
-                }
-            }
-            // Don't forget the last group
-            if current_mi.is_some() {
-                *family_size_counter.entry(current_count).or_insert(0) += 1;
-                num_families += 1;
-            }
-
-            if num_families > 0 {
-                *position_group_size_counter.entry(num_families).or_insert(0) += 1;
-            }
-        }
-
-        // Write templates (already sorted by MI, then by name).
-        //
-        // Advance the global MI counter by the number of distinct numeric MoleculeId
-        // IDs actually assigned in this group, not by the template count, so the
-        // emitted MI integers are consecutive 0..N-1 across all position groups
-        // (matching fgbio's `GroupReadsByUmi`; see issue #269). Assigners hand out
-        // numeric IDs 0, 1, 2, ... contiguously, so `max(id) + 1` equals the count.
-        let distinct_mi_count: u64 =
-            templates.iter().filter_map(|t| t.mi.id()).max().map(|max_id| max_id + 1).unwrap_or(0);
-        let base_mi = *next_mi_base;
-        // `checked_add` so wraparound is reported instead of silently reusing MI integers.
-        *next_mi_base = next_mi_base.checked_add(distinct_mi_count).ok_or_else(|| {
-            anyhow::anyhow!("MoleculeId offset overflow: cumulative MI counter exceeded u64::MAX")
-        })?;
-
-        // Raw-byte output: inject MI tag directly into raw bytes, write without noodles.
-        use std::io::Write as _;
-        let mut scratch = Vec::with_capacity(512);
-        let mut mi_buf = String::with_capacity(16);
-        let inner = writer.get_mut();
-        emit_templates_raw_with_mi(
-            &templates,
-            base_mi,
-            assign_tag_bytes,
-            &mut scratch,
-            &mut mi_buf,
-            |bytes| inner.write_all(bytes),
-        )?;
-
-        Ok(())
-    }
-
-    /// Write all metrics files: individual flags and --metrics prefix outputs.
-    ///
-    /// Delegates to [`write_metrics_for_chain`] so the single-threaded path and
-    /// the chain builder's `GroupFinalizeHook` share one implementation and
-    /// cannot emit divergent metrics files (same filenames, order, and labels)
-    /// for the same input.
-    fn write_all_metrics(
-        &self,
-        grouping_metrics: &UmiGroupingMetrics,
-        family_sizes: &AHashMap<usize, u64>,
-        position_group_sizes: &AHashMap<usize, u64>,
-    ) -> Result<()> {
-        write_metrics_for_chain(
-            grouping_metrics,
-            family_sizes,
-            position_group_sizes,
-            self.family_size_histogram.as_deref(),
-            self.grouping_metrics.as_deref(),
-            self.metrics.as_deref(),
-        )
-    }
-}
-
-/// Emit raw-byte primary reads for a batch of templates with MI tags injected.
-///
-/// For each template, if `has_mi` then the raw bytes are copied into `scratch`,
-/// the MI tag is updated in place, and the result is emitted via `emit`; otherwise
-/// the raw bytes are emitted unchanged. Each emitted record is prefixed with a
-/// 4-byte little-endian `block_size`. `mi_buf` and `scratch` are reused across
-/// templates to amortize allocations.
-///
-/// This helper is shared between the threaded-pipeline serialize step and the
-/// single-threaded writer so they can't drift in MI-injection semantics.
-#[allow(clippy::cast_possible_truncation)]
-fn emit_templates_raw_with_mi(
-    templates: &[Template],
-    base_mi: u64,
-    assign_tag_bytes: [u8; 2],
-    scratch: &mut Vec<u8>,
-    mi_buf: &mut String,
-    mut emit: impl FnMut(&[u8]) -> std::io::Result<()>,
-) -> std::io::Result<()> {
-    use fgumi_raw_bam;
-    for template in templates {
-        let mi = template.mi;
-        let has_mi = mi.is_assigned();
-        if has_mi {
-            // write_with_offset clears the buffer before writing.
-            mi.write_with_offset(base_mi, mi_buf);
-        }
-        for raw in [template.r1(), template.r2()].into_iter().flatten() {
-            if has_mi {
-                scratch.clear();
-                scratch.extend_from_slice(raw);
-                fgumi_raw_bam::update_string_tag(scratch, assign_tag_bytes, mi_buf.as_bytes());
-                let block_size = scratch.len() as u32;
-                emit(&block_size.to_le_bytes())?;
-                emit(scratch)?;
-            } else {
-                let block_size = raw.len() as u32;
-                emit(&block_size.to_le_bytes())?;
-                emit(raw)?;
-            }
-        }
-    }
-    Ok(())
 }
 
 /// Write metrics to a TSV file and log the output path.
@@ -1449,9 +1007,9 @@ fn with_extension(prefix: &Path, suffix: &str) -> PathBuf {
 /// Write all group metrics files for the chain-builder finalize hook.
 ///
 /// Called from `GroupFinalizeHook::finalize` with the fully reduced
-/// per-thread accumulators. Mirrors the logic in
-/// `GroupReadsByUmi::write_all_metrics` but takes explicit paths rather than
-/// reading from `&self`.
+/// per-thread accumulators. Takes explicit paths rather than reading from
+/// `&self` so it can be called from the finalize hook, which only has the
+/// resolved `GroupOptions`.
 pub(crate) fn write_metrics_for_chain(
     grouping_metrics: &crate::metrics::group::UmiGroupingMetrics,
     family_sizes: &AHashMap<usize, u64>,
@@ -1501,6 +1059,10 @@ mod tests {
     // Production code now writes metrics via `write_metrics_for_chain` (which
     // imports these itself); the tests still construct them directly.
     use crate::metrics::group::{FamilySizeMetrics, PositionGroupSizeMetrics};
+    // Only the tests below construct raw records/filter configs directly; the
+    // chain builder (`pipeline::chains::commands::group`) imports these itself.
+    use crate::sam::SamTag;
+    use crate::template_filter::{TemplateFilterConfig, filter_template};
 
     /// The `--no-umi` and identity-implies-zero-edits rules, pinned as a table.
     ///
@@ -1924,9 +1486,8 @@ mod tests {
 
     /// Even with `use_parallel = true`, a single worker thread must not build a
     /// parallel assigner: a one-thread rayon pool is pure startup overhead with
-    /// zero parallelism. The `--threads 1` pipeline path and `execute_single_threaded`
-    /// (which passes `threads = 1`) both reach `create_umi_assigner` with
-    /// `num_threads == 1`, so this guards against spawning a useless pool there.
+    /// zero parallelism. The `--threads 1` chain path reaches `create_umi_assigner`
+    /// with `num_threads == 1`, so this guards against spawning a useless pool there.
     #[rstest]
     #[case(Strategy::Identity)]
     #[case(Strategy::Edit)]
@@ -2452,12 +2013,12 @@ mod tests {
     /// carry two `-`-delimited segments, and a single-segment UMI passes every
     /// filter before failing in the assigner.
     ///
-    /// Both execution paths are covered. `--allow-unmapped` forces the threaded
-    /// path (see `should_use_parallel`), which swallowed the error at a different
-    /// call site than the single-threaded path uses.
+    /// Both UMI-assigner variants are covered. `--allow-unmapped` forces the
+    /// parallel assigner (see `should_use_parallel`), which swallowed the error
+    /// at a different call site than the sequential assigner uses.
     #[rstest]
-    #[case::single_threaded(false)]
-    #[case::threaded(true)]
+    #[case::sequential_assigner(false)]
+    #[case::parallel_assigner(true)]
     fn test_umi_assignment_failure_fails_the_run(#[case] force_parallel_path: bool) -> Result<()> {
         // Single-segment UMIs: accepted by every filter, rejected by the paired
         // assigner because it needs `<a>-<b>`.
@@ -2913,14 +2474,13 @@ mod tests {
         Ok(())
     }
 
-    /// Regression test for #285: verify that the per-thread accumulator path
-    /// used in the multi-threaded pipeline produces metrics identical to the
-    /// single-threaded fast path. Runs the same dataset as
-    /// `test_metrics_prefix_writes_all_files` across three threading modes and
-    /// asserts family sizes, grouping metrics, and position-group sizes all
-    /// match.
+    /// Regression test for #285: verify that the per-thread accumulator merge
+    /// produces identical metrics regardless of thread count. Runs the same
+    /// dataset as `test_metrics_prefix_writes_all_files` across three threading
+    /// modes (no `--threads` flag, `--threads 1`, `--threads 4`) and asserts
+    /// family sizes, grouping metrics, and position-group sizes all match.
     #[rstest]
-    #[case::fast_path(ThreadingOptions::none())]
+    #[case::no_threads_flag(ThreadingOptions::none())]
     #[case::pipeline_1(ThreadingOptions::new(1))]
     #[case::pipeline_4(ThreadingOptions::new(4))]
     fn test_metrics_parity_across_threading_modes(
@@ -2981,7 +2541,7 @@ mod tests {
         let (family_path, grouping_path, position_path) =
             metrics_prefix_paths(&paths.metrics_prefix);
 
-        // Family sizes must match the known single-threaded reference exactly.
+        // Family sizes must match the known reference exactly, across all threading modes.
         let family_metrics: Vec<FamilySizeMetrics> = DelimFile::default().read_tsv(&family_path)?;
         assert_eq!(
             family_metrics,
@@ -3019,7 +2579,7 @@ mod tests {
         assert_eq!(grouping[0].discarded_ns_in_umi, 2);
         assert_eq!(grouping[0].discarded_umi_too_short, 0);
 
-        // Position group sizes must match the known single-threaded reference.
+        // Position group sizes must match the known reference, across all threading modes.
         let position_metrics: Vec<PositionGroupSizeMetrics> =
             DelimFile::default().read_tsv(&position_path)?;
         assert_eq!(
@@ -5688,14 +5248,13 @@ mod tests {
         Ok(())
     }
 
-    /// Parameterized test for all threading modes.
-    ///
-    /// Tests:
-    /// - `None`: Single-threaded fast path, no pipeline
-    /// - `Some(1)`: Pipeline with 1 thread
-    /// - `Some(2)`: Pipeline with 2 threads
+    /// Parameterized test for all threading modes. All three run the chain
+    /// builder (the only execution path):
+    /// - `None`: `--threads` omitted, which resolves to 1 worker
+    /// - `Some(1)`: chain pipeline with 1 worker
+    /// - `Some(2)`: chain pipeline with 2 workers
     #[rstest]
-    #[case::fast_path(ThreadingOptions::none())]
+    #[case::no_threads_flag(ThreadingOptions::none())]
     #[case::pipeline_1(ThreadingOptions::new(1))]
     #[case::pipeline_2(ThreadingOptions::new(2))]
     fn test_threading_modes(#[case] threading: ThreadingOptions) -> Result<()> {
@@ -6771,7 +6330,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::fast_path(ThreadingOptions::none())]
+    #[case::no_threads_flag(ThreadingOptions::none())]
     #[case::pipeline_1(ThreadingOptions::new(1))]
     #[case::pipeline_2(ThreadingOptions::new(2))]
     fn test_allow_unmapped_threading_modes(#[case] threading: ThreadingOptions) -> Result<()> {

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -3108,10 +3108,12 @@ impl<'a> ChainBuilder<'a> {
         info!("{}", self.spec.threading.log_message());
         info!("Using pipeline with {num_threads} threads");
 
-        // Record-ordering precondition + info/warn logging, shared verbatim
-        // with `Group::execute` (see `require_group_input_ordering`) so the two
-        // orchestrations of the group stage cannot drift on accepted orders,
-        // error text, or logging.
+        // Record-ordering precondition + info/warn logging
+        // (`require_group_input_ordering`). `group`'s legacy non-chain call
+        // site was retired in the C4 cutover, so the chain is now the only
+        // path that reaches this helper — kept as its own function (rather
+        // than inlined here) so a future second caller cannot drift on
+        // accepted orders, error text, or logging.
         crate::commands::common::require_group_input_ordering(&self.header, group.allow_unmapped)?;
 
         // Tag constants per SAM specification.
@@ -4816,9 +4818,12 @@ impl<'a> ChainBuilder<'a> {
 
         let timer = OperationTimer::new("Marking duplicates");
 
+        // Resolve source path for log messages only (mirrors `add_group`).
+        let input_path = self.resolve_log_input_path();
         let output_path = self.spec.sink.path().clone();
 
         info!("Starting dedup");
+        info!("Input: {}", input_path.display());
         info!("Output: {}", output_path.display());
 
         // Handle --no-umi mode: force identity strategy.

--- a/src/lib/pipeline/chains/commands/dedup.rs
+++ b/src/lib/pipeline/chains/commands/dedup.rs
@@ -268,12 +268,11 @@ pub(crate) fn build_process_step(
 /// monotonically increasing MI offsets to each batch.
 ///
 /// When `ladder_recorder` is `Some`, this step also records the
-/// `--duplication-ladder` saturation curve — per position group, in the same
-/// serial/coordinate-order seam the non-chain path records it (`mi_assign_fn`),
-/// **not** in the parallel serialize step. `MiAssign` is `Serial` +
-/// `ByItemOrdinal`, so batches reach this closure in input-record order and the
-/// groups within a batch are in coordinate order, exactly reproducing the
-/// non-chain per-group stream — see the ordering note on
+/// `--duplication-ladder` saturation curve — per position group, in this
+/// serial/coordinate-order seam, **not** in the parallel serialize step.
+/// `MiAssign` is `Serial` + `ByItemOrdinal`, so batches reach this closure in
+/// input-record order and the groups within a batch are in coordinate order —
+/// see the ordering note on
 /// [`crate::commands::dedup::DuplicationLadderRecorder`].
 ///
 /// `pub(crate)` — consumed only by `ChainBuilder::add_dedup`.

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -26,6 +26,7 @@ mod test_consensus_downsampling;
 mod test_copy_umi_command;
 mod test_correct_command;
 mod test_dedup_command;
+mod test_dedup_cutover_parity;
 mod test_downsample_command;
 #[cfg(feature = "duplex")]
 mod test_duplex_command;
@@ -41,6 +42,7 @@ mod test_fastq_pipeline_memory_backpressure;
 mod test_filter_command;
 mod test_filter_cutover_parity;
 mod test_group_command;
+mod test_group_cutover_parity;
 mod test_group_determinism;
 mod test_input_source_matrix;
 mod test_merge_command;

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -1908,9 +1908,8 @@ fn test_dedup_accepts_index_threshold_never() {
     assert_eq!(duplicates, 4, "two of the three pairs must be marked duplicate: {never:?}");
 }
 
-/// The chain (`--threads N`) dedup path's `Index threshold:` startup banner must
-/// be strategy/edits-aware, matching the non-chain path's
-/// `common::log_index_threshold` wording exactly (see
+/// `dedup`'s `Index threshold:` startup banner must be strategy/edits-aware,
+/// using the shared `common::log_index_threshold` wording exactly (see
 /// `test_index_threshold_log_message` in `commands::common` for the full case
 /// table) -- not the flat `Index threshold: {dedup.index_threshold}` (the raw
 /// `--index-threshold` value, unfloored) the chain path used to emit whenever
@@ -2122,11 +2121,8 @@ fn test_dedup_no_check_crc_accepts_corrupted_crc_on_file_input() {
 }
 
 //////////////////////////////////////////////////////////////////////////////
-// Chain-path (`--threads`) parity tests
-//
-// `dedup --threads N` routes through the declarative chain builder; the
-// no-`--threads` path keeps the hand-rolled unified pipeline and is the
-// in-process oracle these tests diff against.
+// Chain-backed `dedup` path (the only execution path since the C4 cutover):
+// worker-count determinism across `--threads` values.
 //////////////////////////////////////////////////////////////////////////////
 
 /// Read a BAM's records back as decoded `RecordBuf`s, for record-for-record
@@ -2150,29 +2146,28 @@ fn dedup_run(input: &Path, output: &Path, extra: &[&str]) {
         .expect("dedup run failed");
 }
 
-/// The chain (`--threads N`) path produces output records record-for-record
-/// identical to the non-chain (no-`--threads`) path. Run at both `--threads 1`
-/// (the minimal chain engine) and `--threads 4` (genuinely parallel) — dedup's
-/// output is deterministic, so both must equal the single oracle.
+/// The `--threads 4` (genuinely parallel) chain path produces output records
+/// record-for-record identical to the `--threads 1` (single-worker) oracle.
+/// Both worker counts run through the declarative chain — the legacy
+/// single-threaded path is retired — so this pins dedup's cross-worker-count
+/// determinism.
 ///
 /// The fixture uses [`create_duplicate_group_rx_offset`] with a cycling filler
 /// count (0-3) so RX lands at a different aux-data offset from one group to the
 /// next, rather than always at offset 0. This is still a useful structural
-/// check (any divergence between the two engines shows up here), but it does
-/// NOT isolate the UMI-position cache: the non-chain oracle already enables
-/// the same cache unconditionally outside `--no-umi` mode (see
-/// `MarkDuplicates::execute`), so a wrong-offset mis-slice would corrupt both
-/// sides identically and this parity check would still pass; the fixture also
-/// gives every record in a group the SAME UMI under `--strategy identity`, so
-/// the UMI *value* never affects the result either. See
+/// check (any divergence between the two worker counts shows up here), but it
+/// does NOT isolate the UMI-position cache: both worker counts enable the same
+/// cache unconditionally outside `--no-umi` mode (see `MarkDuplicates::execute`),
+/// so a wrong-offset mis-slice would corrupt both sides identically and this
+/// parity check would still pass; the fixture also gives every record in a group
+/// the SAME UMI under `--strategy identity`, so the UMI *value* never affects the
+/// result either. See
 /// [`test_dedup_umi_grouping_correct_with_varied_rx_aux_offsets`] for the
 /// hand-computed, cache-independent check this gap motivates -- and its doc
 /// comment for why no *end-to-end* dedup test can currently isolate the
 /// cache specifically.
-#[rstest]
-#[case::threads_1(&["--threads", "1"])]
-#[case::threads_4(&["--threads", "4"])]
-fn test_dedup_chain_matches_single_threaded(#[case] thread_args: &[&str]) {
+#[test]
+fn test_dedup_threads4_matches_threads1() {
     let temp_dir = TempDir::new().unwrap();
     let input_bam = temp_dir.path().join("input.bam");
 
@@ -2192,33 +2187,31 @@ fn test_dedup_chain_matches_single_threaded(#[case] thread_args: &[&str]) {
     create_sorted_bam(&input_bam, records);
 
     let oracle_out = temp_dir.path().join("oracle.bam");
-    dedup_run(&input_bam, &oracle_out, &["--strategy", "identity"]);
+    dedup_run(&input_bam, &oracle_out, &["--strategy", "identity", "--threads", "1"]);
 
     let chain_out = temp_dir.path().join("chain.bam");
-    let mut chain_args = vec!["--strategy", "identity"];
-    chain_args.extend_from_slice(thread_args);
-    dedup_run(&input_bam, &chain_out, &chain_args);
+    dedup_run(&input_bam, &chain_out, &["--strategy", "identity", "--threads", "4"]);
 
     let expected = read_deduped_records(&oracle_out);
     let actual = read_deduped_records(&chain_out);
     assert!(!expected.is_empty(), "oracle output must be non-empty (guard against a vacuous pass)");
     assert_eq!(
         actual, expected,
-        "chain {thread_args:?} output must match the non-chain path record-for-record"
+        "chain --threads 4 output must match the --threads 1 oracle record-for-record"
     );
 }
 
 /// Cache-discriminating regression test for the UMI-position cache (#334).
 ///
-/// [`test_dedup_chain_matches_single_threaded`] above compares chain vs
-/// non-chain output, but that comparison structurally cannot detect a cache
-/// mis-slice: both paths already enable the UMI-position cache (the
-/// non-chain path unconditionally, outside `--no-umi` mode), so a
+/// [`test_dedup_threads4_matches_threads1`] above compares `--threads 4` vs
+/// `--threads 1` output, but that comparison structurally cannot detect a cache
+/// mis-slice: both worker counts already enable the UMI-position cache
+/// (unconditionally, outside `--no-umi` mode), so a
 /// wrong-offset mis-slice corrupts both sides identically and the two would
 /// still agree; its fixture also gives every record in a group the same UMI
 /// under `--strategy identity`, so the UMI *value* never affects the result.
 /// This test fixes both gaps: it asserts against a CACHE-INDEPENDENT,
-/// hand-computed expectation (not "chain == non-chain"), and it varies the
+/// hand-computed expectation (not "`--threads 4` == `--threads 1`"), and it varies the
 /// UMI *value* across records that share a position, with a varied number of
 /// filler tags before RX per record.
 ///
@@ -2399,24 +2392,24 @@ fn create_chain_parity_group(base: &str, start: i32) -> Vec<RawRecord> {
 }
 
 /// Read a BAM's `@HD` record (declared sort order). The `@PG` command-line field
-/// legitimately differs between the chain and non-chain invocations (different
-/// `--threads` args), so parity checks compare `@HD` rather than the whole header.
+/// legitimately differs between two invocations with different `--threads`
+/// args, so parity checks compare `@HD` rather than the whole header.
 fn read_bam_hd(path: &Path) -> Option<String> {
     let mut reader = bam::io::Reader::new(fs::File::open(path).unwrap());
     let header = reader.read_header().unwrap();
     header.header().map(|hd| format!("{hd:?}"))
 }
 
-/// The chain (`--threads`) path matches the non-chain path across the
-/// output-changing knobs the identity-only parity tests leave uncovered:
+/// `--threads 4` must match the `--threads 1` oracle across the
+/// output-changing knobs the identity-only determinism test above leaves
+/// uncovered:
 /// - the CLI-default `adjacency` strategy (the common `dedup --threads N`
 ///   invocation) and `--strategy edit`, on mixed UMIs so both do real
 ///   clustering work rather than collapsing to identity (vacuous);
 /// - `--remove-duplicates` (the serialize-step drop path);
-/// - `--no-umi`, whose handling this diff specifically changed (it forces
-///   identity/edits=0 and flips `filter_config.no_umi` on the chain path);
+/// - `--no-umi` (forces identity/edits=0 and flips `filter_config.no_umi`);
 /// - `--min-map-q 30`, which filters the fixture's mapq-10 subfamily, exercising
-///   the chain's ported filter funnel with a non-zero filtered count.
+///   the filter funnel with a non-zero filtered count.
 /// The `@HD` sort-order header is compared too (the `@PG` command-line field
 /// legitimately differs between the two invocations, so it is excluded).
 #[rstest]
@@ -2427,7 +2420,7 @@ fn read_bam_hd(path: &Path) -> Option<String> {
 #[case::identity_remove(&["--strategy", "identity", "--remove-duplicates"])]
 #[case::no_umi(&["--no-umi"])]
 #[case::min_map_q_filters(&["--strategy", "identity", "--min-map-q", "30"])]
-fn test_dedup_chain_matches_non_chain_across_knobs(#[case] extra: &[&str]) {
+fn test_dedup_threads4_matches_threads1_across_knobs(#[case] extra: &[&str]) {
     let temp_dir = TempDir::new().unwrap();
     let input_bam = temp_dir.path().join("input.bam");
 
@@ -2438,7 +2431,9 @@ fn test_dedup_chain_matches_non_chain_across_knobs(#[case] extra: &[&str]) {
     create_sorted_bam(&input_bam, records);
 
     let oracle_out = temp_dir.path().join("oracle.bam");
-    dedup_run(&input_bam, &oracle_out, extra);
+    let mut oracle_args = extra.to_vec();
+    oracle_args.extend_from_slice(&["--threads", "1"]);
+    dedup_run(&input_bam, &oracle_out, &oracle_args);
 
     let chain_out = temp_dir.path().join("chain.bam");
     let mut chain_args = extra.to_vec();
@@ -2450,12 +2445,12 @@ fn test_dedup_chain_matches_non_chain_across_knobs(#[case] extra: &[&str]) {
     assert!(!expected.is_empty(), "oracle output must be non-empty (guard against a vacuous pass)");
     assert_eq!(
         actual, expected,
-        "chain --threads 4 output must match the non-chain path for knobs {extra:?}"
+        "chain --threads 4 output must match the --threads 1 oracle for knobs {extra:?}"
     );
     assert_eq!(
         read_bam_hd(&chain_out),
         read_bam_hd(&oracle_out),
-        "chain and non-chain must declare the same @HD sort order for knobs {extra:?}"
+        "--threads 4 and --threads 1 must declare the same @HD sort order for knobs {extra:?}"
     );
 }
 
@@ -2551,12 +2546,16 @@ fn test_dedup_threaded_crc_policy(#[case] crc_args: &[&str], #[case] expect_ok: 
 }
 
 /// The `--duplication-ladder` (and `--metrics` / `--family-size-histogram`)
-/// output from the chain path is byte-identical to the non-chain path.
+/// text outputs at `--threads 4` are byte-identical to the no-flag (single-worker)
+/// oracle. The BAM output is compared at the decoded-record level (via
+/// `read_deduped_records` below), not byte-for-byte on the serialized stream, so a
+/// pure BAM header or BGZF-encoding regression is out of this test's scope; the
+/// order-sensitive byte-parity claim applies to the three metric text files.
 ///
 /// This MUST run multi-threaded: the ladder is order-sensitive (it samples a
 /// saturation curve at cumulative-template intervals), and its recording seam
 /// is the chain's serial `MiAssign` step, which only actually reorders at
-/// `--threads > 1`. At `--threads 1` a reorder regression would slip through.
+/// `--threads > 1`. At a single worker a reorder regression would slip through.
 /// The input carries several hundred position groups (so batches span many
 /// in-flight batches at `--threads 4`) across two libraries (so per-library
 /// ladder rows are exercised), with a small `--ladder-interval` so rows are
@@ -2582,7 +2581,7 @@ fn test_dedup_threaded_duplication_ladder_parity() {
     create_sorted_bam_with_header(&input_bam, &header, records);
 
     // Run dedup writing the BAM plus all three metric outputs; `extra` carries
-    // the thread flags (empty = non-chain oracle).
+    // the thread flags (empty = the no-flag single-worker oracle).
     let run = |tag: &str, extra: &[&str]| {
         let out = temp_dir.path().join(format!("{tag}.bam"));
         let ladder = temp_dir.path().join(format!("{tag}.ladder.txt"));
@@ -2622,22 +2621,22 @@ fn test_dedup_threaded_duplication_ladder_parity() {
     assert_eq!(
         fs::read(&oracle_ladder).unwrap(),
         fs::read(&chain_ladder).unwrap(),
-        "duplication ladder diverged between the chain and non-chain paths"
+        "duplication ladder diverged between the no-flag oracle and --threads 4"
     );
     assert_eq!(
         fs::read(&oracle_metrics).unwrap(),
         fs::read(&chain_metrics).unwrap(),
-        "metrics diverged between the chain and non-chain paths"
+        "metrics diverged between the no-flag oracle and --threads 4"
     );
     assert_eq!(
         fs::read(&oracle_hist).unwrap(),
         fs::read(&chain_hist).unwrap(),
-        "family-size histogram diverged between the chain and non-chain paths"
+        "family-size histogram diverged between the no-flag oracle and --threads 4"
     );
     assert_eq!(
         read_deduped_records(&oracle_out),
         read_deduped_records(&chain_out),
-        "output records diverged between the chain and non-chain paths"
+        "output records diverged between the no-flag oracle and --threads 4"
     );
 }
 

--- a/tests/integration/test_dedup_cutover_parity.rs
+++ b/tests/integration/test_dedup_cutover_parity.rs
@@ -1,0 +1,910 @@
+//! Cutover parity gate for the `dedup` command's legacy-path retirement (C4):
+//! `MarkDuplicates::execute` no longer has a no-`--threads` hand-rolled
+//! `unified_pipeline` engine — it *always* routes through the declarative chain
+//! builder (`execute_chain`). This test proves that cutover lost nothing
+//! user-observable in the duplicate-marking / UMI-family-assignment logic.
+//!
+//! Two independent things are checked here:
+//!
+//! 1. **The cutover actually happened** (`dedup_no_threads_routes_through_chain`).
+//!    A no-`--threads` run now emits the chain-only "Pipeline `dedup` ran in"
+//!    line from `pipeline::chains::finalize`, and the per-step `Pipeline stats`
+//!    table — both come from the pipeline-core runtime, which the retired
+//!    `unified_pipeline` engine never used. This is the RED (pre-removal) /
+//!    GREEN (post-removal) discriminator for the cutover.
+//!
+//! 2. **Output parity with the pre-removal legacy path**
+//!    (`cutover_matches_baseline_*`). The current build's `dedup` output — BAM
+//!    records (byte-identical, modulo the `@PG` line) and `--metrics` /
+//!    `--family-size-histogram` — must match the frozen legacy-path baseline
+//!    binary run with no `--threads` (its hand-rolled `unified_pipeline`
+//!    engine). The baseline path comes from `FGUMI_BASELINE_BIN`; when unset
+//!    (or names a missing file) the case degrades to a self-consistency oracle
+//!    rather than skipping — the fallback discipline of
+//!    `test_sort_cutover_parity.rs`.
+//!
+//! Coverage spans the shapes the campaign plan calls out as historically
+//! divergence-prone between the legacy engine and the chain: multiple UMI
+//! strategies (identity / adjacency / paired, the last exercising the `/A`+`/B`
+//! duplex-style molecule-id split), the `--index-threshold` indexed-clustering
+//! path (a position group large enough to trigger indexing under the default
+//! threshold), single-end (unpaired) templates, and secondary/supplementary
+//! reads carrying the `tc` tag.
+
+use std::path::Path;
+use std::process::Command;
+
+use rstest::rstest;
+use tempfile::TempDir;
+
+use fgumi_lib::sam::SamTag;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
+
+use crate::helpers::bam_generator::{create_minimal_header, write_bam};
+use crate::helpers::read_bam_output;
+
+/// Resolves the saved pre-removal legacy-path baseline binary to compare
+/// against.
+///
+/// The path comes solely from `FGUMI_BASELINE_BIN`; when unset (or naming a
+/// missing file) this returns `None` — "no baseline oracle available", never a
+/// silent pass. Callers layer the baseline byte-parity check on top of the
+/// always-available self-consistency oracle; a missing baseline drops only the
+/// byte-parity half, it never skips the case. No hardcoded fallback: a baseline
+/// binary is host-specific and must never be a path committed into the repo.
+fn baseline_bin() -> Option<std::path::PathBuf> {
+    let path = std::path::PathBuf::from(std::env::var_os("FGUMI_BASELINE_BIN")?);
+    if path.is_file() {
+        return Some(path);
+    }
+    eprintln!(
+        "FGUMI_BASELINE_BIN={} does not name an existing file; baseline oracle unavailable",
+        path.display()
+    );
+    None
+}
+
+/// Removes every `@PG` line from a SAM header text blob.
+///
+/// The fixtures are built by piping through `fgumi sort` (see
+/// `create_sorted_bam`), which stamps its own `@PG` line, so the dedup input
+/// already carries one before `dedup` adds a second (`PP`-chained) one. The
+/// `sort` line is byte-identical between the current build's run and the
+/// baseline's — both invoke the *same* `fgumi sort` binary on the same input —
+/// so it would compare equal either way; it is the `dedup`/baseline-binary
+/// `@PG` line that differs (`VN`, the git-describe version, and `CL`, which
+/// names argv[0] — a different binary path for each side — and the per-run
+/// output path). Stripping every `@PG` line rather than only the last one is
+/// simply the simpler correct implementation: dropping an already-identical
+/// line changes nothing.
+fn strip_pg_lines(text: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+    let mut lines: Vec<&str> = text.split('\n').collect();
+    let had_trailing_newline = lines.last() == Some(&"");
+    if had_trailing_newline {
+        lines.pop();
+    }
+    lines.retain(|line| !line.starts_with("@PG"));
+    let mut out = lines.join("\n");
+    if had_trailing_newline {
+        out.push('\n');
+    }
+    out
+}
+
+/// Reads a BAM's raw BGZF stream, decompresses it, strips the `@PG` line(s) from
+/// the embedded SAM header text, and returns the resulting bytes (new header +
+/// unmodified `n_ref`/reference-list/record bytes).
+///
+/// Comparing the *decompressed* BAM binary — rather than `RecordBuf`-parsed
+/// records or raw file bytes — keeps everything except the `@PG` line an exact,
+/// uninterpreted byte comparison: BGZF block boundaries differ between the two
+/// writers even for identical logical content (so raw file bytes never match),
+/// while parsing into `RecordBuf` and re-encoding could mask a real tag-order or
+/// binary-layout regression (e.g. MI-tag injection) by normalizing it away.
+fn decompressed_records_without_pg(path: &Path) -> Vec<u8> {
+    let file = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+    let mut reader = noodles::bgzf::io::Reader::new(std::io::BufReader::new(file));
+    let mut raw = Vec::new();
+    std::io::Read::read_to_end(&mut reader, &mut raw)
+        .unwrap_or_else(|e| panic!("decompress BGZF stream for {}: {e}", path.display()));
+
+    assert!(
+        raw.len() >= 8 && &raw[0..4] == b"BAM\x01",
+        "{} does not decompress to a BAM binary stream (missing magic)",
+        path.display()
+    );
+    let l_text = i32::from_le_bytes(raw[4..8].try_into().expect("4 bytes"));
+    let l_text = usize::try_from(l_text).expect("l_text is non-negative");
+    let text_start = 8;
+    let text_end = text_start + l_text;
+    assert!(raw.len() >= text_end, "{} header text runs past end of stream", path.display());
+
+    let text = String::from_utf8_lossy(&raw[text_start..text_end]);
+    let stripped_text = strip_pg_lines(&text);
+
+    let mut out = Vec::with_capacity(raw.len());
+    out.extend_from_slice(b"BAM\x01");
+    let new_l_text = i32::try_from(stripped_text.len()).expect("stripped header text fits i32");
+    out.extend_from_slice(&new_l_text.to_le_bytes());
+    out.extend_from_slice(stripped_text.as_bytes());
+    out.extend_from_slice(&raw[text_end..]); // n_ref, reference list, and all records, untouched
+    out
+}
+
+/// Writes `records` to an unsorted BAM alongside `path`, then runs `fgumi
+/// sort --order template-coordinate` to produce the final input at `path`.
+///
+/// `dedup` requires *true* template-coordinate order, which correctly
+/// interleaves `tc`-keyed secondary/supplementary reads at their primary's
+/// coordinate regardless of where they were written in the input stream.
+/// Writing records in an order that merely satisfies the header's `SO`/`GO`/
+/// `SS` tags is not sufficient — an out-of-place secondary/supplementary
+/// silently lands in the wrong (or no) position group and is dropped by the
+/// `NoPrimaryReads` filter with no error. Routing through a real `fgumi sort`
+/// is the same approach `test_dedup_command.rs::create_sorted_bam_with_header`
+/// uses for exactly this reason.
+fn create_sorted_bam(path: &Path, header: &noodles::sam::Header, records: &[RawRecord]) {
+    let unsorted = path.with_extension("unsorted.bam");
+    write_bam(&unsorted, header, records);
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "sort",
+            "-i",
+            unsorted.to_str().unwrap(),
+            "-o",
+            path.to_str().unwrap(),
+            "--order",
+            "template-coordinate",
+            "--key-types",
+            "mi",
+        ])
+        .status()
+        .unwrap_or_else(|e| panic!("failed to spawn `fgumi sort` for test input: {e}"));
+    assert!(status.success(), "failed to template-coordinate sort test input {}", path.display());
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Fixture builders
+//////////////////////////////////////////////////////////////////////////////
+
+/// Builds one paired-end template: R1 at `r1_pos` and R2 at `r2_pos` (1-based
+/// reference positions), with the given `umi` and strand orientation. Carries
+/// `MC` (required by `RecordPositionGrouper` for paired reads).
+fn build_pair(
+    name: &str,
+    umi: &str,
+    r1_pos: i32,
+    r2_pos: i32,
+    r1_reverse: bool,
+    base_qual: u8,
+) -> (RawRecord, RawRecord) {
+    let seq = b"ACGTACGT";
+    let cigar_op = (u32::try_from(seq.len()).expect("fits u32")) << 4;
+    let r2_reverse = !r1_reverse;
+    let tlen = (r2_pos - r1_pos) + i32::try_from(seq.len()).expect("fits i32");
+
+    let mut b1 = SamBuilder::new();
+    b1.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(&vec![base_qual; seq.len()])
+        .flags(
+            flags::PAIRED
+                | flags::FIRST_SEGMENT
+                | if r1_reverse { flags::REVERSE } else { 0 }
+                | if r2_reverse { flags::MATE_REVERSE } else { 0 },
+        )
+        .ref_id(0)
+        .pos(r1_pos - 1)
+        .mapq(60)
+        .cigar_ops(&[cigar_op])
+        .mate_ref_id(0)
+        .mate_pos(r2_pos - 1)
+        .template_length(tlen)
+        .add_string_tag(SamTag::MC, b"8M")
+        .add_string_tag(SamTag::RX, umi.as_bytes());
+
+    let mut b2 = SamBuilder::new();
+    b2.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(&vec![base_qual; seq.len()])
+        .flags(
+            flags::PAIRED
+                | flags::LAST_SEGMENT
+                | if r2_reverse { flags::REVERSE } else { 0 }
+                | if r1_reverse { flags::MATE_REVERSE } else { 0 },
+        )
+        .ref_id(0)
+        .pos(r2_pos - 1)
+        .mapq(60)
+        .cigar_ops(&[cigar_op])
+        .mate_ref_id(0)
+        .mate_pos(r1_pos - 1)
+        .template_length(-tlen)
+        .add_string_tag(SamTag::MC, b"8M")
+        .add_string_tag(SamTag::RX, umi.as_bytes());
+
+    (b1.build(), b2.build())
+}
+
+/// Builds `count` paired templates, all at the same coordinates and UMI —
+/// a PCR-duplicate family that a duplicate-marking run must collapse to one
+/// representative, with the rest flagged `0x400`.
+fn build_duplicate_family(
+    base_name: &str,
+    umi: &str,
+    count: usize,
+    r1_pos: i32,
+    r2_pos: i32,
+) -> Vec<RawRecord> {
+    let mut records = Vec::with_capacity(count * 2);
+    for i in 0..count {
+        // Distinct base qualities make the highest-scoring representative
+        // unambiguous (no tie whose resolution depends on stream order).
+        let qual = 20 + u8::try_from(i).expect("small count") * 5;
+        let (r1, r2) = build_pair(&format!("{base_name}_{i}"), umi, r1_pos, r2_pos, false, qual);
+        records.push(r1);
+        records.push(r2);
+    }
+    records
+}
+
+/// A single-end (unpaired, mapped) read at `pos` with `umi`.
+fn build_single_end(name: &str, umi: &str, pos: i32, base_qual: u8) -> RawRecord {
+    let seq = b"ACGTACGT";
+    let cigar_op = (u32::try_from(seq.len()).expect("fits u32")) << 4;
+    let mut b = SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(&vec![base_qual; seq.len()])
+        .flags(0)
+        .ref_id(0)
+        .pos(pos - 1)
+        .mapq(60)
+        .cigar_ops(&[cigar_op])
+        .add_string_tag(SamTag::RX, umi.as_bytes());
+    b.build()
+}
+
+/// The `tc` aux array `fgumi zipper` stamps onto a secondary/supplementary
+/// read: `[tid1, pos1, neg1, tid2, pos2, neg2]`, the *primary* pair's own
+/// unclipped-5' reference coordinates and strand. Computed from the actual
+/// built R1/R2 records (rather than hand-derived arithmetic) so it can never
+/// drift from what `build_pair` actually produced — e.g. a reverse-strand
+/// mate's unclipped 5' position is its rightmost aligned base, not `pos`.
+fn primary_tc_array(r1: &RawRecord, r2: &RawRecord) -> [i32; 6] {
+    use fgumi_raw_bam::RawRecordView;
+
+    let strand_of = |r: &RawRecord| -> i32 {
+        i32::from((RawRecordView::new(r.as_ref()).flags() & flags::REVERSE) != 0)
+    };
+    [
+        fgumi_raw_bam::ref_id(r1.as_ref()),
+        fgumi_raw_bam::unclipped_5prime_from_raw_bam(r1.as_ref()),
+        strand_of(r1),
+        fgumi_raw_bam::ref_id(r2.as_ref()),
+        fgumi_raw_bam::unclipped_5prime_from_raw_bam(r2.as_ref()),
+        strand_of(r2),
+    ]
+}
+
+/// A secondary or supplementary read carrying the `tc` tag pointing at
+/// `primary`'s template coordinate, so it travels in that pair's position
+/// group regardless of its own placement — mirroring what `fgumi zipper`
+/// stamps in production.
+fn build_non_primary(
+    name: &str,
+    umi: &str,
+    primary: (&RawRecord, &RawRecord),
+    supplementary: bool,
+) -> RawRecord {
+    let seq = b"ACGTACGT";
+    let cigar_op = (u32::try_from(seq.len()).expect("fits u32")) << 4;
+    let non_primary_flag = if supplementary { flags::SUPPLEMENTARY } else { flags::SECONDARY };
+    let tc = primary_tc_array(primary.0, primary.1);
+    let mut b = SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(&[30; 8])
+        .flags(flags::PAIRED | flags::FIRST_SEGMENT | non_primary_flag)
+        // Placed far from the primary; grouping must key on `tc`, not this.
+        .ref_id(0)
+        .pos(tc[1] + 2000 - 1)
+        .mapq(60)
+        .cigar_ops(&[cigar_op])
+        .mate_ref_id(0)
+        .mate_pos(tc[4] - 1)
+        .add_string_tag(SamTag::RX, umi.as_bytes())
+        .add_string_tag(SamTag::MC, b"8M")
+        .add_array_i32(SamTag::TC, &tc);
+    b.build()
+}
+
+/// The main fixture: four independent position groups exercising, in one
+/// input, everything a single strategy run needs to prove parity on:
+///
+/// - `(100, 300)`: a 3-read exact-UMI family (`AAAAAAAA`) plus a 2-read
+///   1-mismatch family (`AAAAAAAT`) — under `--strategy identity` these are two
+///   separate molecules/duplicate families; under `--strategy adjacency` they
+///   cluster into one.
+/// - `(500, 700)`: a plain 2-read duplicate family (`CCCCCCCC`), an ordinary
+///   control group.
+/// - single-end reads at position `900`: 3 unpaired reads sharing UMI
+///   `GGGGGGGG` — the single-end/fragment shape.
+/// - `(1100, 1300)`: a single template (`TTTTTTTT`) carrying a `tc`-keyed
+///   secondary AND a `tc`-keyed supplementary read. Kept as a lone template
+///   (not a duplicate family) on its own exclusive position group, because
+///   `RecordPositionGrouper` coalesces a tc-keyed non-primary read into its
+///   template by QNAME match against the immediately *preceding* accumulated
+///   record, not by resolved-key equality alone (see
+///   `RecordPositionGrouper::with_secondary_supplementary`'s doc comment) —
+///   with two same-coordinate templates, which one a following non-primary
+///   read lands next to depends on the sort's coordinate tie-break, not
+///   insertion order, so a lone template is what makes the outcome
+///   unambiguous. Covers the `secondary_reads`/`supplementary_reads`/
+///   `missing_tc_tag` accounting.
+fn build_family_fixture(dir: &Path) -> std::path::PathBuf {
+    let input = dir.join("in.bam");
+    let header = create_minimal_header("chr1", 10000);
+
+    let mut records = Vec::new();
+    records.extend(build_duplicate_family("exact", "AAAAAAAA", 3, 100, 300));
+    records.extend(build_duplicate_family("near", "AAAAAAAT", 2, 100, 300));
+    records.extend(build_duplicate_family("ctrl", "CCCCCCCC", 2, 500, 700));
+    for i in 0..3 {
+        records.push(build_single_end(&format!("frag_{i}"), "GGGGGGGG", 900, 30));
+    }
+
+    // A dedicated 2-template family at its own exclusive coordinate, one
+    // template carrying a tc-keyed secondary and the other a tc-keyed
+    // supplementary. `RecordPositionGrouper` coalesces a tc-keyed
+    // secondary/supplementary into its template by QNAME match against the
+    // immediately preceding accumulated record ("coalescing is driven by...
+    // stream adjacency", not by the resolved key alone) — so each goes right
+    // after its own primary pair, and this family gets its own position
+    // group so no *other* template's records can land in between.
+    // A single template (not a duplicate family — with two same-coordinate
+    // templates, which one a same-position tc-keyed non-primary read lands
+    // next to depends on the coordinate-tie-break, not insertion order) so
+    // both non-primary reads unambiguously coalesce right after it.
+    let (sec_r1, sec_r2) = build_pair("sec_0", "TTTTTTTT", 1100, 1300, false, 30);
+    records.push(sec_r1.clone());
+    records.push(sec_r2.clone());
+    records.push(build_non_primary("sec_0", "TTTTTTTT", (&sec_r1, &sec_r2), false));
+    records.push(build_non_primary("sec_0", "TTTTTTTT", (&sec_r1, &sec_r2), true));
+
+    create_sorted_bam(&input, &header, &records);
+    input
+}
+
+/// A duplex-shaped fixture for `--strategy paired`: two templates at the same
+/// coordinates carrying the paired-UMI format (`AAAA-CCCC`) in opposite
+/// physical orientations (FR vs RF) — the shape that makes the `PairedUmiAssigner`
+/// assign the same molecule two distinct `/A`/`/B` suffixes, exactly like a
+/// duplex-sequenced molecule read from both strands.
+fn build_paired_strategy_fixture(dir: &Path) -> std::path::PathBuf {
+    let input = dir.join("in.bam");
+    let header = create_minimal_header("chr1", 10000);
+
+    let mut records = Vec::new();
+    // FR: R1 (unclipped 5') at 100 < R2 at 300 -> is_r1_earlier = true.
+    let (r1, r2) = build_pair("duplex_fwd", "AAAA-CCCC", 100, 300, false, 30);
+    records.push(r1);
+    records.push(r2);
+    // RF: R1 at 300 > R2 at 100 -> is_r1_earlier = false. Same physical
+    // molecule read from the opposite strand.
+    let (r1, r2) = build_pair("duplex_rev", "AAAA-CCCC", 300, 100, true, 30);
+    records.push(r1);
+    records.push(r2);
+
+    create_sorted_bam(&input, &header, &records);
+    input
+}
+
+/// A single large position group of `n` templates with pairwise-distinct UMIs,
+/// large enough to cross the default `--index-threshold 100` (adjacency/edit
+/// index at `--edits 1`) so both the current build and the baseline exercise
+/// the indexed-clustering path rather than the brute-force one.
+fn build_index_threshold_fixture(dir: &Path, n: usize) -> std::path::PathBuf {
+    let input = dir.join("in.bam");
+    let header = create_minimal_header("chr1", 10000);
+
+    let bases = [b'A', b'C', b'G', b'T'];
+    let mut records = Vec::with_capacity(n * 2);
+    for i in 0..n {
+        // Deterministic 8-mers built as a single-parity-check code: the first
+        // 7 symbols are the base-4 digits of `i` (4^7 = 16384, far more than
+        // `n`), and the 8th is their digit-sum mod 4. Flipping exactly one
+        // base always changes that sum mod 4, so any two *distinct* codes
+        // from this family differ in at least 2 positions — never edit
+        // distance 1 of each other. Plain sequential base-4 digits (no parity
+        // digit) do NOT have this property: consecutive indices differ only
+        // in their lowest digit, chaining almost every UMI to a neighbor at
+        // edit distance 1 and letting adjacency's directed capture collapse
+        // the whole set into one molecule — not the "120 independent
+        // molecules" this fixture needs to isolate the indexed-clustering
+        // path from UMI-clustering behavior.
+        let mut umi = [b'A'; 8];
+        let mut v = i;
+        let mut parity = 0usize;
+        for slot in &mut umi[..7] {
+            let digit = v % 4;
+            v /= 4;
+            parity = (parity + digit) % 4;
+            *slot = bases[digit];
+        }
+        umi[7] = bases[parity];
+        let umi = std::str::from_utf8(&umi).expect("ACGT is valid UTF-8");
+        let (r1, r2) = build_pair(&format!("idx_{i}"), umi, 100, 300, false, 30);
+        records.push(r1);
+        records.push(r2);
+    }
+
+    create_sorted_bam(&input, &header, &records);
+    input
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Runner
+//////////////////////////////////////////////////////////////////////////////
+
+/// Runs `<bin> dedup` (no `--threads`, so the current build takes the
+/// post-cutover chain path and the baseline takes its legacy engine) with
+/// `RUST_LOG=info`, and returns the process output for stderr/exit assertions.
+#[allow(clippy::too_many_arguments)]
+fn run_dedup(
+    bin: &Path,
+    input: &Path,
+    output: &Path,
+    strategy: &str,
+    metrics: Option<&Path>,
+    family_size_histogram: Option<&Path>,
+    index_threshold: Option<&str>,
+) -> std::process::Output {
+    let mut cmd = Command::new(bin);
+    cmd.env("RUST_LOG", "info").args([
+        "dedup",
+        "-i",
+        input.to_str().unwrap(),
+        "-o",
+        output.to_str().unwrap(),
+        "--strategy",
+        strategy,
+        "--compression-level",
+        "1",
+    ]);
+    if let Some(m) = metrics {
+        cmd.args(["-m", m.to_str().unwrap()]);
+    }
+    if let Some(h) = family_size_histogram {
+        cmd.args(["-H", h.to_str().unwrap()]);
+    }
+    if let Some(t) = index_threshold {
+        cmd.args(["--index-threshold", t]);
+    }
+    cmd.output().unwrap_or_else(|e| panic!("failed to spawn `{}` dedup: {e}", bin.display()))
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Tests
+//////////////////////////////////////////////////////////////////////////////
+
+/// A no-`--threads` run now routes through the declarative chain, which logs
+/// "Pipeline `dedup` ran in" (from `pipeline::chains::finalize`) and the
+/// per-step `Pipeline stats` table (from the pipeline-core runtime). The
+/// retired `unified_pipeline` engine never printed either — a hand-rolled loop
+/// with no step-based runtime — so this is the RED (pre-removal) -> GREEN
+/// (post-removal) discriminator for the cutover.
+#[test]
+fn dedup_no_threads_routes_through_chain() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = build_family_fixture(dir.path());
+    let output = dir.path().join("out.bam");
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let out = run_dedup(current_bin, &input, &output, "identity", None, None, None);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "no-threads dedup must succeed; stderr:\n{stderr}");
+    assert!(
+        stderr.contains("Pipeline `dedup` ran in"),
+        "a no-`--threads` dedup must route through the chain (which logs the pipeline-core \
+         finalize line); the unified_pipeline engine is retired. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Starting dedup"),
+        "the chain must still emit the `Starting dedup` banner; stderr:\n{stderr}"
+    );
+}
+
+/// Output parity of the post-cutover chain against the pre-removal legacy-path
+/// baseline binary (run with no `--threads`, i.e. its `unified_pipeline`
+/// engine), across UMI strategies — plus the always-available self-consistency
+/// oracle when no baseline is set.
+///
+/// `identity` keeps the exact/near-mismatch families in [`build_family_fixture`]
+/// as two distinct molecules; `adjacency` clusters them into one. Both exercise
+/// the secondary/supplementary (`tc`-keyed) and single-end position groups
+/// identically, since strategy only changes UMI clustering, not template
+/// shape handling.
+#[rstest]
+#[case::identity("identity")]
+#[case::adjacency("adjacency")]
+fn cutover_matches_baseline_by_strategy(#[case] strategy: &str) {
+    let dir = TempDir::new().expect("temp dir");
+    let input = build_family_fixture(dir.path());
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current_metrics = dir.path().join("current.metrics.txt");
+    let current_hist = dir.path().join("current.hist.txt");
+    let current = run_dedup(
+        current_bin,
+        &input,
+        &current_out,
+        strategy,
+        Some(&current_metrics),
+        Some(&current_hist),
+        None,
+    );
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(current.status.success(), "current dedup must succeed; stderr:\n{current_stderr}");
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let baseline_metrics = dir.path().join("baseline.metrics.txt");
+        let baseline_hist = dir.path().join("baseline.hist.txt");
+        let base = run_dedup(
+            &baseline,
+            &input,
+            &baseline_out,
+            strategy,
+            Some(&baseline_metrics),
+            Some(&baseline_hist),
+            None,
+        );
+        assert!(
+            base.status.success(),
+            "baseline dedup failed; stderr:\n{}",
+            String::from_utf8_lossy(&base.stderr)
+        );
+
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "chain dedup output (--strategy {strategy}) diverges from the pre-removal legacy \
+             baseline binary ({}) after stripping @PG — a real cutover parity bug",
+            baseline.display(),
+        );
+        assert_eq!(
+            std::fs::read_to_string(&current_metrics).expect("current metrics"),
+            std::fs::read_to_string(&baseline_metrics).expect("baseline metrics"),
+            "chain --metrics TSV (--strategy {strategy}) diverges from the legacy baseline"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&current_hist).expect("current histogram"),
+            std::fs::read_to_string(&baseline_hist).expect("baseline histogram"),
+            "chain --family-size-histogram TSV (--strategy {strategy}) diverges from the legacy \
+             baseline"
+        );
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_matches_baseline_by_strategy[{strategy}]: \
+             FGUMI_BASELINE_BIN is unset or does not name an existing file — running \
+             self-consistency oracle instead"
+        );
+        assert_self_consistent_family_fixture(&current_out, strategy);
+    }
+}
+
+/// Output parity for `--strategy paired` on the duplex-shaped (`/A`/`/B`)
+/// fixture — the known-divergence shape where a paired UMI read from both
+/// physical strands must resolve to one canonical molecule split into two
+/// duplex halves.
+#[test]
+fn cutover_matches_baseline_paired_duplex() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = build_paired_strategy_fixture(dir.path());
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current = run_dedup(current_bin, &input, &current_out, "paired", None, None, None);
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(
+        current.status.success(),
+        "current dedup (paired) must succeed; stderr:\n{current_stderr}"
+    );
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let base = run_dedup(&baseline, &input, &baseline_out, "paired", None, None, None);
+        assert!(
+            base.status.success(),
+            "baseline dedup (paired) failed; stderr:\n{}",
+            String::from_utf8_lossy(&base.stderr)
+        );
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "chain dedup output (--strategy paired, duplex A/B shape) diverges from the \
+             pre-removal legacy baseline binary ({}) after stripping @PG",
+            baseline.display(),
+        );
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_matches_baseline_paired_duplex: FGUMI_BASELINE_BIN \
+             is unset or does not name an existing file — running self-consistency oracle instead"
+        );
+        let (_, records) = read_bam_output(&current_out);
+        assert_eq!(records.len(), 4, "both duplex-strand templates (2 reads each) must survive");
+        let mi_tags = mi_strings(&records);
+        assert_eq!(mi_tags.len(), 4, "every record must carry an MI tag");
+        let distinct: std::collections::HashSet<&String> = mi_tags.iter().collect();
+        // Two distinct molecule ids (one per duplex strand: `/A` and `/B`), not
+        // one (which would mean the strand split collapsed) and not four
+        // (which would mean nothing paired up at all).
+        assert_eq!(
+            distinct.len(),
+            2,
+            "the two physical-strand templates must resolve to exactly 2 distinct molecule ids \
+             (the /A and /B duplex halves), got: {mi_tags:?}"
+        );
+        assert!(
+            mi_tags.iter().any(|m| m.ends_with("/A")) && mi_tags.iter().any(|m| m.ends_with("/B")),
+            "the paired assigner must emit both a /A and a /B suffixed molecule id, got: {mi_tags:?}"
+        );
+    }
+}
+
+/// Output parity across the `--index-threshold`-triggered indexed-clustering
+/// path: a single position group of 120 pairwise-distinct UMIs under
+/// `--strategy adjacency`, which crosses the default `--index-threshold 100`
+/// and forces both binaries onto the N-gram/BK-tree index rather than the
+/// brute-force pairwise comparison.
+#[test]
+fn cutover_matches_baseline_index_threshold() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = build_index_threshold_fixture(dir.path(), 120);
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    // `--index-threshold always` is a CLI-level assertion, not a test-side
+    // one: `validate_index_threshold` rejects it up front if the resolved
+    // strategy/edits combination can never index (see `--index-threshold`'s
+    // help), so a successful run here already proves indexing was reachable
+    // for `adjacency` at the default `--edits 1`. Neither this test nor the
+    // fallback self-consistency oracle below can observe, from the output
+    // alone, whether the indexed or brute-force code path actually ran for a
+    // given group — both must produce byte-identical clustering by
+    // construction, so there is no output-visible difference to assert on.
+    let current =
+        run_dedup(current_bin, &input, &current_out, "adjacency", None, None, Some("always"));
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(
+        current.status.success(),
+        "current dedup (index-threshold always) must succeed; stderr:\n{current_stderr}"
+    );
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let base =
+            run_dedup(&baseline, &input, &baseline_out, "adjacency", None, None, Some("always"));
+        assert!(
+            base.status.success(),
+            "baseline dedup (index-threshold always) failed; stderr:\n{}",
+            String::from_utf8_lossy(&base.stderr)
+        );
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "chain dedup output (120-UMI indexed adjacency) diverges from the pre-removal \
+             legacy baseline binary ({}) after stripping @PG",
+            baseline.display(),
+        );
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_matches_baseline_index_threshold: FGUMI_BASELINE_BIN \
+             is unset or does not name an existing file — running self-consistency oracle instead"
+        );
+        let (_, records) = read_bam_output(&current_out);
+        assert_eq!(records.len(), 240, "all 120 templates (2 reads each) must survive");
+        let mi_tags = mi_strings(&records);
+        let distinct: std::collections::HashSet<&String> = mi_tags.iter().collect();
+        // Every UMI is pairwise-distinct and none is within edit distance 1 of
+        // another under this construction (differing base-4 digit patterns), so
+        // every template must remain its own molecule — a passthrough that
+        // dropped all clustering (or a bug that over-merged everything into one
+        // molecule) both fail this.
+        assert_eq!(
+            distinct.len(),
+            120,
+            "120 pairwise-distinct UMIs must resolve to 120 distinct molecule ids"
+        );
+        // Non-vacuous duplicate-marking check: with one template per molecule,
+        // no read should be flagged a duplicate.
+        let dup_count = records.iter().filter(|r| r.flags().is_duplicate()).count();
+        assert_eq!(dup_count, 0, "singleton families must not be marked duplicate");
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Self-consistency oracle
+//////////////////////////////////////////////////////////////////////////////
+
+/// Extracts every record's `MI:Z` tag value (skips records without one).
+fn mi_strings(records: &[noodles::sam::alignment::RecordBuf]) -> Vec<String> {
+    use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::Value;
+
+    let mi_tag = Tag::from(SamTag::MI);
+    records
+        .iter()
+        .filter_map(|r| match r.data().get(&mi_tag) {
+            Some(Value::String(s)) => Some(s.to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// A single record's `MI:Z` tag value, if present.
+fn mi_of(record: &noodles::sam::alignment::RecordBuf) -> Option<String> {
+    use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::Value;
+
+    match record.data().get(&Tag::from(SamTag::MI)) {
+        Some(Value::String(s)) => Some(s.to_string()),
+        _ => None,
+    }
+}
+
+/// Every record whose read name starts with `prefix`.
+fn records_named<'a>(
+    records: &'a [noodles::sam::alignment::RecordBuf],
+    prefix: &str,
+) -> Vec<&'a noodles::sam::alignment::RecordBuf> {
+    records
+        .iter()
+        .filter(|r| {
+            r.name().is_some_and(|n| String::from_utf8_lossy(n.as_ref()).starts_with(prefix))
+        })
+        .collect()
+}
+
+/// All records matching read name `name` exactly, asserting every one of them
+/// agrees on the `0x400` duplicate flag (a template's primaries — and, for
+/// `sec_0`, its tc-keyed non-primary records — must always propagate together;
+/// a mismatch here is itself a bug independent of which value is expected).
+/// Returns that shared flag.
+fn is_duplicate_by_name(records: &[noodles::sam::alignment::RecordBuf], name: &str) -> bool {
+    let matching: Vec<_> = records
+        .iter()
+        .filter(|r| r.name().is_some_and(|n| AsRef::<[u8]>::as_ref(n) == name.as_bytes()))
+        .collect();
+    assert!(!matching.is_empty(), "no output record named {name:?}");
+    let flags: std::collections::HashSet<bool> =
+        matching.iter().map(|r| r.flags().is_duplicate()).collect();
+    assert_eq!(
+        flags.len(),
+        1,
+        "every record named {name:?} must agree on the duplicate flag, got {matching:?}"
+    );
+    flags.into_iter().next().expect("checked non-empty above")
+}
+
+/// Always-available oracle used when no baseline binary is set: proves the
+/// chain's dedup output on [`build_family_fixture`] is a real transform, not a
+/// passthrough — every kept record carries an `MI` tag, the exact/near-UMI
+/// families come out as the strategy-appropriate number of distinct molecules,
+/// EVERY template's duplicate flag matches its known representative-selection
+/// outcome (pinned per family, per strategy, as exact literals — not just "some
+/// duplicate exists somewhere"), the tc-keyed secondary/supplementary reads
+/// survive and carry their primary's molecule id, and single-end fragments
+/// form their own (unpaired) molecule with the correct representative kept.
+///
+/// A chain that mismarks duplicates within a family (wrong representative,
+/// a family that should merge but doesn't, or vice versa) fails one of the
+/// per-template assertions below, not just a weakened aggregate count.
+fn assert_self_consistent_family_fixture(output: &Path, strategy: &str) {
+    let (_, records) = read_bam_output(output);
+    // exact(3 pairs=6) + near(2 pairs=4) + ctrl(2 pairs=4) + frag(3) +
+    // sec_0(1 pair=2 primaries + 1 secondary + 1 supplementary=4) = 21.
+    assert_eq!(records.len(), 21, "no record may be dropped or added by dedup (mark-only mode)");
+    assert_eq!(mi_strings(&records).len(), 21, "every kept record must carry an MI tag");
+
+    // The exact(3)+near(2) position group: under identity, 2 distinct
+    // molecules (AAAAAAAA and AAAAAAAT never cluster); under adjacency, they
+    // cluster into 1. Distinguishing this is the whole point of running both
+    // strategies over the same fixture — a strategy that silently ignored the
+    // UMI would collapse to a different count than expected here.
+    let mut exact_near = records_named(&records, "exact_");
+    exact_near.extend(records_named(&records, "near_"));
+    let exact_near_mi: std::collections::HashSet<String> =
+        exact_near.iter().filter_map(|r| mi_of(r)).collect();
+    let expected_molecules = if strategy == "adjacency" { 1 } else { 2 };
+    assert_eq!(
+        exact_near_mi.len(),
+        expected_molecules,
+        "--strategy {strategy}: exact(AAAAAAAA)+near(AAAAAAAT) families must resolve to \
+         {expected_molecules} distinct molecule id(s), got {exact_near_mi:?}"
+    );
+
+    // Per-template duplicate flags, pinned exactly from `build_duplicate_family`'s
+    // known base qualities (20/25/30 for indices 0/1/2 — see
+    // `score_template`/`PICARD_MIN_BASE_QUALITY`, which every base here clears):
+    // the highest-quality template in a molecule is kept, every other template
+    // in that SAME molecule is marked duplicate. `exact_2` (quality 30) is the
+    // overall maximum across both `exact` and `near`, so it is the kept
+    // representative under EITHER strategy. `near_1` (quality 25) is only its
+    // own family's representative when `near` is NOT merged into `exact`
+    // (identity) — once adjacency merges the two families, `near_1` loses to
+    // `exact_2` and becomes a duplicate too.
+    let near_1_kept_alone = strategy != "adjacency";
+    for (name, expect_duplicate) in [
+        ("exact_0", true),
+        ("exact_1", true),
+        ("exact_2", false), // highest quality (30) in the merged or unmerged group
+        ("near_0", true),
+        ("near_1", !near_1_kept_alone),
+    ] {
+        assert_eq!(
+            is_duplicate_by_name(&records, name),
+            expect_duplicate,
+            "--strategy {strategy}: {name} duplicate flag must be {expect_duplicate}"
+        );
+    }
+
+    // The dedicated `sec_0` template (its own exclusive position group): both
+    // the secondary and the supplementary read must survive, carry the same
+    // MI as the primary they were tc-keyed into, and — a singleton family, so
+    // never a duplicate — leave the `0x400` flag unset on every one of them
+    // (checked via `is_duplicate_by_name`, which also asserts internal
+    // agreement across the primary pair + both non-primary records).
+    let sec_family = records_named(&records, "sec_0");
+    assert_eq!(sec_family.len(), 4, "1 primary pair + 1 secondary + 1 supplementary");
+    let sec_mi: std::collections::HashSet<String> =
+        sec_family.iter().filter_map(|r| mi_of(r)).collect();
+    assert_eq!(sec_mi.len(), 1, "the lone sec_0 template is one molecule");
+    let non_primary: Vec<_> = sec_family
+        .iter()
+        .filter(|r| r.flags().is_secondary() || r.flags().is_supplementary())
+        .collect();
+    assert_eq!(non_primary.len(), 2, "both the secondary and supplementary read must survive");
+    for r in &non_primary {
+        assert!(
+            mi_of(r).is_some_and(|mi| sec_mi.contains(&mi)),
+            "secondary/supplementary reads must carry the tc-keyed template's MI tag"
+        );
+    }
+    assert!(
+        !is_duplicate_by_name(&records, "sec_0"),
+        "a singleton template (including its tc-keyed secondary/supplementary) \
+         must not be marked duplicate"
+    );
+
+    // Control family (2 duplicate templates at 500/700, qualities 20/25):
+    // exactly 1 molecule, `ctrl_1` (the higher quality) kept, `ctrl_0` marked.
+    let ctrl = records_named(&records, "ctrl_");
+    let ctrl_mi: std::collections::HashSet<String> = ctrl.iter().filter_map(|r| mi_of(r)).collect();
+    assert_eq!(ctrl_mi.len(), 1, "the 2-template control family must resolve to 1 molecule");
+    assert!(is_duplicate_by_name(&records, "ctrl_0"), "ctrl_0 (quality 20) must be duplicate");
+    assert!(
+        !is_duplicate_by_name(&records, "ctrl_1"),
+        "ctrl_1 (quality 25, the family's highest) must be kept"
+    );
+
+    // Single-end fragments (3 unpaired reads, same UMI, same position, all
+    // quality 30 — a full 3-way tie). `mark_duplicates_in_family`'s size-3 fast
+    // path resolves a tie by keeping the FIRST record and marking the rest, so
+    // `frag_0` is kept and `frag_1`/`frag_2` are duplicates, deterministically
+    // (not merely "2 of the 3 are marked, order unspecified").
+    let frag = records_named(&records, "frag_");
+    assert_eq!(frag.len(), 3, "all 3 single-end fragments must survive");
+    assert!(frag.iter().all(|r| !r.flags().is_segmented()), "fragments must not carry PAIRED");
+    let frag_mi: std::collections::HashSet<String> = frag.iter().filter_map(|r| mi_of(r)).collect();
+    assert_eq!(frag_mi.len(), 1, "the 3 identical single-end fragments must resolve to 1 molecule");
+    assert!(!is_duplicate_by_name(&records, "frag_0"), "frag_0 must be the kept tie-break winner");
+    assert!(is_duplicate_by_name(&records, "frag_1"), "frag_1 must be marked duplicate");
+    assert!(is_duplicate_by_name(&records, "frag_2"), "frag_2 must be marked duplicate");
+}

--- a/tests/integration/test_group_command.rs
+++ b/tests/integration/test_group_command.rs
@@ -16,8 +16,7 @@ use tempfile::TempDir;
 
 use crate::helpers::assertions::assert_bam_sorted;
 use crate::helpers::bam_generator::{
-    create_minimal_header, create_query_grouped_header, create_umi_family,
-    create_umi_family_at_pos, to_record_buf,
+    create_minimal_header, create_umi_family, create_umi_family_at_pos, to_record_buf,
 };
 use crate::helpers::cli::run_and_capture_logs;
 use fgumi_lib::sam::SamTag;
@@ -205,7 +204,7 @@ fn create_test_bam_with_n_umis(path: &PathBuf) {
 }
 
 // ============================================================================
-// --check-crc / --no-check-crc on the single-threaded fast path (#800)
+// --check-crc / --no-check-crc on the default (no `--threads`) chain path (#800)
 // ============================================================================
 
 /// Flip a byte in the last BGZF block's CRC32 footer, so decoding that block
@@ -247,8 +246,8 @@ fn create_multiblock_group_bam(path: &PathBuf) {
     writer.try_finish().expect("Failed to finish BAM");
 }
 
-/// Build group's argv for the single-threaded fast path (no `--threads`),
-/// appending any extra flags (e.g. `--no-check-crc`).
+/// Build group's argv for the default (no `--threads`) invocation, appending
+/// any extra flags (e.g. `--no-check-crc`).
 fn group_args<'a>(input: &'a str, output: &'a str, extra: &[&'a str]) -> Vec<&'a str> {
     let mut args = vec![
         "group",
@@ -267,9 +266,10 @@ fn group_args<'a>(input: &'a str, output: &'a str, extra: &[&'a str]) -> Vec<&'a
     args
 }
 
-/// `--no-check-crc` must let group's single-threaded reader accept a corrupted
-/// BGZF CRC32: it decodes through fgumi-bgzf, honoring the flag (#800). Against
-/// the noodles reader this path used before, this could not pass.
+/// `--no-check-crc` must let `group`'s default (no `--threads`) reader accept a
+/// corrupted BGZF CRC32: it decodes through fgumi-bgzf, honoring the flag
+/// (#800). Against the noodles reader this path used before, this could not
+/// pass.
 #[test]
 fn test_group_no_check_crc_accepts_corrupted_crc() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -337,11 +337,8 @@ fn test_group_check_crc_rejects_corrupted_crc() {
 }
 
 // ============================================================================
-// Chain-backed `--threads N` path: parity with the single-threaded fast path
-// (the `group` pilot rewire). The `--threads` path now runs on the declarative
-// chain builder; these tests pin the behaviors the single-threaded oracle
-// cannot see: the chain's CRC policy and its record-ordering acceptance, plus
-// cross-mode output parity.
+// Chain-backed `group` path (the only execution path since the C4 cutover):
+// CRC policy, record-ordering acceptance, and worker-count determinism.
 // ============================================================================
 
 /// Read the complete `RecordBuf` for every output record, in output order,
@@ -391,12 +388,12 @@ fn run_group_records(
     read_group_records(&output)
 }
 
-/// The chain-backed `--threads N` path must honor the same CRC-verification
-/// policy as the single-threaded fast path — the plumbing that threads
-/// `effective_check_crc()` into the chain's BGZF decode. Before that plumbing
-/// the chain hardcoded verify-on, so `--no-check-crc --threads N` would have
-/// wrongly rejected a corrupted-CRC file. The single-threaded CRC tests above
-/// cannot see this path.
+/// `group --threads N` must honor `--no-check-crc`/`--check-crc` — the
+/// plumbing that threads `effective_check_crc()` into the chain's BGZF
+/// decode. Before that plumbing the chain hardcoded verify-on, so
+/// `--no-check-crc --threads N` would have wrongly rejected a corrupted-CRC
+/// file. The default-mode CRC tests above run through the same chain but
+/// don't exercise `--threads`, so they cannot see this path.
 #[rstest]
 #[case::no_check_crc_accepts(&["--no-check-crc"], true)]
 #[case::default_rejects(&[], false)]
@@ -441,34 +438,11 @@ fn test_group_threaded_crc_policy(#[case] extra: &[&str], #[case] expect_ok: boo
     }
 }
 
-/// The chain-backed `--threads 1` output must match the single-threaded fast
-/// path record-for-record on a normal template-coordinate input. This is the
-/// cross-mode parity oracle the within-mode determinism tests cannot provide.
-#[test]
-fn test_group_chain_matches_single_threaded() {
-    let temp_dir = TempDir::new().expect("Failed to create temp dir");
-    let input_bam = temp_dir.path().join("input.bam");
-    create_test_input_bam(&input_bam);
-
-    let single = run_group_records(temp_dir.path(), "single", &input_bam, &[]);
-    let chained = run_group_records(temp_dir.path(), "chained", &input_bam, &["--threads", "1"]);
-
-    assert!(
-        !single.is_empty(),
-        "sanity: expected grouped records so the parity check is not vacuous"
-    );
-    assert_eq!(
-        single, chained,
-        "chain (--threads 1) output must match the single-threaded fast path record-for-record",
-    );
-}
-
 /// Sibling of `dedup`'s `test_dedup_chain_index_threshold_banner_is_strategy_aware`:
-/// `group`'s non-chain path also reports the `Index threshold:` startup banner
-/// via the shared strategy/edits-aware `common::log_index_threshold` (see
-/// `group.rs`'s `execute`), so the chain path's banner must match it exactly --
-/// not the flat `Index threshold: {group.index_threshold}` (the raw
-/// `--index-threshold` value, unfloored) the chain path used to emit whenever
+/// `group`'s `Index threshold:` startup banner must be strategy/edits-aware,
+/// using the shared `common::log_index_threshold` wording exactly -- not the
+/// flat `Index threshold: {group.index_threshold}` (the raw `--index-threshold`
+/// value, unfloored) the chain path used to emit whenever
 /// `matches!(group.effective_strategy, Strategy::Adjacency | Strategy::Paired)`.
 ///
 /// `old_flat_regression_line` is `Some(line)` only when the OLD `matches!`-gated
@@ -617,104 +591,39 @@ fn test_group_chain_index_threshold_banner_paired_strategy() {
     );
 }
 
-/// A query-grouped (GO:query, not template-coordinate) input under
-/// `--allow-unmapped` must be accepted by the chain and produce output
-/// identical to the single-threaded path. The chain builder previously required
-/// `SO:queryname` and would have rejected this input; sharing the classifier
-/// (`require_group_input_ordering`) fixed that.
+/// `FGUMI_SHORT_CIRCUIT` was honored by the retired single-threaded path; the
+/// chain builder — now the only execution path — cannot honor it, so `execute_chain`
+/// warns and ignores it rather than silently no-op'ing. A dedicated process is
+/// required because the trigger is an environment variable (not a CLI flag), and
+/// the run must still succeed — the flag is ignored, not an error.
 #[test]
-fn test_group_allow_unmapped_query_grouped_chain_parity() {
+fn test_group_chain_warns_and_ignores_short_circuit_env() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let input_bam = temp_dir.path().join("input.bam");
-
-    // Query-grouped (GO:query) input, not template-coordinate sorted.
-    let header = create_query_grouped_header("chr1", 10000);
-    let mut writer =
-        bam::io::Writer::new(fs::File::create(&input_bam).expect("Failed to create BAM file"));
-    writer.write_header(&header).expect("Failed to write header");
-    let family1 = create_umi_family("AAAAAAAA", 10, "family1", "ACGTACGT", 30);
-    let family2 = create_umi_family("CCCCCCCC", 5, "family2", "TGCATGCA", 30);
-    for record in family1.iter().chain(family2.iter()) {
-        writer
-            .write_alignment_record(&header, &to_record_buf(record))
-            .expect("Failed to write record");
-    }
-    writer.try_finish().expect("Failed to finish BAM");
-
-    let single = run_group_records(temp_dir.path(), "single", &input_bam, &["--allow-unmapped"]);
-    let chained = run_group_records(
-        temp_dir.path(),
-        "chained",
-        &input_bam,
-        &["--allow-unmapped", "--threads", "1"],
-    );
-
-    // This fixture/flag combo is content-pinned by no other test, so guard
-    // against a vacuous pass where both paths regressed to empty/all-dropped
-    // output: 10 + 5 input reads across two UMI families, all accepted.
-    assert_eq!(single.len(), 15, "expected all 15 query-grouped reads in the output");
-    assert_eq!(
-        single, chained,
-        "chain and single-threaded --allow-unmapped output must match on a query-grouped input",
-    );
-}
-
-/// The chain's finalize hook writes metrics via `write_metrics_for_chain`, a
-/// separate path from the single-threaded `write_all_metrics`. This pins that
-/// the two produce identical metrics files (grouping-metrics and the
-/// family-size histogram) on the same input, so the two orchestrations cannot
-/// drift on secondary output. Metrics files are deterministic TSV count tables
-/// with no embedded paths/timestamps, so a byte comparison is stable.
-#[test]
-fn test_group_metrics_files_match_across_modes() {
-    let temp_dir = TempDir::new().expect("Failed to create temp dir");
-    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
     create_test_input_bam(&input_bam);
 
-    // Run `group` for one mode, returning (grouping-metrics, family-size-histogram) contents.
-    let run = |tag: &str, extra: &[&str]| -> (String, String) {
-        let output = temp_dir.path().join(format!("{tag}.bam"));
-        let grouping = temp_dir.path().join(format!("{tag}.grouping.txt"));
-        let famsize = temp_dir.path().join(format!("{tag}.famsize.txt"));
-        let mut args: Vec<&str> = vec![
-            "--grouping-metrics",
-            grouping.to_str().unwrap(),
-            "--family-size-histogram",
-            famsize.to_str().unwrap(),
-        ];
-        args.extend_from_slice(extra);
-        let cmd = GroupReadsByUmi::try_parse_from(group_args(
-            input_bam.to_str().unwrap(),
-            output.to_str().unwrap(),
-            &args,
-        ))
-        .expect("failed to parse group args");
-        cmd.execute("fgumi group").unwrap_or_else(|e| panic!("group ({tag}) failed: {e:#}"));
-        (
-            fs::read_to_string(&grouping).expect("read grouping metrics"),
-            fs::read_to_string(&famsize).expect("read family-size histogram"),
-        )
-    };
+    let result = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .env("RUST_LOG", "info")
+        .env("FGUMI_SHORT_CIRCUIT", "1")
+        .args(["group", "-i"])
+        .arg(&input_bam)
+        .arg("-o")
+        .arg(&output_bam)
+        .args(["--strategy", "adjacency", "--threads", "1"])
+        .output()
+        .expect("failed to spawn `fgumi group`");
 
-    let single = run("single", &[]);
-    let chained = run("chained", &["--threads", "1"]);
-
-    // Pin a concrete value so the equality checks below cannot pass on two empty
-    // or degenerate files: create_test_input_bam has 30 accepted records, and
-    // `accepted_sam_records` is the first grouping-metrics column.
+    let stderr = String::from_utf8_lossy(&result.stderr);
     assert!(
-        single.0.lines().nth(1).is_some_and(|row| row.starts_with("30\t")),
-        "grouping-metrics should report 30 accepted records; got:\n{}",
-        single.0
+        result.status.success(),
+        "FGUMI_SHORT_CIRCUIT must be ignored, not fatal; group failed:\n{stderr}"
     );
-
-    assert_eq!(
-        single.0, chained.0,
-        "grouping-metrics file must be identical across single-threaded and chain modes",
-    );
-    assert_eq!(
-        single.1, chained.1,
-        "family-size histogram must be identical across single-threaded and chain modes",
+    assert!(
+        stderr
+            .lines()
+            .any(|line| line.contains("FGUMI_SHORT_CIRCUIT is not supported by the chain builder")),
+        "expected a warning that FGUMI_SHORT_CIRCUIT is ignored on the chain path; got:\n{stderr}"
     );
 }
 
@@ -739,24 +648,24 @@ fn create_multi_batch_input_bam(path: &std::path::Path, n: usize) {
 }
 
 /// The chain's multi-worker path (`--threads N>1`) reorders across batches and
-/// accumulates per-batch `MoleculeId` offsets — machinery the `--threads 1` parity
-/// tests do not exercise. Compare `--threads 4` output record-for-record against
-/// the single-threaded oracle on an input spanning many position groups and
-/// multiple pipeline batches (> the 500-template batch size).
+/// accumulates per-batch `MoleculeId` offsets — machinery the `--threads 1`
+/// parity tests do not exercise. Compare `--threads 4` output record-for-record
+/// against the `--threads 1` oracle on an input spanning many position groups
+/// and multiple pipeline batches (> the 500-template batch size).
 #[test]
-fn test_group_chain_threads4_matches_single_threaded_multi_batch() {
+fn test_group_threads4_matches_threads1_multi_batch() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let input_bam = temp_dir.path().join("input.bam");
     create_multi_batch_input_bam(&input_bam, 600);
 
-    let single = run_group_records(temp_dir.path(), "single", &input_bam, &[]);
+    let threads1 = run_group_records(temp_dir.path(), "threads1", &input_bam, &["--threads", "1"]);
     let threads4 = run_group_records(temp_dir.path(), "threads4", &input_bam, &["--threads", "4"]);
 
     // 600 positions × 1 read → 600 output records spanning multiple batches.
-    assert_eq!(single.len(), 600, "expected 600 grouped records (one per position group)");
+    assert_eq!(threads1.len(), 600, "expected 600 grouped records (one per position group)");
     assert_eq!(
-        single, threads4,
-        "chain (--threads 4) output must match the single-threaded oracle record-for-record across batches",
+        threads1, threads4,
+        "chain (--threads 4) output must match the --threads 1 oracle record-for-record across batches",
     );
 }
 
@@ -945,10 +854,10 @@ fn assert_single_molecule_no_secondary(
     }
 }
 
-/// Regression for issue #901 across both the single-threaded fast path and the
-/// `--threads N` chain path, for single-end and paired input. A `tc`-keyed
-/// supplementary interleaved between two same-UMI reads of one molecule must not
-/// split it or appear in the output, on every path.
+/// Regression for issue #901 across both the default (no `--threads`) and
+/// `--threads N` chain invocations, for single-end and paired input. A
+/// `tc`-keyed supplementary interleaved between two same-UMI reads of one
+/// molecule must not split it or appear in the output, at any worker count.
 #[rstest]
 #[case::single_end(false)]
 #[case::paired(true)]

--- a/tests/integration/test_group_cutover_parity.rs
+++ b/tests/integration/test_group_cutover_parity.rs
@@ -1,0 +1,763 @@
+//! Cutover parity gate for the `group` command's legacy-path retirement (C4):
+//! `GroupReadsByUmi::execute` no longer has a no-`--threads` hand-rolled
+//! streaming engine (`execute_single_threaded`) — it *always* routes through
+//! the declarative chain builder (`execute_chain`). This test proves that
+//! cutover lost nothing user-observable in the UMI-family-assignment logic.
+//!
+//! Two independent things are checked here:
+//!
+//! 1. **The cutover actually happened** (`group_no_threads_routes_through_chain`).
+//!    A no-`--threads` run now emits the chain-only "Pipeline `group` ran in"
+//!    line from `pipeline::chains::finalize`, and the per-step `Pipeline stats`
+//!    table — both come from the pipeline-core runtime, which the retired
+//!    single-threaded engine never used. This is the RED (pre-removal) / GREEN
+//!    (post-removal) discriminator for the cutover.
+//!
+//! 2. **Output parity with the pre-removal legacy path**
+//!    (`cutover_matches_baseline_*`). The current build's `group` output — BAM
+//!    records (byte-identical, modulo the `@PG` line) and `--metrics`/
+//!    `--family-size-histogram`/`--grouping-metrics` — must match the frozen
+//!    legacy-path baseline binary run with no `--threads` (its hand-rolled
+//!    `execute_single_threaded` engine). The baseline path comes from
+//!    `FGUMI_BASELINE_BIN`; when unset (or names a missing file) the case
+//!    degrades to a self-consistency oracle rather than skipping — the
+//!    fallback discipline of `test_sort_cutover_parity.rs`.
+//!
+//! Coverage spans the shapes the campaign plan calls out as historically
+//! divergence-prone between the legacy engine and the chain: the assigner
+//! strategies `group` supports (identity / edit / adjacency / paired, the last
+//! exercising the `/A`+`/B` duplex-style molecule-id split), paired-end vs
+//! single-end (fragment) templates in the same input, the
+//! `--index-threshold` indexed-clustering path, and secondary/supplementary
+//! reads (which `group`, unlike `dedup`, discards entirely — see #903).
+
+use std::path::Path;
+use std::process::Command;
+
+use rstest::rstest;
+use tempfile::TempDir;
+
+use fgumi_lib::sam::SamTag;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
+
+use crate::helpers::bam_generator::{create_minimal_header, write_bam};
+use crate::helpers::read_bam_output;
+
+/// Resolves the saved pre-removal legacy-path baseline binary to compare
+/// against.
+///
+/// The path comes solely from `FGUMI_BASELINE_BIN`; when unset (or naming a
+/// missing file) this returns `None` — "no baseline oracle available", never a
+/// silent pass. Callers layer the baseline byte-parity check on top of the
+/// always-available self-consistency oracle; a missing baseline drops only the
+/// byte-parity half, it never skips the case. No hardcoded fallback: a baseline
+/// binary is host-specific and must never be a path committed into the repo.
+fn baseline_bin() -> Option<std::path::PathBuf> {
+    let path = std::path::PathBuf::from(std::env::var_os("FGUMI_BASELINE_BIN")?);
+    if path.is_file() {
+        return Some(path);
+    }
+    eprintln!(
+        "FGUMI_BASELINE_BIN={} does not name an existing file; baseline oracle unavailable",
+        path.display()
+    );
+    None
+}
+
+/// Removes every `@PG` line from a SAM header text blob.
+///
+/// The fixtures are built by piping through `fgumi sort` (see
+/// `create_sorted_bam`), which stamps its own `@PG` line, so the group input
+/// already carries one before `group` adds a second (`PP`-chained) one. The
+/// `sort` line is byte-identical between the current build's run and the
+/// baseline's — both invoke the *same* `fgumi sort` binary on the same input —
+/// so it would compare equal either way; it is the `group`/baseline-binary
+/// `@PG` line that differs (`VN`, the git-describe version, and `CL`, which
+/// names argv[0] — a different binary path for each side — and the per-run
+/// output path). Stripping every `@PG` line rather than only the last one is
+/// simply the simpler correct implementation: dropping an already-identical
+/// line changes nothing.
+fn strip_pg_lines(text: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+    let mut lines: Vec<&str> = text.split('\n').collect();
+    let had_trailing_newline = lines.last() == Some(&"");
+    if had_trailing_newline {
+        lines.pop();
+    }
+    lines.retain(|line| !line.starts_with("@PG"));
+    let mut out = lines.join("\n");
+    if had_trailing_newline {
+        out.push('\n');
+    }
+    out
+}
+
+/// Reads a BAM's raw BGZF stream, decompresses it, strips the `@PG` line(s) from
+/// the embedded SAM header text, and returns the resulting bytes (new header +
+/// unmodified `n_ref`/reference-list/record bytes).
+///
+/// Comparing the *decompressed* BAM binary — rather than `RecordBuf`-parsed
+/// records or raw file bytes — keeps everything except the `@PG` line an exact,
+/// uninterpreted byte comparison: BGZF block boundaries differ between the two
+/// writers even for identical logical content (so raw file bytes never match),
+/// while parsing into `RecordBuf` and re-encoding could mask a real tag-order or
+/// binary-layout regression (e.g. MI-tag injection) by normalizing it away.
+fn decompressed_records_without_pg(path: &Path) -> Vec<u8> {
+    let file = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+    let mut reader = noodles::bgzf::io::Reader::new(std::io::BufReader::new(file));
+    let mut raw = Vec::new();
+    std::io::Read::read_to_end(&mut reader, &mut raw)
+        .unwrap_or_else(|e| panic!("decompress BGZF stream for {}: {e}", path.display()));
+
+    assert!(
+        raw.len() >= 8 && &raw[0..4] == b"BAM\x01",
+        "{} does not decompress to a BAM binary stream (missing magic)",
+        path.display()
+    );
+    let l_text = i32::from_le_bytes(raw[4..8].try_into().expect("4 bytes"));
+    let l_text = usize::try_from(l_text).expect("l_text is non-negative");
+    let text_start = 8;
+    let text_end = text_start + l_text;
+    assert!(raw.len() >= text_end, "{} header text runs past end of stream", path.display());
+
+    let text = String::from_utf8_lossy(&raw[text_start..text_end]);
+    let stripped_text = strip_pg_lines(&text);
+
+    let mut out = Vec::with_capacity(raw.len());
+    out.extend_from_slice(b"BAM\x01");
+    let new_l_text = i32::try_from(stripped_text.len()).expect("stripped header text fits i32");
+    out.extend_from_slice(&new_l_text.to_le_bytes());
+    out.extend_from_slice(stripped_text.as_bytes());
+    out.extend_from_slice(&raw[text_end..]); // n_ref, reference list, and all records, untouched
+    out
+}
+
+/// Writes `records` to an unsorted BAM alongside `path`, then runs `fgumi
+/// sort --order template-coordinate` to produce the final input at `path`.
+///
+/// `group` requires *true* template-coordinate order for
+/// `RecordPositionGrouper`'s streaming position-group boundaries to line up
+/// correctly; writing records in an order that merely satisfies the header's
+/// `SO`/`GO`/`SS` tags is not sufficient. Routing through a real `fgumi sort`
+/// is the same approach `test_dedup_command.rs::create_sorted_bam_with_header`
+/// uses for exactly this reason.
+fn create_sorted_bam(path: &Path, header: &noodles::sam::Header, records: &[RawRecord]) {
+    let unsorted = path.with_extension("unsorted.bam");
+    write_bam(&unsorted, header, records);
+
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "sort",
+            "-i",
+            unsorted.to_str().unwrap(),
+            "-o",
+            path.to_str().unwrap(),
+            "--order",
+            "template-coordinate",
+            "--key-types",
+            "mi",
+        ])
+        .status()
+        .unwrap_or_else(|e| panic!("failed to spawn `fgumi sort` for test input: {e}"));
+    assert!(status.success(), "failed to template-coordinate sort test input {}", path.display());
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Fixture builders
+//////////////////////////////////////////////////////////////////////////////
+
+/// Builds one paired-end template: R1 at `r1_pos` and R2 at `r2_pos` (1-based
+/// reference positions), with the given `umi` and strand orientation. Carries
+/// `MC` (required by `RecordPositionGrouper` for paired reads).
+fn build_pair(
+    name: &str,
+    umi: &str,
+    r1_pos: i32,
+    r2_pos: i32,
+    r1_reverse: bool,
+    base_qual: u8,
+) -> (RawRecord, RawRecord) {
+    let seq = b"ACGTACGT";
+    let cigar_op = (u32::try_from(seq.len()).expect("fits u32")) << 4;
+    let r2_reverse = !r1_reverse;
+    let tlen = (r2_pos - r1_pos) + i32::try_from(seq.len()).expect("fits i32");
+
+    let mut b1 = SamBuilder::new();
+    b1.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(&vec![base_qual; seq.len()])
+        .flags(
+            flags::PAIRED
+                | flags::FIRST_SEGMENT
+                | if r1_reverse { flags::REVERSE } else { 0 }
+                | if r2_reverse { flags::MATE_REVERSE } else { 0 },
+        )
+        .ref_id(0)
+        .pos(r1_pos - 1)
+        .mapq(60)
+        .cigar_ops(&[cigar_op])
+        .mate_ref_id(0)
+        .mate_pos(r2_pos - 1)
+        .template_length(tlen)
+        .add_string_tag(SamTag::MC, b"8M")
+        .add_string_tag(SamTag::RX, umi.as_bytes());
+
+    let mut b2 = SamBuilder::new();
+    b2.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(&vec![base_qual; seq.len()])
+        .flags(
+            flags::PAIRED
+                | flags::LAST_SEGMENT
+                | if r2_reverse { flags::REVERSE } else { 0 }
+                | if r1_reverse { flags::MATE_REVERSE } else { 0 },
+        )
+        .ref_id(0)
+        .pos(r2_pos - 1)
+        .mapq(60)
+        .cigar_ops(&[cigar_op])
+        .mate_ref_id(0)
+        .mate_pos(r1_pos - 1)
+        .template_length(-tlen)
+        .add_string_tag(SamTag::MC, b"8M")
+        .add_string_tag(SamTag::RX, umi.as_bytes());
+
+    (b1.build(), b2.build())
+}
+
+/// Builds `count` paired templates, all at the same coordinates and UMI.
+fn build_family(
+    base_name: &str,
+    umi: &str,
+    count: usize,
+    r1_pos: i32,
+    r2_pos: i32,
+) -> Vec<RawRecord> {
+    let mut records = Vec::with_capacity(count * 2);
+    for i in 0..count {
+        let (r1, r2) = build_pair(&format!("{base_name}_{i}"), umi, r1_pos, r2_pos, false, 30);
+        records.push(r1);
+        records.push(r2);
+    }
+    records
+}
+
+/// A single-end (unpaired, mapped) read at `pos` with `umi`.
+fn build_single_end(name: &str, umi: &str, pos: i32) -> RawRecord {
+    let seq = b"ACGTACGT";
+    let cigar_op = (u32::try_from(seq.len()).expect("fits u32")) << 4;
+    let mut b = SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(&[30; 8])
+        .flags(0)
+        .ref_id(0)
+        .pos(pos - 1)
+        .mapq(60)
+        .cigar_ops(&[cigar_op])
+        .add_string_tag(SamTag::RX, umi.as_bytes());
+    b.build()
+}
+
+/// A secondary or supplementary read at the same coordinates as a primary
+/// pair. `group` (unlike `dedup`) discards secondary/supplementary reads
+/// entirely (#903), so unlike `dedup`'s cutover-parity fixture this needs no
+/// `tc` tag — it never reaches template building.
+fn build_non_primary_at(
+    name: &str,
+    umi: &str,
+    pos: i32,
+    mate_pos: i32,
+    supplementary: bool,
+) -> (RawRecord, RawRecord) {
+    let seq = b"ACGTACGT";
+    let cigar_op = (u32::try_from(seq.len()).expect("fits u32")) << 4;
+    let non_primary_flag = if supplementary { flags::SUPPLEMENTARY } else { flags::SECONDARY };
+    let mut b1 = SamBuilder::new();
+    b1.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(&[30; 8])
+        .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE | non_primary_flag)
+        .ref_id(0)
+        .pos(pos - 1)
+        .mapq(60)
+        .cigar_ops(&[cigar_op])
+        .mate_ref_id(0)
+        .mate_pos(mate_pos - 1)
+        .add_string_tag(SamTag::RX, umi.as_bytes());
+    let mut b2 = SamBuilder::new();
+    b2.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(&[30; 8])
+        .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE | non_primary_flag)
+        .ref_id(0)
+        .pos(mate_pos - 1)
+        .mapq(60)
+        .cigar_ops(&[cigar_op])
+        .mate_ref_id(0)
+        .mate_pos(pos - 1)
+        .add_string_tag(SamTag::RX, umi.as_bytes());
+    (b1.build(), b2.build())
+}
+
+/// The main fixture: three independent position groups exercising, in one
+/// input, everything a single strategy run needs to prove parity on:
+///
+/// - `(100, 300)`: a 3-read exact-UMI family (`AAAAAAAA`) plus a 2-read
+///   1-mismatch family (`AAAAAAAT`) — under `--strategy identity` these are two
+///   separate molecules; under `edit`/`adjacency` they cluster into one. Also
+///   carries one secondary and one supplementary pair, which must be dropped
+///   entirely from the output regardless of strategy.
+/// - `(500, 700)`: a plain 2-read family (`CCCCCCCC`), an ordinary paired
+///   control group.
+/// - single-end reads at position `900`: 3 unpaired reads sharing UMI
+///   `GGGGGGGG` — the fragment shape.
+fn build_family_fixture(dir: &Path) -> std::path::PathBuf {
+    let input = dir.join("in.bam");
+    let header = create_minimal_header("chr1", 10000);
+
+    let mut records = Vec::new();
+    records.extend(build_family("exact", "AAAAAAAA", 3, 100, 300));
+    records.extend(build_family("near", "AAAAAAAT", 2, 100, 300));
+    let (s1, s2) = build_non_primary_at("exact_0_sec", "AAAAAAAA", 100, 300, false);
+    records.push(s1);
+    records.push(s2);
+    let (u1, u2) = build_non_primary_at("exact_0_sup", "AAAAAAAA", 100, 300, true);
+    records.push(u1);
+    records.push(u2);
+
+    records.extend(build_family("ctrl", "CCCCCCCC", 2, 500, 700));
+
+    for i in 0..3 {
+        records.push(build_single_end(&format!("frag_{i}"), "GGGGGGGG", 900));
+    }
+
+    create_sorted_bam(&input, &header, &records);
+    input
+}
+
+/// A duplex-shaped fixture for `--strategy paired`: two templates at the same
+/// coordinates carrying the paired-UMI format (`AAAA-CCCC`) in opposite
+/// physical orientations (FR vs RF) — the shape that makes the `PairedUmiAssigner`
+/// assign the same molecule two distinct `/A`/`/B` suffixes.
+fn build_paired_strategy_fixture(dir: &Path) -> std::path::PathBuf {
+    let input = dir.join("in.bam");
+    let header = create_minimal_header("chr1", 10000);
+
+    let mut records = Vec::new();
+    let (r1, r2) = build_pair("duplex_fwd", "AAAA-CCCC", 100, 300, false, 30);
+    records.push(r1);
+    records.push(r2);
+    let (r1, r2) = build_pair("duplex_rev", "AAAA-CCCC", 300, 100, true, 30);
+    records.push(r1);
+    records.push(r2);
+
+    create_sorted_bam(&input, &header, &records);
+    input
+}
+
+/// A single large position group of `n` templates with pairwise-distinct UMIs,
+/// large enough to cross the default `--index-threshold 100` (adjacency/edit
+/// index at `--edits 1`) so both the current build and the baseline exercise
+/// the indexed-clustering path.
+fn build_index_threshold_fixture(dir: &Path, n: usize) -> std::path::PathBuf {
+    let input = dir.join("in.bam");
+    let header = create_minimal_header("chr1", 10000);
+
+    let bases = [b'A', b'C', b'G', b'T'];
+    let mut records = Vec::with_capacity(n * 2);
+    for i in 0..n {
+        // Single-parity-check code: the first 7 symbols are the base-4 digits
+        // of `i` (4^7 = 16384, far more than `n`), the 8th is their digit-sum
+        // mod 4. Flipping exactly one base always changes that sum mod 4, so
+        // any two *distinct* codes from this family differ in at least 2
+        // positions — never edit distance 1 of each other. Plain sequential
+        // base-4 digits (no parity digit) do NOT have this property:
+        // consecutive indices differ only in their lowest digit, chaining
+        // almost every UMI to a neighbor at edit distance 1 and letting
+        // adjacency's directed capture collapse the whole set into one
+        // molecule — not the "120 independent molecules" this fixture needs
+        // to isolate the indexed-clustering path from UMI-clustering
+        // behavior.
+        let mut umi = [b'A'; 8];
+        let mut v = i;
+        let mut parity = 0usize;
+        for slot in &mut umi[..7] {
+            let digit = v % 4;
+            v /= 4;
+            parity = (parity + digit) % 4;
+            *slot = bases[digit];
+        }
+        umi[7] = bases[parity];
+        let umi = std::str::from_utf8(&umi).expect("ACGT is valid UTF-8");
+        let (r1, r2) = build_pair(&format!("idx_{i}"), umi, 100, 300, false, 30);
+        records.push(r1);
+        records.push(r2);
+    }
+
+    create_sorted_bam(&input, &header, &records);
+    input
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Runner
+//////////////////////////////////////////////////////////////////////////////
+
+/// Runs `<bin> group` (no `--threads`, so the current build takes the
+/// post-cutover chain path and the baseline takes its legacy engine) with
+/// `RUST_LOG=info`, and returns the process output for stderr/exit assertions.
+#[allow(clippy::too_many_arguments)]
+fn run_group(
+    bin: &Path,
+    input: &Path,
+    output: &Path,
+    strategy: &str,
+    metrics_prefix: Option<&Path>,
+    index_threshold: Option<&str>,
+) -> std::process::Output {
+    let mut cmd = Command::new(bin);
+    cmd.env("RUST_LOG", "info").args([
+        "group",
+        "-i",
+        input.to_str().unwrap(),
+        "-o",
+        output.to_str().unwrap(),
+        "--strategy",
+        strategy,
+        "--compression-level",
+        "1",
+    ]);
+    if let Some(m) = metrics_prefix {
+        cmd.args(["-M", m.to_str().unwrap()]);
+    }
+    if let Some(t) = index_threshold {
+        cmd.args(["--index-threshold", t]);
+    }
+    cmd.output().unwrap_or_else(|e| panic!("failed to spawn `{}` group: {e}", bin.display()))
+}
+
+/// The three files a `--metrics PREFIX` run writes (see
+/// `commands::group::with_extension`).
+fn metrics_prefix_paths(
+    prefix: &Path,
+) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+    let ext = |suffix: &str| {
+        let mut s = prefix.as_os_str().to_owned();
+        s.push(".");
+        s.push(suffix);
+        std::path::PathBuf::from(s)
+    };
+    (ext("family_sizes.txt"), ext("grouping_metrics.txt"), ext("position_group_sizes.txt"))
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Tests
+//////////////////////////////////////////////////////////////////////////////
+
+/// A no-`--threads` run now routes through the declarative chain, which logs
+/// "Pipeline `group` ran in" (from `pipeline::chains::finalize`) and the
+/// per-step `Pipeline stats` table (from the pipeline-core runtime). The
+/// retired single-threaded engine never printed either — a hand-rolled
+/// streaming loop with no step-based runtime — so this is the RED
+/// (pre-removal) -> GREEN (post-removal) discriminator for the cutover.
+#[test]
+fn group_no_threads_routes_through_chain() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = build_family_fixture(dir.path());
+    let output = dir.path().join("out.bam");
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let out = run_group(current_bin, &input, &output, "identity", None, None);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "no-threads group must succeed; stderr:\n{stderr}");
+    assert!(
+        stderr.contains("Pipeline `group` ran in"),
+        "a no-`--threads` group must route through the chain (which logs the pipeline-core \
+         finalize line); the single-threaded engine is retired. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Starting group"),
+        "the chain must still emit the `Starting group` banner; stderr:\n{stderr}"
+    );
+}
+
+/// Output parity of the post-cutover chain against the pre-removal legacy-path
+/// baseline binary (run with no `--threads`, i.e. its single-threaded engine),
+/// across the assigner strategies `group` supports — plus the always-available
+/// self-consistency oracle when no baseline is set.
+///
+/// `identity` keeps the exact/near-mismatch families in [`build_family_fixture`]
+/// as two distinct molecules; `edit` and `adjacency` cluster them into one. All
+/// three exercise the secondary/supplementary-discard and single-end (fragment)
+/// position groups identically, since strategy only changes UMI clustering.
+#[rstest]
+#[case::identity("identity")]
+#[case::edit("edit")]
+#[case::adjacency("adjacency")]
+fn cutover_matches_baseline_by_strategy(#[case] strategy: &str) {
+    let dir = TempDir::new().expect("temp dir");
+    let input = build_family_fixture(dir.path());
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current_prefix = dir.path().join("current");
+    let current =
+        run_group(current_bin, &input, &current_out, strategy, Some(&current_prefix), None);
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(current.status.success(), "current group must succeed; stderr:\n{current_stderr}");
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let baseline_prefix = dir.path().join("baseline");
+        let base =
+            run_group(&baseline, &input, &baseline_out, strategy, Some(&baseline_prefix), None);
+        assert!(
+            base.status.success(),
+            "baseline group failed; stderr:\n{}",
+            String::from_utf8_lossy(&base.stderr)
+        );
+
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "chain group output (--strategy {strategy}) diverges from the pre-removal legacy \
+             baseline binary ({}) after stripping @PG — a real cutover parity bug",
+            baseline.display(),
+        );
+
+        let (cur_fam, cur_grp, cur_pos) = metrics_prefix_paths(&current_prefix);
+        let (base_fam, base_grp, base_pos) = metrics_prefix_paths(&baseline_prefix);
+        for (label, cur, base) in [
+            ("family_sizes", cur_fam, base_fam),
+            ("grouping_metrics", cur_grp, base_grp),
+            ("position_group_sizes", cur_pos, base_pos),
+        ] {
+            assert_eq!(
+                std::fs::read_to_string(&cur).unwrap_or_else(|e| panic!("current {label}: {e}")),
+                std::fs::read_to_string(&base).unwrap_or_else(|e| panic!("baseline {label}: {e}")),
+                "chain --metrics {label} TSV (--strategy {strategy}) diverges from the legacy \
+                 baseline"
+            );
+        }
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_matches_baseline_by_strategy[{strategy}]: \
+             FGUMI_BASELINE_BIN is unset or does not name an existing file — running \
+             self-consistency oracle instead"
+        );
+        assert_self_consistent_family_fixture(&current_out, strategy);
+    }
+}
+
+/// Output parity for `--strategy paired` on the duplex-shaped (`/A`/`/B`)
+/// fixture — the known-divergence shape where a paired UMI read from both
+/// physical strands must resolve to one canonical molecule split into two
+/// duplex halves.
+#[test]
+fn cutover_matches_baseline_paired_duplex() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = build_paired_strategy_fixture(dir.path());
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current = run_group(current_bin, &input, &current_out, "paired", None, None);
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(
+        current.status.success(),
+        "current group (paired) must succeed; stderr:\n{current_stderr}"
+    );
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let base = run_group(&baseline, &input, &baseline_out, "paired", None, None);
+        assert!(
+            base.status.success(),
+            "baseline group (paired) failed; stderr:\n{}",
+            String::from_utf8_lossy(&base.stderr)
+        );
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "chain group output (--strategy paired, duplex A/B shape) diverges from the \
+             pre-removal legacy baseline binary ({}) after stripping @PG",
+            baseline.display(),
+        );
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_matches_baseline_paired_duplex: FGUMI_BASELINE_BIN \
+             is unset or does not name an existing file — running self-consistency oracle instead"
+        );
+        let (_, records) = read_bam_output(&current_out);
+        assert_eq!(records.len(), 4, "both duplex-strand templates (2 reads each) must survive");
+        let mi_tags = mi_strings(&records);
+        assert_eq!(mi_tags.len(), 4, "every record must carry an MI tag");
+        let distinct: std::collections::HashSet<&String> = mi_tags.iter().collect();
+        assert_eq!(
+            distinct.len(),
+            2,
+            "the two physical-strand templates must resolve to exactly 2 distinct molecule ids \
+             (the /A and /B duplex halves), got: {mi_tags:?}"
+        );
+        assert!(
+            mi_tags.iter().any(|m| m.ends_with("/A")) && mi_tags.iter().any(|m| m.ends_with("/B")),
+            "the paired assigner must emit both a /A and a /B suffixed molecule id, got: {mi_tags:?}"
+        );
+    }
+}
+
+/// Output parity across the `--index-threshold`-triggered indexed-clustering
+/// path: a single position group of 120 pairwise-distinct UMIs under
+/// `--strategy adjacency`, which crosses the default `--index-threshold 100`
+/// and forces both binaries onto the N-gram/BK-tree index rather than the
+/// brute-force pairwise comparison.
+#[test]
+fn cutover_matches_baseline_index_threshold() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = build_index_threshold_fixture(dir.path(), 120);
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current = run_group(current_bin, &input, &current_out, "adjacency", None, Some("always"));
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(
+        current.status.success(),
+        "current group (index-threshold always) must succeed; stderr:\n{current_stderr}"
+    );
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let base = run_group(&baseline, &input, &baseline_out, "adjacency", None, Some("always"));
+        assert!(
+            base.status.success(),
+            "baseline group (index-threshold always) failed; stderr:\n{}",
+            String::from_utf8_lossy(&base.stderr)
+        );
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "chain group output (120-UMI indexed adjacency) diverges from the pre-removal \
+             legacy baseline binary ({}) after stripping @PG",
+            baseline.display(),
+        );
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_matches_baseline_index_threshold: FGUMI_BASELINE_BIN \
+             is unset or does not name an existing file — running self-consistency oracle instead"
+        );
+        let (_, records) = read_bam_output(&current_out);
+        assert_eq!(records.len(), 240, "all 120 templates (2 reads each) must survive");
+        let mi_tags = mi_strings(&records);
+        let distinct: std::collections::HashSet<&String> = mi_tags.iter().collect();
+        assert_eq!(
+            distinct.len(),
+            120,
+            "120 pairwise-distinct UMIs must resolve to 120 distinct molecule ids"
+        );
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Self-consistency oracle
+//////////////////////////////////////////////////////////////////////////////
+
+/// Extracts every record's `MI:Z` tag value (skips records without one).
+fn mi_strings(records: &[noodles::sam::alignment::RecordBuf]) -> Vec<String> {
+    use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::Value;
+
+    let mi_tag = Tag::from(SamTag::MI);
+    records
+        .iter()
+        .filter_map(|r| match r.data().get(&mi_tag) {
+            Some(Value::String(s)) => Some(s.to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn mi_of(record: &noodles::sam::alignment::RecordBuf) -> Option<String> {
+    use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::Value;
+
+    match record.data().get(&Tag::from(SamTag::MI)) {
+        Some(Value::String(s)) => Some(s.to_string()),
+        _ => None,
+    }
+}
+
+/// Always-available oracle used when no baseline binary is set: proves the
+/// chain's group output on [`build_family_fixture`] is a real transform, not a
+/// passthrough — every kept record carries an `MI` tag, the exact/near-UMI
+/// families come out as the strategy-appropriate number of distinct molecules,
+/// secondary/supplementary reads are entirely absent from the output, and
+/// single-end fragments form their own molecule.
+///
+/// A no-op run (output MI-family structure identical across an input that
+/// should cluster, or secondary/supplementary reads leaking through) fails
+/// this — see the per-assertion messages.
+fn assert_self_consistent_family_fixture(output: &Path, strategy: &str) {
+    let (_, records) = read_bam_output(output);
+    // exact(3 pairs=6) + near(2 pairs=4) + ctrl(2 pairs=4) + frag(3) = 17; the
+    // 2 secondary + 2 supplementary reads are discarded entirely (#903).
+    assert_eq!(
+        records.len(),
+        17,
+        "secondary/supplementary reads must be discarded and every primary kept"
+    );
+    assert!(
+        records.iter().all(|r| !r.flags().is_secondary() && !r.flags().is_supplementary()),
+        "no output record may be flagged secondary or supplementary"
+    );
+
+    let mi_tags = mi_strings(&records);
+    assert_eq!(mi_tags.len(), 17, "every kept record must carry an MI tag");
+
+    // The exact(3)+near(2) position group: under identity, 2 distinct
+    // molecules; under edit/adjacency, they cluster into 1.
+    let exact_near_mi: std::collections::HashSet<String> = records
+        .iter()
+        .filter(|r| {
+            r.name().is_some_and(|n| {
+                let n = String::from_utf8_lossy(n.as_ref());
+                n.starts_with("exact_") || n.starts_with("near_")
+            })
+        })
+        .filter_map(mi_of)
+        .collect();
+    let expected_molecules = if strategy == "identity" { 2 } else { 1 };
+    assert_eq!(
+        exact_near_mi.len(),
+        expected_molecules,
+        "--strategy {strategy}: exact(AAAAAAAA)+near(AAAAAAAT) families must resolve to \
+         {expected_molecules} distinct molecule id(s), got {exact_near_mi:?}"
+    );
+
+    // Control family (2 templates at 500/700): exactly 1 molecule.
+    let ctrl_mi: std::collections::HashSet<String> = records
+        .iter()
+        .filter(|r| {
+            r.name().is_some_and(|n| String::from_utf8_lossy(n.as_ref()).starts_with("ctrl_"))
+        })
+        .filter_map(mi_of)
+        .collect();
+    assert_eq!(ctrl_mi.len(), 1, "the 2-template control family must resolve to 1 molecule");
+
+    // Single-end fragments (3 unpaired reads, same UMI, same position): one
+    // molecule, and none carry the PAIRED flag.
+    let frag_records: Vec<_> = records
+        .iter()
+        .filter(|r| {
+            r.name().is_some_and(|n| String::from_utf8_lossy(n.as_ref()).starts_with("frag_"))
+        })
+        .collect();
+    assert_eq!(frag_records.len(), 3, "all 3 single-end fragments must survive");
+    assert!(
+        frag_records.iter().all(|r| !r.flags().is_segmented()),
+        "single-end fragments must not carry the PAIRED flag"
+    );
+    let frag_mi: std::collections::HashSet<String> =
+        frag_records.iter().filter_map(|r| mi_of(r)).collect();
+    assert_eq!(frag_mi.len(), 1, "the 3 identical single-end fragments must resolve to 1 molecule");
+}

--- a/tests/integration/test_group_determinism.rs
+++ b/tests/integration/test_group_determinism.rs
@@ -211,11 +211,10 @@ fn read_qname_mi(path: &Path) -> Vec<(String, u16, String)> {
 /// comparing pairwise raises the probability of catching the variance even
 /// when only a handful of subgroup keys are present.
 ///
-/// `threads = None` omits the `--threads` flag entirely. For `fgumi group`
-/// this triggers the dedicated `execute_single_threaded` fast path
-/// (`src/lib/commands/group.rs`'s `if self.threading.threads.is_none()` at
-/// the top of `execute`); `Some("1")` runs the parallel pipeline with one
-/// worker, which is a different code path. Both must be deterministic.
+/// `threads = None` omits the `--threads` flag entirely, which still runs the
+/// declarative chain builder (the only execution path for `group`/`dedup`) —
+/// `ThreadingOptions::num_threads` resolves the omitted flag to 1 worker, the
+/// same as `Some("1")` below. Both must be deterministic.
 fn assert_mi_deterministic(subcommand: &str, threads: Option<&str>, n_runs: usize) {
     let temp_dir = TempDir::new().unwrap();
     let input_bam = temp_dir.path().join("input.bam");
@@ -299,13 +298,13 @@ fn assert_mi_deterministic(subcommand: &str, threads: Option<&str>, n_runs: usiz
 /// must assign identical `MI:Z` tags to every record across runs and across
 /// every supported threading mode.
 ///
-/// The three threads cases exercise three distinct code paths:
+/// The three threads cases all run the declarative chain builder (the only
+/// execution path), at different worker counts:
 ///
-/// * `None` — `group` only: the dedicated `execute_single_threaded` fast
-///   path (taken when `--threads` is omitted), which assigns `MoleculeId`s
-///   inline without going through the unified pipeline scheduler.
-/// * `Some("1")` — the unified pipeline with a single worker.
-/// * `Some("4")` — the unified pipeline with four workers, which was the
+/// * `None` — `group` only: `--threads` omitted, which resolves to 1 worker
+///   (same as `Some("1")` below).
+/// * `Some("1")` — the chain pipeline with a single worker.
+/// * `Some("4")` — the chain pipeline with four workers, which was the
 ///   originally failing case before the serial-ordered `MI Assign` hook.
 #[rstest]
 #[case::group_no_threads("group", None)]


### PR DESCRIPTION
## What

Retire the legacy single-threaded execution paths in **both** `fgumi dedup` and `fgumi group` so the declarative chain builder is the **only** path for each. They share the assigner/grouper machinery, so they are retired together. Each `execute()` keeps its reader-free pre-flight validation and then always dispatches to the chain (`add_dedup` / `add_group`), with or without `--threads`. Output is byte-identical (modulo `@PG`).

Both legacy paths were `unified_pipeline` consumers, so this also **drops their `unified_pipeline` imports** — `dedup`: `GroupKeyConfig`, `Grouper`, `run_bam_pipeline_from_reader_with_mi_assign`; `group`: `DecodedRecord`, `Grouper`, `compute_group_key_from_raw`. The `unified_pipeline` module itself is untouched (its full deletion is a later campaign step); this reduces the coupling ahead of that.

> [!NOTE]
> Stacked on #914 (chain diagnostic parity), which put the dedup/group index-threshold banner on the chain — the precondition for deleting the legacy banner without a diagnostic regression. #918 (dedup UMI-position cache) is a separate, byte-identical perf co-requisite; it is not required for this correctness cutover.

## Parity analysis (done before deleting)

Every diagnostic the legacy paths emitted is already produced by the chain (`add_dedup`/`add_group` + finalize hooks): the banner + strategy/edits params, `OperationTimer`, progress, the index-threshold banner (from #914), the grouping/duplicate summary, CRC-verify line, and `@PG`. One gap was found and fixed: the chain `dedup` path was missing the `Input: <path>` info line the legacy path logged — **restored** on `add_dedup` (group's chain already logged it). `Scheduler: <strategy>` was already absent from the `--threads N` chain path before this PR (a pre-existing chain gap, not introduced here); the dispatch doc comment now names that exception explicitly rather than claiming full re-emission.

## Tests

- `tests/integration/test_dedup_cutover_parity.rs`, `tests/integration/test_group_cutover_parity.rs` — pin each command's no-`--threads` chain output against the frozen pre-removal baseline via `FGUMI_BASELINE_BIN` (records byte-identical modulo `@PG`, plus metrics) across UMI strategies (identity/edit/adjacency/paired), the index-threshold path, and a `tc`-keyed secondary/supplementary shape. Fixtures route through a real `fgumi sort --order template-coordinate`. When `FGUMI_BASELINE_BIN` is unset (default CI), the self-consistency oracle asserts real transform behavior — for `dedup`, **exact per-family duplicate/kept outcomes** (derived from the fixtures' known base qualities) across both `identity` and `adjacency`, so a chain that mismarks duplicates within a family fails in CI, not just a passthrough.
- The old "chain vs single-threaded" tests are reconciled to the post-cutover reality: those that compared no-`--threads` against `--threads 1` (now the identical chain configuration) are deleted, superseded by the cutover-parity oracle; those comparing `--threads 1` against `N>1` are kept and reworded as worker-count-determinism checks (no more "single-threaded"/"non-chain"/`write_all_metrics` framing).

Full gate green: `cargo check` in all three feature configs (default, `--all-features`, `--no-default-features`), `ci-fmt`/`ci-lint`/`ci-doc`, and `ci-test` (9972 passed / 31 skipped) both with and without `FGUMI_BASELINE_BIN` set proving byte-parity for both commands. Part of the per-command R6-0 legacy-path retirements; no user-facing behavior change (no-`--threads` now runs the chain at a single worker).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: Grouping, corrected UMI, sort-order, and metrics output can change; declarative-chain execution and parity tests pin the new output. Consensus output: none. `unsafe`: none; `CLAUDE.md` allowlist update: none. Thread and backpressure policy changes: all runs now use the chain, with chain worker counts and queue-memory limits.

- `fgumi dedup` and `fgumi group` validate before execution and always use the declarative chain.
- Retired legacy single-threaded execution paths were removed.
- Tests cover UMI strategies, indexed processing, secondary and supplementary reads, metrics, histograms, and worker determinism.
- Optional baseline comparisons provide byte-level parity checks after `@PG` normalization.
- `dedup` restores the `Input: <path>` diagnostic. The chain still has no `Scheduler: <strategy>` diagnostic.
- `group` ignores unsupported legacy `--debug-memory` and `FGUMI_SHORT_CIRCUIT` behavior and reports the limitation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->