### PR TITLE
refactor(pipeline): relocate reusable types out of unified_pipeline (R6a)

### DIFF
--- a/src/lib/batch_weight.rs
+++ b/src/lib/batch_weight.rs
@@ -1,0 +1,26 @@
+//! Batch weight trait for template-based batching.
+//!
+//! Moved out of `unified_pipeline::base` (C5/R6a) so `grouper`/`mi_group` can
+//! depend on it without going through the (now-legacy) `unified_pipeline`
+//! module. Stays in the root crate rather than `fgumi-bam-io`: its surviving
+//! implementations target foreign types (`noodles::sam::alignment::RecordBuf`,
+//! `fgumi_raw_bam::RawRecord`, `Vec<u8>`), which are only legal `impl`s while
+//! the trait itself is defined in this crate (orphan rule).
+
+/// Trait for groups that can report their "weight" for batching purposes.
+///
+/// The weight is typically the number of templates in the group, allowing
+/// the pipeline to batch groups based on total templates rather than group count.
+/// This provides more consistent batch sizes across datasets with varying
+/// templates-per-group ratios.
+///
+/// # Example
+///
+/// For a position group with 10 templates, `batch_weight()` returns 10.
+/// The pipeline accumulates groups until the total weight reaches a threshold
+/// (e.g., 500 templates), then flushes the batch.
+pub trait BatchWeight {
+    /// Returns the weight of this group for batching purposes.
+    /// For position groups, this is typically the number of templates.
+    fn batch_weight(&self) -> usize;
+}

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -12,10 +12,11 @@ use std::sync::Arc;
 use crate::assigner::Strategy;
 #[cfg(feature = "consensus")]
 use crate::logging::OperationTimer;
-use crate::unified_pipeline::{
-    BACKPRESSURE_THRESHOLD_BYTES, BamPipelineConfig, Q5_BACKPRESSURE_THRESHOLD_BYTES,
-    SchedulerStrategy, stage_high_water_mark,
+use crate::pipeline::backpressure::{
+    BACKPRESSURE_THRESHOLD_BYTES, Q5_BACKPRESSURE_THRESHOLD_BYTES, stage_high_water_mark,
 };
+use crate::scheduler_strategy::SchedulerStrategy;
+use crate::unified_pipeline::BamPipelineConfig;
 use crate::validation::validate_input_exists;
 use bytesize::ByteSize;
 use clap::Args;
@@ -1777,7 +1778,7 @@ pub(crate) fn warn_unwired_pipeline_flags(scheduler_opts: &SchedulerOptions) {
     // `info!`) to match the sibling "flag has no effect on the chain path"
     // diagnostics in `group::execute_chain` (--debug-memory, FGUMI_SHORT_CIRCUIT).
     let requested_scheduler = scheduler_opts.strategy();
-    if requested_scheduler != crate::unified_pipeline::scheduler::SchedulerStrategy::default() {
+    if requested_scheduler != SchedulerStrategy::default() {
         log::warn!(
             "--scheduler has no effect in the typed-step pipeline: the chain engine \
              does not use a pluggable scheduler strategy, so the requested strategy \

--- a/src/lib/fastq_parse.rs
+++ b/src/lib/fastq_parse.rs
@@ -6,7 +6,7 @@
 
 use std::io;
 
-use crate::unified_pipeline::MemoryEstimate;
+use fgumi_bam_io::MemoryEstimate;
 
 /// A parsed FASTQ record stored as a single heap allocation.
 ///

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -11,8 +11,9 @@ use std::io;
 
 use noodles::sam::alignment::RecordBuf;
 
+use crate::batch_weight::BatchWeight;
 use crate::template::{Template, TemplateBatch};
-use crate::unified_pipeline::{BatchWeight, DecodedRecord, Grouper, MemoryEstimate};
+use fgumi_bam_io::{DecodedRecord, Grouper, MemoryEstimate};
 use fgumi_metrics::TemplateFilterCounts;
 use fgumi_raw_bam;
 use fgumi_raw_bam::{RawRecord, raw_record_to_record_buf};
@@ -268,7 +269,7 @@ impl Grouper for TemplateGrouper {
     }
 }
 
-use crate::unified_pipeline::GroupKey;
+use fgumi_bam_io::GroupKey;
 
 impl MemoryEstimate for ProcessedPositionGroup {
     fn estimate_heap_size(&self) -> usize {
@@ -1089,7 +1090,7 @@ mod tests {
 
     #[test]
     fn test_single_raw_record_grouper_emits_each_record() {
-        use crate::unified_pipeline::{DecodedRecord, GroupKey};
+        use fgumi_bam_io::{DecodedRecord, GroupKey};
 
         let mut grouper = SingleRawRecordGrouper::new();
         let raw1 = RawRecord::from(vec![1u8; 36]);
@@ -1901,10 +1902,10 @@ mod tests {
     /// group contract. Every MC-validation test below builds its record this way.
     fn decoded_via_decode(flags: u16, pos: i32, mc: Option<&str>, name: &[u8]) -> DecodedRecord {
         use crate::read_info::LibraryIndex;
-        use crate::unified_pipeline::compute_group_key_from_raw;
+        use fgumi_bam_io::compute_group_key_from_raw;
 
         let raw = build_raw(flags, pos, mc, name, false);
-        let (key, _) = compute_group_key_from_raw(&raw, &LibraryIndex::default(), None, None);
+        let key = compute_group_key_from_raw(&raw, &LibraryIndex::default(), None);
         DecodedRecord::from_raw_bytes(raw, key)
     }
 
@@ -1937,10 +1938,10 @@ mod tests {
         #[case] byte_scan_finds_mc: bool,
     ) {
         use crate::read_info::LibraryIndex;
-        use crate::unified_pipeline::compute_group_key_from_raw;
+        use fgumi_bam_io::compute_group_key_from_raw;
 
         let raw = build_raw(flags, 99, mc, b"read1", prepend_non_z_mc);
-        let (key, _) = compute_group_key_from_raw(&raw, &LibraryIndex::default(), None, None);
+        let key = compute_group_key_from_raw(&raw, &LibraryIndex::default(), None);
 
         assert_eq!(
             fgumi_raw_bam::find_mc_tag_in_record(&raw).is_some(),
@@ -2186,7 +2187,7 @@ mod tests {
 
     #[test]
     fn test_build_templates_from_raw_bytes() {
-        use crate::unified_pipeline::{DecodedRecord, GroupKey};
+        use fgumi_bam_io::{DecodedRecord, GroupKey};
         use fgumi_raw_bam;
 
         let key = GroupKey::single(0, 100, 0, 0, 0, 12345);
@@ -2210,7 +2211,7 @@ mod tests {
 
     #[test]
     fn test_build_templates_from_raw_bytes_paired() {
-        use crate::unified_pipeline::{DecodedRecord, GroupKey};
+        use fgumi_bam_io::{DecodedRecord, GroupKey};
         use fgumi_raw_bam;
 
         let key1 = GroupKey::paired(0, 100, 0, 0, 200, 1, 0, 0, 12345);

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -8,9 +8,10 @@ use anyhow::Result;
 use fgumi_raw_bam::RawRecord;
 use std::io;
 
-use crate::unified_pipeline::{BatchWeight, DecodedRecord, MemoryEstimate};
+use crate::batch_weight::BatchWeight;
+use fgumi_bam_io::{DecodedRecord, MemoryEstimate};
 
-use crate::unified_pipeline::Grouper;
+use fgumi_bam_io::Grouper;
 use std::collections::VecDeque;
 
 // ============================================================================
@@ -1049,14 +1050,14 @@ mod tests {
     /// Helper: create a `DecodedRecord` from raw bytes with a dummy group key.
     fn make_raw_decoded_record(tag_name: &str, tag_value: &str) -> DecodedRecord {
         let raw = make_raw_bam_with_tag(tag_name, tag_value);
-        let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
+        let key = fgumi_bam_io::GroupKey::single(0, 0, 0, 0, 0, 0);
         DecodedRecord::from_raw_bytes(raw, key)
     }
 
     /// Helper: create a `DecodedRecord` from raw bytes with no tags.
     fn make_raw_decoded_record_no_tag() -> DecodedRecord {
         let raw = make_raw_bam_without_tag();
-        let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
+        let key = fgumi_bam_io::GroupKey::single(0, 0, 0, 0, 0, 0);
         DecodedRecord::from_raw_bytes(raw, key)
     }
 
@@ -1233,7 +1234,7 @@ mod tests {
 
         let rec_b = make_raw_bam_with_tag("MI", "1/B");
 
-        let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
+        let key = fgumi_bam_io::GroupKey::single(0, 0, 0, 0, 0, 0);
         let records = vec![
             DecodedRecord::from_raw_bytes(rec_primary, key),
             DecodedRecord::from_raw_bytes(rec_secondary, key),
@@ -1258,7 +1259,7 @@ mod tests {
         // `MiGroup::mi` for logging but never written back to the output records.
         fn make_two_tag_decoded(mi: &str, cb: &str) -> DecodedRecord {
             let raw = make_raw_bam_with_two_tags("MI", mi, "CB", cb);
-            let key = crate::unified_pipeline::GroupKey::single(0, 0, 0, 0, 0, 0);
+            let key = fgumi_bam_io::GroupKey::single(0, 0, 0, 0, 0, 0);
             DecodedRecord::from_raw_bytes(raw, key)
         }
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -127,6 +127,7 @@
 //! - [noodles](https://github.com/zaeleus/noodles) - Rust bioinformatics I/O
 
 pub mod aligner;
+pub mod batch_weight;
 pub mod commands;
 pub mod version;
 pub use fgumi_bgzf::reader as bgzf_reader;
@@ -152,6 +153,7 @@ pub mod read_structure;
 pub mod reference;
 pub use fgumi_metrics::rejection;
 pub mod sam;
+pub mod scheduler_strategy;
 pub mod system;
 pub mod tag_reversal;
 pub mod template;

--- a/src/lib/pipeline/backpressure.rs
+++ b/src/lib/pipeline/backpressure.rs
@@ -1,0 +1,156 @@
+//! Per-stage backpressure thresholds and the queue-memory-budget/high-water
+//! mark relationship.
+//!
+//! Moved out of `unified_pipeline::base` (C5/R6a) — the definitions are pure
+//! (a `u64` constant and a `fn(u64, u64) -> u64`) with no dependency on the
+//! `unified_pipeline` scheduler/queue machinery, so they relocate cleanly to
+//! the root crate's `pipeline` module. `unified_pipeline::base` keeps a
+//! `pub use` shim so its own internal call sites and the still-present legacy
+//! command paths keep resolving these names unchanged.
+
+/// Default high-water mark for a reorder-buffered stage (512 MiB).
+///
+/// This is the point at which one stage stops taking on new work and the
+/// scheduler starts prioritizing downstream steps (Process, Serialize,
+/// Compress, Write) so the stage can drain.
+///
+/// It is reached only through `ReorderBufferState::effective_limit`, so it
+/// applies to exactly three stages: Q2 and Q3 (whose counters span the queue
+/// and its reorder buffer both) and the post-Group write reorder buffer. The
+/// remaining queues — Q1, Q2b, Q4, Q6, Q7 — carry byte counters but no byte
+/// mark of their own; they are bounded by their slot count and by the
+/// pipeline-wide total gated at the Read step.
+///
+/// # Architecture — where the scheduler reads its drain signal
+///
+/// Only one of the three feeds the scheduler's `memory_high` / `memory_drained`
+/// pair, and the two pipelines pick different ones:
+/// - **BAM pipeline**: `q3_reorder_state`, the reorder buffer after Decode and
+///   before Group (`BamPipelineState::is_memory_high`)
+/// - **FASTQ pipeline**: `output.write_reorder_state`, the post-Compress write
+///   reorder buffer (`FastqStepContext::get_backpressure`)
+///
+/// For the BAM pipeline that placement is deliberate: memory is tracked before
+/// the exclusive Group step rather than after it, because tracking after Group
+/// releases the pre-Group buffer's bytes before knowing whether the post-Group
+/// queue can accept them, leaving data in an untracked intermediate buffer.
+///
+/// # Threshold behaviour
+///
+/// - When tracked memory >= the mark, `is_memory_high()` returns true: the
+///   producing step declines new work and the scheduler enters "drain mode"
+/// - When tracked memory < half the mark, `is_memory_drained()` returns true
+///   and the scheduler exits drain mode (hysteresis prevents thrashing)
+///
+/// # Relationship to `--max-memory`
+///
+/// This is a *per-stage trigger*, not the user's capacity budget; see
+/// [`stage_high_water_mark`] for why the two are separate and why a larger
+/// budget does not raise this. The budget's capacity role is enforced on the
+/// pipeline's total in-flight bytes at the Read step
+/// (`BamPipelineState::read_admission_allowed`).
+pub const BACKPRESSURE_THRESHOLD_BYTES: u64 = 512 * 1024 * 1024; // 512 MiB
+
+/// Default high-water mark for Q5, the processed queue (256 MiB).
+///
+/// This is set lower than the Q3 mark (256 MiB vs 512 MiB) because items in Q5
+/// are typically larger (e.g., `SimplexProcessedBatch` with `RecordBuf` vectors).
+/// When Q5 memory reaches this mark, the Process step pauses to let
+/// downstream steps (Serialize, Compress, Write) catch up.
+///
+/// Like [`BACKPRESSURE_THRESHOLD_BYTES`] it is applied through
+/// [`stage_high_water_mark`], so a `--max-memory` below it tightens it and one
+/// above it leaves it alone.
+pub const Q5_BACKPRESSURE_THRESHOLD_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB
+
+/// The high-water mark one pipeline stage backs off at, given the declared
+/// queue memory budget and that stage's default mark.
+///
+/// Returns `default_mark` when `queue_memory_limit` is 0 (meaning "unset"),
+/// and `min(queue_memory_limit, default_mark)` otherwise.
+///
+/// # Why the budget cannot raise the mark (issue #765)
+///
+/// `--max-memory` is a *capacity* budget: how many bytes the pipeline may hold
+/// in total. A stage's high-water mark is a *trigger*: the depth at which that
+/// one stage stops pulling in work so the rest of the pipeline can catch up.
+/// Historically the mark was the only place the budget reached, which fused the
+/// two ideas into one number and made `--max-memory` above 512 MiB inert. The
+/// capacity half now lives where it belongs — on the pipeline's total in-flight
+/// bytes, gated at the Read step — and what is left here is only the trigger.
+///
+/// A trigger should not scale with the total budget, for three reasons:
+///
+/// - **It would buy no throughput.** The scheduler's response to `memory_high`
+///   is a priority reordering, not a stop. Raising the mark only postpones the
+///   moment output steps are favoured, so the stage parks more bytes and the
+///   pipeline runs no faster.
+/// - **Reorder capacity is bounded by serial skew, not by bytes.** The
+///   pre-Group reorder buffers exist to absorb out-of-order completion between
+///   workers. That skew is bounded by the number of batches in flight, which is
+///   bounded by the queue slot count, so bytes past the skew window are dead
+///   weight.
+/// - **It would let one stage monopolize the budget.** These marks are the only
+///   byte bound on Q2, Q3 and Q5 individually. Uncapped, a single stage could
+///   park the entire budget and the total gate would fire before any other
+///   stage buffered anything — converting a pipeline into a queue.
+///
+/// The downward direction is the useful one and is preserved: a budget smaller
+/// than the default mark pulls the mark down with it, so no single stage can
+/// hold more than the whole declared budget.
+#[inline]
+#[must_use]
+pub fn stage_high_water_mark(queue_memory_limit: u64, default_mark: u64) -> u64 {
+    if queue_memory_limit == 0 { default_mark } else { queue_memory_limit.min(default_mark) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // Stage high-water mark tests (issue #765)
+    // ========================================================================
+
+    #[test]
+    fn test_stage_high_water_mark_treats_zero_as_unset() {
+        assert_eq!(
+            stage_high_water_mark(0, BACKPRESSURE_THRESHOLD_BYTES),
+            BACKPRESSURE_THRESHOLD_BYTES
+        );
+        assert_eq!(
+            stage_high_water_mark(0, Q5_BACKPRESSURE_THRESHOLD_BYTES),
+            Q5_BACKPRESSURE_THRESHOLD_BYTES
+        );
+    }
+
+    #[test]
+    fn test_stage_high_water_mark_tightens_under_a_small_budget() {
+        // A budget below the default mark pulls the mark down with it, so a
+        // single stage can never park more than the whole declared budget.
+        assert_eq!(
+            stage_high_water_mark(64 * 1024 * 1024, BACKPRESSURE_THRESHOLD_BYTES),
+            64 * 1024 * 1024
+        );
+        assert_eq!(
+            stage_high_water_mark(64 * 1024 * 1024, Q5_BACKPRESSURE_THRESHOLD_BYTES),
+            64 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn test_stage_high_water_mark_does_not_scale_above_the_default() {
+        // Deliberate: the mark is a per-stage trigger, not the user's capacity
+        // budget. See the `stage_high_water_mark` docs for why raising it buys
+        // nothing. The budget's capacity role lives at the Read admission gate.
+        let huge = 32 * 1024 * 1024 * 1024;
+        assert_eq!(
+            stage_high_water_mark(huge, BACKPRESSURE_THRESHOLD_BYTES),
+            BACKPRESSURE_THRESHOLD_BYTES
+        );
+        assert_eq!(
+            stage_high_water_mark(huge, Q5_BACKPRESSURE_THRESHOLD_BYTES),
+            Q5_BACKPRESSURE_THRESHOLD_BYTES
+        );
+    }
+}

--- a/src/lib/pipeline/mod.rs
+++ b/src/lib/pipeline/mod.rs
@@ -24,5 +24,6 @@
 /// `crate::pipeline::core::…` path resolves — which is what lets the ported
 /// step sources compile unmodified.
 pub use fgumi_pipeline_core as core;
+pub mod backpressure;
 pub mod chains;
 pub mod steps;

--- a/src/lib/pipeline/steps/tuning.rs
+++ b/src/lib/pipeline/steps/tuning.rs
@@ -34,9 +34,9 @@ pub struct BamPipelineTuning {
 
 impl BamPipelineTuning {
     /// Auto-tuned defaults for `threads` worker threads, mirroring the legacy
-    /// `PipelineConfig::auto_tuned` (`unified_pipeline::base`). Deliberately not
-    /// an intra-doc link: that module is deleted once the commands migrate off
-    /// it, and a link would break again then.
+    /// `PipelineConfig::auto_tuned` from the now-deprecated unified pipeline.
+    /// Deliberately not an intra-doc link: that code is deleted once the
+    /// commands migrate off it, and a link would break again then.
     #[must_use]
     pub fn auto_tuned(threads: usize) -> Self {
         let threads = threads.max(1);

--- a/src/lib/scheduler_strategy.rs
+++ b/src/lib/scheduler_strategy.rs
@@ -1,0 +1,122 @@
+//! Scheduler strategy enum shared by the scheduler dispatch and the CLI.
+//!
+//! Relocated out of `unified_pipeline::scheduler` (C5/R6a) to a neutral root
+//! module rather than `commands::common`: it is consumed both by the
+//! scheduler dispatch (`unified_pipeline::scheduler::create_scheduler`, a
+//! pipeline-layer concern) and by the CLI's `SchedulerOptions`
+//! (`commands::common`, the CLI layer). Homing it under `commands` would have
+//! made the pipeline layer depend upward on the CLI layer through
+//! `unified_pipeline::scheduler`'s shim; this module is downward-reachable
+//! from both. It also survives C6, since the enum outlives
+//! `unified_pipeline`.
+
+/// Scheduler strategy for pipeline execution.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum SchedulerStrategy {
+    /// Fixed priority scheduling based on thread role.
+    ///
+    /// Thread 0 prioritizes reading, Thread N-1 prioritizes writing,
+    /// middle threads rotate among parallel steps. Includes backpressure
+    /// override when output queue fills.
+    #[value(name = "fixed-priority")]
+    FixedPriority,
+
+    /// Chase-bottleneck scheduling with dynamic adaptation.
+    ///
+    /// Threads follow work: move downstream when output blocked,
+    /// move upstream when input empty, stay sticky on success.
+    /// Automatically rebalances as pipeline stages progress.
+    /// Shows ~10% improvement at medium thread counts (4 threads).
+    #[value(name = "chase-bottleneck")]
+    ChaseBottleneck,
+
+    /// Thompson Sampling with Beta distributions.
+    ///
+    /// Uses Bayesian inference to balance exploration and exploitation.
+    /// Each step maintains a Beta(α, β) distribution updated on success/failure.
+    #[value(name = "thompson-sampling")]
+    ThompsonSampling,
+
+    /// Upper Confidence Bound algorithm.
+    ///
+    /// Prioritizes steps with high success rate plus uncertainty bonus.
+    /// Naturally explores under-tried steps while exploiting successful ones.
+    #[value(name = "ucb")]
+    UCB,
+
+    /// Epsilon-Greedy exploration/exploitation.
+    ///
+    /// With probability ε (10%), explores randomly.
+    /// Otherwise exploits the step with highest observed success rate.
+    #[value(name = "epsilon-greedy")]
+    EpsilonGreedy,
+
+    /// Thompson Sampling with thread-specific priors.
+    ///
+    /// Like Thompson Sampling, but initializes with biased priors based on
+    /// thread role (reader→Read, writer→Write, etc.).
+    #[value(name = "thompson-with-priors")]
+    ThompsonWithPriors,
+
+    /// Hybrid: switches between fixed-priority and chase-bottleneck.
+    ///
+    /// Starts with fixed-priority for efficiency. After consecutive failures,
+    /// switches to chase-bottleneck for adaptability. Returns when stable.
+    #[value(name = "hybrid-adaptive")]
+    HybridAdaptive,
+
+    /// Backpressure-proportional with EMA weights.
+    ///
+    /// Dynamically adjusts step weights based on queue depths.
+    /// Downstream steps get higher priority when output backs up.
+    #[value(name = "backpressure-proportional")]
+    BackpressureProportional,
+
+    /// Two-phase: startup/steady-state/drain optimization.
+    ///
+    /// Uses chase-bottleneck during startup (fill pipeline) and drain (empty pipeline).
+    /// Uses fixed-priority during steady-state for efficiency.
+    #[value(name = "two-phase")]
+    TwoPhase,
+
+    /// Sticky work-stealing with home steps.
+    ///
+    /// Each thread has a "home" step based on role. When home step has no work,
+    /// steals from adjacent steps first, then any step. Periodically returns home.
+    #[value(name = "sticky-work-stealing")]
+    StickyWorkStealing,
+
+    /// Learned affinity with decaying exploration.
+    ///
+    /// Tracks success rates per step and builds learned priority order.
+    /// Exploration rate decays over time to converge on optimal strategy.
+    #[value(name = "learned-affinity")]
+    LearnedAffinity,
+
+    /// Optimized chase-bottleneck with profiling-based improvements.
+    ///
+    /// Enhanced chase-bottleneck with:
+    /// - Compress-biased prioritization (Compress is the bottleneck)
+    /// - Exclusive step avoidance (non-specialists deprioritize exclusive steps)
+    /// - Bottleneck stickiness (stay on Compress/Serialize longer)
+    /// - Contention backoff (avoid exclusive steps after contention)
+    #[value(name = "optimized-chase")]
+    OptimizedChase,
+
+    /// Balanced chase scheduler focused on even work distribution.
+    ///
+    /// Key insight: exclusive specialists (T0=Read, T7=Write) should help
+    /// with bottleneck steps instead of staying sticky. After completing
+    /// exclusive work, immediately pivot to Compress/Serialize.
+    #[value(name = "balanced-chase")]
+    BalancedChase,
+
+    /// Balanced chase with drain mode for output backpressure (default).
+    ///
+    /// Like balanced-chase, but when Serialize fails due to Q6 being full,
+    /// enters drain mode: prioritize Compress until backpressure clears.
+    /// This is backpressure-driven rather than using a fixed iteration count.
+    #[default]
+    #[value(name = "balanced-chase-drain")]
+    BalancedChaseDrain,
+}

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -36,8 +36,8 @@
 //! ```
 
 use crate::sam::SamTag;
-use crate::unified_pipeline::{DecodedRecord, MemoryEstimate};
 use anyhow::{Result, bail};
+use fgumi_bam_io::{DecodedRecord, MemoryEstimate};
 use fgumi_raw_bam::{RawRecord, RawRecordView};
 
 // Re-export PairOrientation from sam module for backwards compatibility
@@ -3021,7 +3021,7 @@ mod tests {
     // Template::from_decoded_records / cached_umi tests (issue #334)
     // ========================================================================
 
-    use crate::unified_pipeline::{DecodedRecord, GroupKey};
+    use fgumi_bam_io::{DecodedRecord, GroupKey};
 
     fn build_raw_with_umi(name: &[u8], flags: u16, umi: &[u8]) -> RawRecord {
         let mut b = RawSamBuilder::new();

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -38,6 +38,11 @@
 //!
 //! ## Data Measurement
 //!
+//! Both traits below are re-exported here, not defined here: [`BatchWeight`]
+//! lives in [`crate::batch_weight`] (root crate, C5/R6a — kept out of
+//! `fgumi-bam-io` because its impls target foreign types) and
+//! [`MemoryEstimate`] lives in `fgumi_bam_io`.
+//!
 //! | Trait | Purpose | Implement when... |
 //! |-------|---------|-------------------|
 //! | [`BatchWeight`] | Batch size for template-based batching thresholds | Your batch type needs weight-based flushing |
@@ -421,23 +426,11 @@ pub fn start_memory_monitor(
 // Batch Weight Trait (for template-based batching)
 // ============================================================================
 
-/// Trait for groups that can report their "weight" for batching purposes.
-///
-/// The weight is typically the number of templates in the group, allowing
-/// the pipeline to batch groups based on total templates rather than group count.
-/// This provides more consistent batch sizes across datasets with varying
-/// templates-per-group ratios.
-///
-/// # Example
-///
-/// For a position group with 10 templates, `batch_weight()` returns 10.
-/// The pipeline accumulates groups until the total weight reaches a threshold
-/// (e.g., 500 templates), then flushes the batch.
-pub trait BatchWeight {
-    /// Returns the weight of this group for batching purposes.
-    /// For position groups, this is typically the number of templates.
-    fn batch_weight(&self) -> usize;
-}
+/// Relocated to [`crate::batch_weight`] (C5/R6a) so the root-crate
+/// `grouper`/`mi_group` modules can depend on it without going through this
+/// (now-legacy) module. Shimmed here for the still-present legacy command
+/// paths.
+pub use crate::batch_weight::BatchWeight;
 
 // ============================================================================
 // Memory Estimate Trait (for memory-based queue limits)
@@ -676,48 +669,11 @@ impl StepResult {
 /// Progress logging interval for the 7-step pipeline.
 pub const PROGRESS_LOG_INTERVAL: u64 = 1_000_000;
 
-/// Default high-water mark for a reorder-buffered stage (512 MiB).
-///
-/// This is the point at which one stage stops taking on new work and the
-/// scheduler starts prioritizing downstream steps (Process, Serialize,
-/// Compress, Write) so the stage can drain.
-///
-/// It is reached only through `ReorderBufferState::effective_limit`, so it
-/// applies to exactly three stages: Q2 and Q3 (whose counters span the queue
-/// and its reorder buffer both) and the post-Group write reorder buffer. The
-/// remaining queues — Q1, Q2b, Q4, Q6, Q7 — carry byte counters but no byte
-/// mark of their own; they are bounded by their slot count and by the
-/// pipeline-wide total gated at the Read step.
-///
-/// # Architecture — where the scheduler reads its drain signal
-///
-/// Only one of the three feeds the scheduler's `memory_high` / `memory_drained`
-/// pair, and the two pipelines pick different ones:
-/// - **BAM pipeline**: `q3_reorder_state`, the reorder buffer after Decode and
-///   before Group (`BamPipelineState::is_memory_high`)
-/// - **FASTQ pipeline**: `output.write_reorder_state`, the post-Compress write
-///   reorder buffer (`FastqStepContext::get_backpressure`)
-///
-/// For the BAM pipeline that placement is deliberate: memory is tracked before
-/// the exclusive Group step rather than after it, because tracking after Group
-/// releases the pre-Group buffer's bytes before knowing whether the post-Group
-/// queue can accept them, leaving data in an untracked intermediate buffer.
-///
-/// # Threshold behaviour
-///
-/// - When tracked memory >= the mark, `is_memory_high()` returns true: the
-///   producing step declines new work and the scheduler enters "drain mode"
-/// - When tracked memory < half the mark, `is_memory_drained()` returns true
-///   and the scheduler exits drain mode (hysteresis prevents thrashing)
-///
-/// # Relationship to `--max-memory`
-///
-/// This is a *per-stage trigger*, not the user's capacity budget; see
-/// [`stage_high_water_mark`] for why the two are separate and why a larger
-/// budget does not raise this. The budget's capacity role is enforced on the
-/// pipeline's total in-flight bytes at the Read step
-/// (`BamPipelineState::read_admission_allowed`).
-pub const BACKPRESSURE_THRESHOLD_BYTES: u64 = 512 * 1024 * 1024; // 512 MiB
+/// Relocated to [`crate::pipeline::backpressure`] (C5/R6a) — pure, with no
+/// dependency on this module's scheduler/queue machinery. Shimmed here so
+/// this module's own internal call sites and the still-present legacy
+/// command paths keep resolving it unchanged.
+pub use crate::pipeline::backpressure::BACKPRESSURE_THRESHOLD_BYTES;
 
 /// Release `bytes` from a queue byte counter, saturating at zero.
 ///
@@ -785,58 +741,15 @@ const fn saturating_refund(current: u64, bytes: u64) -> u64 {
     current.saturating_sub(bytes)
 }
 
-/// Default high-water mark for Q5, the processed queue (256 MiB).
-///
-/// This is set lower than the Q3 mark (256 MiB vs 512 MiB) because items in Q5
-/// are typically larger (e.g., `CorrectProcessedBatch` with `RecordBuf` vectors).
-/// When Q5 memory reaches this mark, the Process step pauses to let
-/// downstream steps (Serialize, Compress, Write) catch up.
-///
-/// Like [`BACKPRESSURE_THRESHOLD_BYTES`] it is applied through
-/// [`stage_high_water_mark`], so a `--max-memory` below it tightens it and one
-/// above it leaves it alone.
-pub const Q5_BACKPRESSURE_THRESHOLD_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB
+/// Relocated to [`crate::pipeline::backpressure`] (C5/R6a); see that module.
+/// Shimmed here so this module's own internal call sites and the
+/// still-present legacy command paths keep resolving it unchanged.
+pub use crate::pipeline::backpressure::Q5_BACKPRESSURE_THRESHOLD_BYTES;
 
-/// The high-water mark one pipeline stage backs off at, given the declared
-/// queue memory budget and that stage's default mark.
-///
-/// Returns `default_mark` when `queue_memory_limit` is 0 (meaning "unset"),
-/// and `min(queue_memory_limit, default_mark)` otherwise.
-///
-/// # Why the budget cannot raise the mark (issue #765)
-///
-/// `--max-memory` is a *capacity* budget: how many bytes the pipeline may hold
-/// in total. A stage's high-water mark is a *trigger*: the depth at which that
-/// one stage stops pulling in work so the rest of the pipeline can catch up.
-/// Historically the mark was the only place the budget reached, which fused the
-/// two ideas into one number and made `--max-memory` above 512 MiB inert. The
-/// capacity half now lives where it belongs — on the pipeline's total in-flight
-/// bytes, gated at the Read step — and what is left here is only the trigger.
-///
-/// A trigger should not scale with the total budget, for three reasons:
-///
-/// - **It would buy no throughput.** The scheduler's response to `memory_high`
-///   is a priority reordering, not a stop. Raising the mark only postpones the
-///   moment output steps are favoured, so the stage parks more bytes and the
-///   pipeline runs no faster.
-/// - **Reorder capacity is bounded by serial skew, not by bytes.** The
-///   pre-Group reorder buffers exist to absorb out-of-order completion between
-///   workers. That skew is bounded by the number of batches in flight, which is
-///   bounded by the queue slot count, so bytes past the skew window are dead
-///   weight.
-/// - **It would let one stage monopolize the budget.** These marks are the only
-///   byte bound on Q2, Q3 and Q5 individually. Uncapped, a single stage could
-///   park the entire budget and the total gate would fire before any other
-///   stage buffered anything — converting a pipeline into a queue.
-///
-/// The downward direction is the useful one and is preserved: a budget smaller
-/// than the default mark pulls the mark down with it, so no single stage can
-/// hold more than the whole declared budget.
-#[inline]
-#[must_use]
-pub fn stage_high_water_mark(queue_memory_limit: u64, default_mark: u64) -> u64 {
-    if queue_memory_limit == 0 { default_mark } else { queue_memory_limit.min(default_mark) }
-}
+/// Relocated to [`crate::pipeline::backpressure`] (C5/R6a); see that module.
+/// Shimmed here so this module's own internal call sites and the
+/// still-present legacy command paths keep resolving it unchanged.
+pub use crate::pipeline::backpressure::stage_high_water_mark;
 
 // ============================================================================
 // Input-Half Reorder Buffer State (shared between BAM and FASTQ pipelines)
@@ -5622,52 +5535,6 @@ mod tests {
         let state_small = ReorderBufferState::new(100);
         state_small.add_heap_bytes(100);
         assert!(state_small.is_memory_high()); // 100 >= min(100, 512MB) = 100
-    }
-
-    // ========================================================================
-    // Stage high-water mark tests (issue #765)
-    // ========================================================================
-
-    #[test]
-    fn test_stage_high_water_mark_treats_zero_as_unset() {
-        assert_eq!(
-            stage_high_water_mark(0, BACKPRESSURE_THRESHOLD_BYTES),
-            BACKPRESSURE_THRESHOLD_BYTES
-        );
-        assert_eq!(
-            stage_high_water_mark(0, Q5_BACKPRESSURE_THRESHOLD_BYTES),
-            Q5_BACKPRESSURE_THRESHOLD_BYTES
-        );
-    }
-
-    #[test]
-    fn test_stage_high_water_mark_tightens_under_a_small_budget() {
-        // A budget below the default mark pulls the mark down with it, so a
-        // single stage can never park more than the whole declared budget.
-        assert_eq!(
-            stage_high_water_mark(64 * 1024 * 1024, BACKPRESSURE_THRESHOLD_BYTES),
-            64 * 1024 * 1024
-        );
-        assert_eq!(
-            stage_high_water_mark(64 * 1024 * 1024, Q5_BACKPRESSURE_THRESHOLD_BYTES),
-            64 * 1024 * 1024
-        );
-    }
-
-    #[test]
-    fn test_stage_high_water_mark_does_not_scale_above_the_default() {
-        // Deliberate: the mark is a per-stage trigger, not the user's capacity
-        // budget. See the `stage_high_water_mark` docs for why raising it buys
-        // nothing. The budget's capacity role lives at the Read admission gate.
-        let huge = 32 * 1024 * 1024 * 1024;
-        assert_eq!(
-            stage_high_water_mark(huge, BACKPRESSURE_THRESHOLD_BYTES),
-            BACKPRESSURE_THRESHOLD_BYTES
-        );
-        assert_eq!(
-            stage_high_water_mark(huge, Q5_BACKPRESSURE_THRESHOLD_BYTES),
-            Q5_BACKPRESSURE_THRESHOLD_BYTES
-        );
     }
 
     #[test]

--- a/src/lib/unified_pipeline/scheduler/mod.rs
+++ b/src/lib/unified_pipeline/scheduler/mod.rs
@@ -4,8 +4,6 @@
 //! Different schedulers make different tradeoffs between simplicity, contention,
 //! and adaptability.
 
-use clap::ValueEnum;
-
 use super::base::{ActiveSteps, PipelineStep};
 
 #[doc(hidden)]
@@ -66,116 +64,14 @@ pub use two_phase::TwoPhaseScheduler;
 #[doc(hidden)]
 pub use ucb::UCBScheduler;
 
-/// Scheduler strategy for pipeline execution.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
-pub enum SchedulerStrategy {
-    /// Fixed priority scheduling based on thread role.
-    ///
-    /// Thread 0 prioritizes reading, Thread N-1 prioritizes writing,
-    /// middle threads rotate among parallel steps. Includes backpressure
-    /// override when output queue fills.
-    #[value(name = "fixed-priority")]
-    FixedPriority,
-
-    /// Chase-bottleneck scheduling with dynamic adaptation.
-    ///
-    /// Threads follow work: move downstream when output blocked,
-    /// move upstream when input empty, stay sticky on success.
-    /// Automatically rebalances as pipeline stages progress.
-    /// Shows ~10% improvement at medium thread counts (4 threads).
-    #[value(name = "chase-bottleneck")]
-    ChaseBottleneck,
-
-    /// Thompson Sampling with Beta distributions.
-    ///
-    /// Uses Bayesian inference to balance exploration and exploitation.
-    /// Each step maintains a Beta(α, β) distribution updated on success/failure.
-    #[value(name = "thompson-sampling")]
-    ThompsonSampling,
-
-    /// Upper Confidence Bound algorithm.
-    ///
-    /// Prioritizes steps with high success rate plus uncertainty bonus.
-    /// Naturally explores under-tried steps while exploiting successful ones.
-    #[value(name = "ucb")]
-    UCB,
-
-    /// Epsilon-Greedy exploration/exploitation.
-    ///
-    /// With probability ε (10%), explores randomly.
-    /// Otherwise exploits the step with highest observed success rate.
-    #[value(name = "epsilon-greedy")]
-    EpsilonGreedy,
-
-    /// Thompson Sampling with thread-specific priors.
-    ///
-    /// Like Thompson Sampling, but initializes with biased priors based on
-    /// thread role (reader→Read, writer→Write, etc.).
-    #[value(name = "thompson-with-priors")]
-    ThompsonWithPriors,
-
-    /// Hybrid: switches between fixed-priority and chase-bottleneck.
-    ///
-    /// Starts with fixed-priority for efficiency. After consecutive failures,
-    /// switches to chase-bottleneck for adaptability. Returns when stable.
-    #[value(name = "hybrid-adaptive")]
-    HybridAdaptive,
-
-    /// Backpressure-proportional with EMA weights.
-    ///
-    /// Dynamically adjusts step weights based on queue depths.
-    /// Downstream steps get higher priority when output backs up.
-    #[value(name = "backpressure-proportional")]
-    BackpressureProportional,
-
-    /// Two-phase: startup/steady-state/drain optimization.
-    ///
-    /// Uses chase-bottleneck during startup (fill pipeline) and drain (empty pipeline).
-    /// Uses fixed-priority during steady-state for efficiency.
-    #[value(name = "two-phase")]
-    TwoPhase,
-
-    /// Sticky work-stealing with home steps.
-    ///
-    /// Each thread has a "home" step based on role. When home step has no work,
-    /// steals from adjacent steps first, then any step. Periodically returns home.
-    #[value(name = "sticky-work-stealing")]
-    StickyWorkStealing,
-
-    /// Learned affinity with decaying exploration.
-    ///
-    /// Tracks success rates per step and builds learned priority order.
-    /// Exploration rate decays over time to converge on optimal strategy.
-    #[value(name = "learned-affinity")]
-    LearnedAffinity,
-
-    /// Optimized chase-bottleneck with profiling-based improvements.
-    ///
-    /// Enhanced chase-bottleneck with:
-    /// - Compress-biased prioritization (Compress is the bottleneck)
-    /// - Exclusive step avoidance (non-specialists deprioritize exclusive steps)
-    /// - Bottleneck stickiness (stay on Compress/Serialize longer)
-    /// - Contention backoff (avoid exclusive steps after contention)
-    #[value(name = "optimized-chase")]
-    OptimizedChase,
-
-    /// Balanced chase scheduler focused on even work distribution.
-    ///
-    /// Key insight: exclusive specialists (T0=Read, T7=Write) should help
-    /// with bottleneck steps instead of staying sticky. After completing
-    /// exclusive work, immediately pivot to Compress/Serialize.
-    #[value(name = "balanced-chase")]
-    BalancedChase,
-
-    /// Balanced chase with drain mode for output backpressure (default).
-    ///
-    /// Like balanced-chase, but when Serialize fails due to Q6 being full,
-    /// enters drain mode: prioritize Compress until backpressure clears.
-    /// This is backpressure-driven rather than using a fixed iteration count.
-    #[default]
-    #[value(name = "balanced-chase-drain")]
-    BalancedChaseDrain,
-}
+/// Relocated to [`crate::scheduler_strategy`] (C5/R6a) — a shared enum
+/// consumed both by this module's `create_scheduler` dispatch (a
+/// pipeline-layer concern) and by the CLI's `SchedulerOptions`
+/// (`commands::common`), so it lives in a neutral root module rather than
+/// under either layer. Shimmed here so this module's own internal call
+/// sites (including `mod.rs`'s re-export below) and the still-present
+/// legacy command paths keep resolving it unchanged.
+pub use crate::scheduler_strategy::SchedulerStrategy;
 
 /// Direction for step traversal in chase-bottleneck scheduler.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## What

Relocate the reusable types that live in `src/lib/unified_pipeline/` but are consumed by code **outside** it, so a later PR can delete the whole `unified_pipeline` module (campaign phase R6a → R6b). Behavior-preserving: no output or CLI change.

## The relocation

- **Grouping types already live in `fgumi-bam-io`** (`DecodedRecord`, `GroupKey`, `GroupKeyConfig`, `Grouper`, `MemoryEstimate`) — `unified_pipeline` only re-exported them. Surviving importers (`fastq_parse.rs`, `grouper.rs`, `mi_group.rs`, `template.rs`, `commands/common.rs`) now import from `fgumi_bam_io::` directly. No definitions moved.
- **Three items still defined in `unified_pipeline` and needed by surviving code are moved intra-crate** (deliberately *not* into `fgumi-bam-io`):
  - `BatchWeight` (trait) → new `src/lib/batch_weight.rs`. Its impls target foreign types (`RecordBuf`, `RawRecord`, `Vec<u8>`), so moving the trait to `fgumi-bam-io` would break the orphan rule — it stays root-local.
  - `SchedulerStrategy` (enum) → new `src/lib/scheduler_strategy.rs`. It is consumed by both the scheduler dispatch (`create_scheduler`) and the CLI `SchedulerOptions`, so it lives in a neutral module both depend on downward (not in the commands layer).
  - `BACKPRESSURE_THRESHOLD_BYTES` / `Q5_BACKPRESSURE_THRESHOLD_BYTES` / `stage_high_water_mark` → new `src/lib/pipeline/backpressure.rs` (with their unit tests).
- **`pub use` re-export shims are left in `unified_pipeline`** (`base.rs`, `scheduler/mod.rs`) so the still-present legacy command paths keep compiling unchanged. Those shims disappear with `unified_pipeline` in the R6b deletion.
- **Excluded:** `BamPipelineConfig` (legacy-only — the chain path builds `PipelineConfig`, not it) and the 4-arg `compute_group_key_from_raw` (the 3-arg `fgumi-bam-io` version is canonical) both stay in `unified_pipeline` to die with R6b.

## Notes

- The two `grouper.rs` tests that called the 4-arg `compute_group_key_from_raw` (passing `None`, discarding the umi offset) are repointed to the canonical 3-arg `fgumi_bam_io::grouping::compute_group_key_from_raw` — byte-identical grouping key for the inputs exercised (confirmed by reading both bodies and by the passing tests).
- No layering cycle: `fgumi-bam-io` does not depend on the root crate, and all three moves are intra-crate. The 8 in-flight per-command legacy-path retirement PRs are **not** touched — they resolve their `unified_pipeline::{BatchWeight,SchedulerStrategy,...}` imports through the shims, which the `--no-default-features` check confirms.

Full gate green: `cargo check` in all three feature configs (default, `--all-features`, `--no-default-features`), `ci-fmt`/`ci-lint`/`ci-doc`, and `ci-test` (9987 passed / 31 skipped). This is the R6a step; R6b (delete `unified_pipeline`) follows once the per-command legacy retirements land.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes—none; grouping remains pinned to `fgumi_bam_io`. `unsafe` changes—none; `CLAUDE.md` needs no update. Memory bounds, queue capacity, and thread/backpressure policy changes—none.

- Relocate reusable types and utilities from `unified_pipeline`.
- Add root modules for `BatchWeight` and `SchedulerStrategy`.
- Add `pipeline::backpressure` with compatibility re-exports.
- Update imports and grouper tests to use canonical `fgumi_bam_io` types.
- Preserve legacy command compatibility, `BamPipelineConfig`, and CLI behavior.
- Full tests and validation pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->