### PR TITLE
feat(sort): add --check-crc / --no-check-crc with the file-vs-stdin default

### DIFF
--- a/crates/fgumi-bgzf/src/lib.rs
+++ b/crates/fgumi-bgzf/src/lib.rs
@@ -19,7 +19,8 @@ pub use header::{
 pub use reader::{
     BGZF_EOF, BGZF_FOOTER_SIZE, MAX_UNCOMPRESSED_BLOCK_SIZE, RawBgzfBlock, decompress_block,
     decompress_block_into, decompress_block_into_opts, decompress_block_slice_into,
-    decompress_block_slice_into_opts, decompress_into_slice, read_raw_blocks, uncompressed_size,
+    decompress_block_slice_into_opts, decompress_into_slice, decompress_into_slice_with_crc,
+    read_raw_blocks, uncompressed_size,
 };
 // Re-export the libdeflater decompressor so downstream crates can name the type
 // required by `decompress_block_into_opts` without depending on libdeflater

--- a/crates/fgumi-bgzf/src/reader.rs
+++ b/crates/fgumi-bgzf/src/reader.rs
@@ -820,12 +820,15 @@ fn copy_stored_and_verify_slice(
     out: &mut [u8],
     expected_crc: u32,
     block_len: usize,
+    verify_crc: bool,
 ) -> io::Result<usize> {
     // `out` is caller-sized to the footer's ISIZE, so passing `out.len()` also
     // enforces LEN == ISIZE; the returned payload is then exactly `out.len()`.
+    // The LEN/ISIZE check runs unconditionally; `verify_crc` gates only the
+    // footer CRC32 compare (see `verify_decompression`).
     let payload = parse_stored_frame(compressed, out.len())?;
     out.copy_from_slice(payload);
-    verify_decompression(out, out.len(), expected_crc, block_len, true)?;
+    verify_decompression(out, out.len(), expected_crc, block_len, verify_crc)?;
     Ok(out.len())
 }
 
@@ -833,22 +836,24 @@ fn copy_stored_and_verify_slice(
 /// the BGZF footer, returning the number of bytes written.
 ///
 /// `out.len()` is taken as the expected uncompressed size, so
-/// [`verify_decompression`] checks both the exact fill
-/// (`bytes_written == out.len()`) and the CRC32. Shared by
-/// [`decompress_into_slice`] and [`decompress_and_verify`]'s non-stored branch
-/// so the inflate-then-verify invariant lives in one place — the same reason
-/// [`parse_stored_frame`] exists for the stored branch.
+/// [`verify_decompression`] checks the exact fill
+/// (`bytes_written == out.len()`) unconditionally; `verify_crc` gates only the
+/// CRC32 compare. Shared by [`decompress_into_slice`] and
+/// [`decompress_and_verify`]'s non-stored branch so the inflate-then-verify
+/// invariant lives in one place — the same reason [`parse_stored_frame`] exists
+/// for the stored branch.
 fn deflate_into_slice_and_verify(
     compressed: &[u8],
     expected_crc: u32,
     block_len: usize,
     decompressor: &mut Decompressor,
     out: &mut [u8],
+    verify_crc: bool,
 ) -> io::Result<usize> {
     let bytes_written = decompressor.deflate_decompress(compressed, out).map_err(|e| {
         io::Error::new(io::ErrorKind::InvalidData, format!("BGZF decompression failed: {e:?}"))
     })?;
-    verify_decompression(&out[..bytes_written], out.len(), expected_crc, block_len, true)?;
+    verify_decompression(&out[..bytes_written], out.len(), expected_crc, block_len, verify_crc)?;
     Ok(bytes_written)
 }
 
@@ -896,10 +901,36 @@ fn deflate_into_slice_and_verify(
 /// their output back. There is nothing to roll back to here: the buffer belongs
 /// to the caller, who must treat its contents as undefined unless this returns
 /// `Ok`.
+///
+/// This entry point always verifies the CRC32; see
+/// [`decompress_into_slice_with_crc`] to opt out of the CRC compare for trusted
+/// input (the size and framing checks still run either way).
 pub fn decompress_into_slice(
     block: &[u8],
     decompressor: &mut Decompressor,
     out: &mut [u8],
+) -> io::Result<usize> {
+    decompress_into_slice_with_crc(block, decompressor, out, true)
+}
+
+/// [`decompress_into_slice`] with an explicit CRC32 policy.
+///
+/// `verify_crc = false` skips **only** the CRC32 compare against the BGZF
+/// footer, for trusted input (a freshly piped aligner stream). Everything else
+/// is unconditional: the ISIZE bound and slot-size check, the exact `BGZF_EOF`
+/// short-circuit, the stored-frame LEN/ISIZE checks, and the exact-fill check.
+/// `verify_crc = true` is identical to [`decompress_into_slice`]. This is the
+/// fixed-slice analogue of [`decompress_block_slice_into`]'s CRC opt-out.
+///
+/// # Errors
+///
+/// As [`decompress_into_slice`], except that a CRC32 mismatch is only reported
+/// when `verify_crc` is true.
+pub fn decompress_into_slice_with_crc(
+    block: &[u8],
+    decompressor: &mut Decompressor,
+    out: &mut [u8],
+    verify_crc: bool,
 ) -> io::Result<usize> {
     // Same accessor the caller sizes `out` with, so the two cannot disagree
     // about either the value or the bound. It carries the length and ISIZE
@@ -944,7 +975,13 @@ pub fn decompress_into_slice(
     // level-0 writer, [`InlineBgzfCompressor::new(0)`]) skip the libdeflater
     // round-trip and get the stored-framing-specific LEN/ISIZE diagnostics.
     if is_stored_block(compressed) {
-        return copy_stored_and_verify_slice(compressed, out, crc32_from_slice(block), block.len());
+        return copy_stored_and_verify_slice(
+            compressed,
+            out,
+            crc32_from_slice(block),
+            block.len(),
+            verify_crc,
+        );
     }
     deflate_into_slice_and_verify(
         compressed,
@@ -952,6 +989,7 @@ pub fn decompress_into_slice(
         block.len(),
         decompressor,
         out,
+        verify_crc,
     )
 }
 
@@ -2023,5 +2061,99 @@ mod tests {
             err.to_string().contains(expect_substr),
             "error should contain {expect_substr:?}, got: {err}"
         );
+    }
+
+    /// `decompress_into_slice_with_crc(.., verify_crc = false)` skips **only**
+    /// the CRC32 compare. A one-bit footer-CRC flip is rejected under `true`
+    /// and accepted under `false`, on both decode branches — level 0 takes
+    /// `copy_stored_and_verify_slice`, level 6 takes
+    /// `deflate_into_slice_and_verify` — and the decoded bytes are right.
+    #[rstest]
+    #[case::deflate_rejects_when_verifying(6, true, false)]
+    #[case::deflate_accepts_when_skipping(6, false, true)]
+    #[case::stored_rejects_when_verifying(0, true, false)]
+    #[case::stored_accepts_when_skipping(0, false, true)]
+    fn decompress_into_slice_with_crc_gates_only_the_crc_compare(
+        #[case] level: u32,
+        #[case] verify_crc: bool,
+        #[case] expect_ok: bool,
+    ) {
+        let (block, mut out) = block_bad_crc(level);
+        let result =
+            decompress_into_slice_with_crc(&block, &mut Decompressor::new(), &mut out, verify_crc);
+        if expect_ok {
+            let n = result.expect("verify_crc=false must skip the CRC32 compare");
+            assert_eq!(n, out.len(), "must still exactly fill the slot");
+            assert_eq!(out.as_slice(), one_block_payload().as_slice(), "payload decodes intact");
+        } else {
+            let err = result.expect_err("verify_crc=true must reject a CRC32 mismatch");
+            assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+            assert!(err.to_string().contains("CRC32"), "error should mention CRC32: {err}");
+        }
+    }
+
+    /// Every non-CRC check stays unconditional when `verify_crc = false`: the
+    /// size / framing / bound errors from `decompress_into_slice_rejects_invalid`
+    /// must fire identically. Only the `bad_crc` fixtures are excluded, because
+    /// they are the one class the flag is allowed to wave through.
+    #[rstest]
+    #[case::short_fill(block_short_fill(), "size mismatch")]
+    #[case::isize_above_max(block_isize_above_max(), "above the")]
+    #[case::oversized_out(block_oversized_out(), "output slice is")]
+    #[case::truncated_stored_framing(block_truncated_stored_framing(), "stored block too small")]
+    #[case::too_short_block(block_too_short(), "too short to contain")]
+    fn decompress_into_slice_with_crc_false_still_rejects_non_crc_faults(
+        #[case] block_and_out: (Vec<u8>, Vec<u8>),
+        #[case] expect_substr: &str,
+    ) {
+        let (block, mut out) = block_and_out;
+        let err = decompress_into_slice_with_crc(&block, &mut Decompressor::new(), &mut out, false)
+            .expect_err("non-CRC faults must be rejected even with verify_crc=false");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData, "expected InvalidData, got {err:?}");
+        assert!(
+            err.to_string().contains(expect_substr),
+            "error should contain {expect_substr:?}, got: {err}"
+        );
+    }
+
+    /// The exact `BGZF_EOF` marker short-circuits to `Ok(0)` regardless of the
+    /// flag, and a CRC-corrupted marker (still ISIZE 0, no longer the exact
+    /// bytes) is rejected under `true` and accepted under `false` — the same
+    /// contract the `Vec` API already has for the marker.
+    #[rstest]
+    #[case::exact_marker_verifying(false, true, true)]
+    #[case::exact_marker_skipping(false, false, true)]
+    #[case::corrupted_marker_verifying(true, true, false)]
+    #[case::corrupted_marker_skipping(true, false, true)]
+    fn decompress_into_slice_with_crc_eof_marker_contract(
+        #[case] corrupt: bool,
+        #[case] verify_crc: bool,
+        #[case] expect_ok: bool,
+    ) {
+        let mut block = BGZF_EOF.to_vec();
+        if corrupt {
+            block[BGZF_EOF.len() - BGZF_FOOTER_SIZE] ^= 0x01;
+        }
+        let result =
+            decompress_into_slice_with_crc(&block, &mut Decompressor::new(), &mut [], verify_crc);
+        if expect_ok {
+            assert_eq!(result.expect("zero-length slot must succeed"), 0);
+        } else {
+            let err = result.expect_err("a corrupted zero-size block must be verified");
+            assert!(err.to_string().contains("CRC32"), "got: {err}");
+        }
+    }
+
+    /// The pre-existing three-argument entry point is a thin `verify_crc = true`
+    /// delegate: it must keep rejecting a bad CRC on both branches. (Guards the
+    /// published API against a refactor that flips the delegate's default.)
+    #[rstest]
+    #[case::deflate(6)]
+    #[case::stored(0)]
+    fn decompress_into_slice_delegates_with_verify_crc_true(#[case] level: u32) {
+        let (block, mut out) = block_bad_crc(level);
+        let err = decompress_into_slice(&block, &mut Decompressor::new(), &mut out)
+            .expect_err("the plain entry point must still verify CRC32");
+        assert!(err.to_string().contains("CRC32"), "got: {err}");
     }
 }

--- a/crates/fgumi-pipeline-io/src/sort/arena_ingest.rs
+++ b/crates/fgumi-pipeline-io/src/sort/arena_ingest.rs
@@ -13,7 +13,8 @@
 //! for the full justification.
 //!
 //! `InflateToArena`: each worker decompresses one BGZF block directly into its
-//! disjoint arena slot via [`fgumi_bgzf::decompress_into_slice`].  This is the first
+//! disjoint arena slot via [`fgumi_bgzf::decompress_into_slice_with_crc`] under
+//! the step's CRC policy.  This is the first
 //! `unsafe` site in `fgumi-pipeline-io`; see CLAUDE.md §"Approved hot-path
 //! unsafe (parallel-inflate sort ingest, fgumi-pipeline-io)" for the
 //! full justification and SAFETY invariant.
@@ -34,7 +35,7 @@ use std::collections::VecDeque;
 use std::io;
 use std::sync::Arc;
 
-use fgumi_bgzf::{Decompressor, decompress_into_slice};
+use fgumi_bgzf::{Decompressor, decompress_into_slice_with_crc};
 use fgumi_sort::{
     ArenaPool, InMemoryChunk, PooledSegmentedBuf, RawSortKey, RecordRef,
     coordinate_chunk_from_refs, extract_coordinate_key_inline, queryname_chunk_from_arena_refs,
@@ -706,17 +707,36 @@ pub struct InflateToArena {
     decompressor: Decompressor,
     held: HeldSlot<Unpushed<InflatedBlock>>,
     output_byte_limit: u64,
+    /// Whether each block's BGZF footer CRC32 is compared after inflate. The
+    /// ISIZE / exact-fill checks always run; see
+    /// [`fgumi_bgzf::decompress_into_slice_with_crc`].
+    verify_crc: bool,
 }
 
 impl InflateToArena {
-    /// Create a new `InflateToArena` step.
+    /// Create a new `InflateToArena` step that verifies every block's CRC32.
+    ///
+    /// Equivalent to [`Self::new_with_crc`]`(output_byte_limit, true)`.
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self::new_with_crc(output_byte_limit, true)
+    }
+
+    /// Create a new `InflateToArena` step with an explicit CRC32 policy.
     ///
     /// `output_byte_limit` bounds the byte-counted output queue (tokens carry
     /// `heap_size == 0`, so this mainly controls queue depth via the framework's
-    /// backpressure mechanism).
+    /// backpressure mechanism). `verify_crc = false` skips only the footer
+    /// CRC32 compare, for trusted input; the ISIZE / exact-fill checks always
+    /// run.
     #[must_use]
-    pub fn new(output_byte_limit: u64) -> Self {
-        Self { decompressor: Decompressor::new(), held: HeldSlot::new(), output_byte_limit }
+    pub fn new_with_crc(output_byte_limit: u64, verify_crc: bool) -> Self {
+        Self {
+            decompressor: Decompressor::new(),
+            held: HeldSlot::new(),
+            output_byte_limit,
+            verify_crc,
+        }
     }
 
     /// Decompress `item.block` into the arena slot `(item.offset, item.len)`,
@@ -751,7 +771,9 @@ impl InflateToArena {
         // prefix-sum partitions the arena into non-overlapping slots, so this
         // `&mut [u8]` aliases no other concurrent inflate worker's slice.
         // `u8` has no validity invariant, so writing before reading is the only
-        // required contract — `decompress_into_slice` below fills every byte.
+        // required contract — `decompress_into_slice_with_crc` below fills every
+        // byte (the exact-fill guarantee is unconditional; `verify_crc` gates
+        // only the CRC32 compare).
         // `offset` is a u64 byte offset into the arena; on a 64-bit platform
         // this always fits in usize — the arena itself cannot exceed
         // `isize::MAX` bytes, which is the Rust allocation bound.
@@ -762,7 +784,8 @@ impl InflateToArena {
         #[allow(unsafe_code)]
         let slot = unsafe { arena.slice_mut(offset_usize, len_usize) };
 
-        let n = decompress_into_slice(&block, &mut self.decompressor, slot)?;
+        let n =
+            decompress_into_slice_with_crc(&block, &mut self.decompressor, slot, self.verify_crc)?;
         debug_assert_eq!(n, len_usize, "decompressed length must match ISIZE");
 
         Ok(InflatedBlock { arena, ordinal, offset, len, is_last_of_run, run_seq, seals_to_spill })
@@ -821,7 +844,7 @@ impl Step for InflateToArena {
     }
 
     fn new_worker_copy(&self) -> Self {
-        Self::new(self.output_byte_limit)
+        Self::new_with_crc(self.output_byte_limit, self.verify_crc)
     }
 }
 
@@ -1615,6 +1638,7 @@ impl<S: ArenaSortStrategy> Step for FindBoundariesAndSort<S> {
 mod tests {
     use super::*;
     use fgumi_sort::{CoordinateChunkSorter, PooledSegmentedBuf, SegmentedBuf};
+    use rstest::rstest;
     use std::sync::Arc;
 
     // -----------------------------------------------------------------------
@@ -2626,5 +2650,93 @@ mod tests {
                  (the value FindBoundariesAndSort was constructed with)"
             );
         }
+    }
+
+    /// Build a one-block `ArenaBlock` over a fresh unpooled arena with its slot
+    /// reserved, for `inflate_one` tests. Returns the token and the arena so the
+    /// caller can read the slot back.
+    fn arena_block_for(
+        block: Vec<u8>,
+        payload_len: usize,
+    ) -> (ArenaBlock, Arc<PooledSegmentedBuf>) {
+        let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+        arena.reserve_full_capacity();
+        // Reserve the slot with the safe API (zero placeholder); `inflate_one`
+        // fully overwrites it before any read, so the placeholder is never
+        // observed. `extend_from_slice` returns the write offset to use.
+        let offset = arena.extend_from_slice(&vec![0u8; payload_len]) as u64;
+        let arena = Arc::new(PooledSegmentedBuf::unpooled(arena));
+        let item = ArenaBlock {
+            arena: Arc::clone(&arena),
+            ordinal: 0,
+            offset,
+            len: u32::try_from(payload_len).unwrap(),
+            block,
+            is_last_of_run: true,
+            run_seq: 0,
+            seals_to_spill: false,
+        };
+        (item, arena)
+    }
+
+    /// Flip one footer-CRC32 bit of a raw BGZF block (the payload is untouched).
+    fn with_flipped_crc(mut block: Vec<u8>) -> Vec<u8> {
+        let crc_off = block.len() - fgumi_bgzf::BGZF_FOOTER_SIZE;
+        block[crc_off] ^= 0x01;
+        block
+    }
+
+    /// `InflateToArena::new_with_crc` decides whether a CRC-only-corrupted block
+    /// is rejected or inflated into the slot. Covered on both decode branches
+    /// (level 6 → libdeflater; level 0 → stored fast path) because the CRC is
+    /// checked at two separate call sites in fgumi-bgzf. The plain `new`
+    /// constructor must behave as `verify_crc = true`.
+    #[rstest]
+    #[case::deflate_verify_rejects(6, Some(true), false)]
+    #[case::deflate_skip_accepts(6, Some(false), true)]
+    #[case::stored_verify_rejects(0, Some(true), false)]
+    #[case::stored_skip_accepts(0, Some(false), true)]
+    #[case::plain_new_verifies(6, None, false)]
+    fn inflate_honors_verify_crc(
+        #[case] level: u32,
+        #[case] verify_crc: Option<bool>,
+        #[case] expect_ok: bool,
+    ) {
+        let payload = b"CRC-POLICY-ARENA-TEST".repeat(40);
+        let block = match level {
+            0 => make_test_bgzf_block(&payload),
+            _ => compress_one_block(&payload),
+        };
+        let (item, arena) = arena_block_for(with_flipped_crc(block), payload.len());
+        let mut step = match verify_crc {
+            Some(v) => InflateToArena::new_with_crc(64 * 1024 * 1024, v),
+            None => InflateToArena::new(64 * 1024 * 1024),
+        };
+        let result = step.inflate_one(item);
+        if expect_ok {
+            let inflated = result.expect("verify_crc=false must inflate past a CRC-only fault");
+            assert_eq!(usize::try_from(inflated.len).unwrap(), payload.len());
+            assert_eq!(arena.slice(0, payload.len()), &payload[..], "slot holds the payload");
+        } else {
+            // `InflatedBlock` is not `Debug`, so match rather than `expect_err`.
+            let Err(err) = result else {
+                panic!("verify_crc=true must reject a CRC32 mismatch");
+            };
+            assert!(err.to_string().contains("CRC32"), "got: {err}");
+        }
+    }
+
+    /// Parallel workers are cloned via `new_worker_copy`; the policy must ride
+    /// along or only the seed worker would honor `--no-check-crc`.
+    #[rstest]
+    #[case::skip(false)]
+    #[case::verify(true)]
+    fn new_worker_copy_propagates_verify_crc(#[case] verify_crc: bool) {
+        let seed = InflateToArena::new_with_crc(1024, verify_crc);
+        let mut copy = seed.new_worker_copy();
+        let payload = b"WORKER-COPY".repeat(20);
+        let (item, _arena) =
+            arena_block_for(with_flipped_crc(compress_one_block(&payload)), payload.len());
+        assert_eq!(copy.inflate_one(item).is_ok(), !verify_crc);
     }
 }

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -490,6 +490,54 @@ impl Default for BamIoOptions {
     }
 }
 
+/// Resolve the effective CRC-verification policy from `--check-crc` /
+/// `--no-check-crc` and the input's stdin-vs-file status.
+///
+/// Single source of truth for every command: `--check-crc` forces
+/// verification on; `--no-check-crc` forces it off; with neither given,
+/// verification defaults on for file input and off for stdin (`-` or
+/// `/dev/stdin`), since a fresh aligner-piped stream is trusted while a file
+/// may have been archived or transferred since it was written. The two flags
+/// are mutually exclusive at the CLI layer (`conflicts_with`), so at most one
+/// is ever true; if both were somehow set, `check_crc` wins.
+///
+/// A free function (rather than only a [`BamIoOptions`] method) so commands
+/// whose I/O block is not `BamIoOptions` — `sort`, whose output is optional —
+/// share the policy instead of re-deriving it.
+#[must_use]
+pub fn resolve_check_crc(check_crc: bool, no_check_crc: bool, input: &Path) -> bool {
+    if check_crc {
+        true
+    } else if no_check_crc {
+        false
+    } else {
+        !fgumi_bam_io::is_stdin_path(input)
+    }
+}
+
+/// The parenthesised reason suffix for the `CRC verify:` startup log line —
+/// which flag or default produced the policy [`resolve_check_crc`] returns.
+#[must_use]
+pub fn check_crc_reason(check_crc: bool, no_check_crc: bool, input: &Path) -> &'static str {
+    if check_crc {
+        " (--check-crc)"
+    } else if no_check_crc {
+        " (--no-check-crc)"
+    } else if fgumi_bam_io::is_stdin_path(input) {
+        " (trusted stdin)"
+    } else {
+        ""
+    }
+}
+
+/// Log the effective CRC-verification setting at info level, once, at run
+/// start, so a default-derived decision is visible in every run's log.
+pub fn log_check_crc(check_crc: bool, no_check_crc: bool, input: &Path) {
+    let effective = resolve_check_crc(check_crc, no_check_crc, input);
+    let reason = check_crc_reason(check_crc, no_check_crc, input);
+    log::info!("CRC verify: {}{reason}", if effective { "on" } else { "off" });
+}
+
 impl BamIoOptions {
     /// Construct a `BamIoOptions` from input and output paths. Leaves
     /// opt-in tuning flags (e.g. `async_reader`) and the CRC-verification
@@ -515,34 +563,19 @@ impl BamIoOptions {
     /// aligner-piped stream is trusted while a file may have been archived
     /// or transferred since it was written. `check_crc` and `no_check_crc`
     /// are mutually exclusive at the CLI layer (`conflicts_with`), so at most
-    /// one is ever true.
+    /// one is ever true. Delegates to the free [`resolve_check_crc`] so this
+    /// method and commands that do not embed `BamIoOptions` share one policy.
     #[must_use]
     pub fn effective_check_crc(&self) -> bool {
-        if self.check_crc {
-            true
-        } else if self.no_check_crc {
-            false
-        } else {
-            !fgumi_bam_io::is_stdin_path(&self.input)
-        }
+        resolve_check_crc(self.check_crc, self.no_check_crc, &self.input)
     }
 
     /// Log the effective CRC-verification setting at info level, once, at
     /// run start. Makes the `effective_check_crc` policy — a default-behavior
     /// change from fgumi's previous always-verify default — visible in every
-    /// run's log rather than a silent decision.
+    /// run's log rather than a silent decision. Delegates to [`log_check_crc`].
     pub fn log_effective_check_crc(&self) {
-        let effective = self.effective_check_crc();
-        let reason = if self.check_crc {
-            " (--check-crc)"
-        } else if self.no_check_crc {
-            " (--no-check-crc)"
-        } else if fgumi_bam_io::is_stdin_path(&self.input) {
-            " (trusted stdin)"
-        } else {
-            ""
-        };
-        log::info!("CRC verify: {}{reason}", if effective { "on" } else { "off" });
+        log_check_crc(self.check_crc, self.no_check_crc, &self.input);
     }
 
     /// Build [`fgumi_bam_io::PipelineReaderOpts`] from the async-reader flag
@@ -2057,6 +2090,50 @@ mod tests {
             no_check_crc,
         };
         assert_eq!(io.effective_check_crc(), expected);
+    }
+
+    /// The free `resolve_check_crc` is the single source of truth for the CRC
+    /// policy; `BamIoOptions::effective_check_crc` must agree with it on every
+    /// cell of the truth table (explicit flag wins; otherwise file → verify,
+    /// stdin → skip).
+    #[rstest::rstest]
+    #[case::file_default_verifies(false, false, "input.bam", true)]
+    #[case::dash_stdin_default_skips(false, false, "-", false)]
+    #[case::dev_stdin_default_skips(false, false, "/dev/stdin", false)]
+    #[case::check_crc_forces_on_for_stdin(true, false, "-", true)]
+    #[case::no_check_crc_forces_off_for_file(false, true, "input.bam", false)]
+    fn resolve_check_crc_truth_table(
+        #[case] check_crc: bool,
+        #[case] no_check_crc: bool,
+        #[case] input: &str,
+        #[case] expected: bool,
+    ) {
+        let input = Path::new(input);
+        assert_eq!(resolve_check_crc(check_crc, no_check_crc, input), expected);
+        let io = BamIoOptions {
+            input: input.to_path_buf(),
+            output: PathBuf::from("output.bam"),
+            async_reader: false,
+            check_crc,
+            no_check_crc,
+        };
+        assert_eq!(io.effective_check_crc(), expected, "method must delegate to the free fn");
+    }
+
+    /// The logged reason suffix names why the policy landed where it did, in the
+    /// exact wording the other commands already emit.
+    #[rstest::rstest]
+    #[case::explicit_on(true, false, "in.bam", " (--check-crc)")]
+    #[case::explicit_off(false, true, "in.bam", " (--no-check-crc)")]
+    #[case::trusted_stdin(false, false, "-", " (trusted stdin)")]
+    #[case::file_default(false, false, "in.bam", "")]
+    fn check_crc_reason_wording(
+        #[case] check_crc: bool,
+        #[case] no_check_crc: bool,
+        #[case] input: &str,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(check_crc_reason(check_crc, no_check_crc, Path::new(input)), expected);
     }
 
     /// `reject_output_collisions` compares destinations, not the strings naming

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -35,8 +35,8 @@ use std::path::{Path, PathBuf};
 use crate::commands::command::Command;
 use crate::commands::common::{
     CompressionOptions, MaxTempFiles, MemoryLimit, MemoryReserve, QueueMemoryOptions,
-    SchedulerOptions, ThreadingOptions, parse_max_temp_files, parse_memory, parse_memory_reserve,
-    resolve_memory_budget,
+    SchedulerOptions, ThreadingOptions, log_check_crc, parse_max_temp_files, parse_memory,
+    parse_memory_reserve, resolve_check_crc, resolve_memory_budget,
 };
 use crate::pipeline::chains::{ChainSpec, SinkSpec, SourceSpec, Stage, StageOptionsBag, build_for};
 
@@ -207,6 +207,30 @@ pub struct Sort {
     /// Output BAM file (required unless --verify is used).
     #[arg(short = 'o', long = "output")]
     pub output: Option<PathBuf>,
+
+    /// Force CRC32 verification on while decoding the input BAM.
+    ///
+    /// Without either `--check-crc` or `--no-check-crc`, sorting verifies for
+    /// file input and skips verification for stdin input: a freshly-piped
+    /// aligner stream is trusted, since any corruption there is a bug in the
+    /// upstream process rather than data at rest, while a file may have been
+    /// archived, transferred, or copied since it was written, where a flipped
+    /// bit is exactly what CRC32 exists to catch. Pass `--check-crc` to force
+    /// verification on (e.g. for stdin input you don't trust). Mutually
+    /// exclusive with `--no-check-crc`. Applies to the sort's own record
+    /// decode; the BAM header block is always verified, and `--verify` mode is
+    /// unaffected. Every run logs a `CRC verify:` line at startup stating what
+    /// actually happened.
+    #[arg(long = "check-crc", default_value_t = false, conflicts_with = "no_check_crc")]
+    pub check_crc: bool,
+
+    /// Skip CRC32 verification while decoding the input BAM.
+    ///
+    /// Trades the CRC32 integrity check for faster decode. See `--check-crc`
+    /// for the default policy this overrides. Mutually exclusive with
+    /// `--check-crc`.
+    #[arg(long = "no-check-crc", default_value_t = false, conflicts_with = "check_crc")]
+    pub no_check_crc: bool,
 
     /// Verify the input file is correctly sorted (no output written).
     ///
@@ -810,11 +834,11 @@ impl Sort {
             // source: Auto probes the device and picks a concurrent-read count,
             // Fixed(n) pins it, Fixed(1) is the plain sequential reader.
             read_streams: self.read_streams,
-            // The owned engine always verified CRC (incl. stdin); keep parity -- a future
-            // PR can add --no-check-crc if opt-out is wanted. `effective_check_crc()` would
-            // skip verification for stdin input (the file-vs-stdin default other commands
-            // use), which is a silent regression from the owned sorter's behavior.
-            verify_crc: true,
+            // Same policy every other BAM command uses (`resolve_check_crc`):
+            // explicit flag wins, else verify file input and trust stdin. This
+            // reaches both decode paths -- the arena front (`InflateToArena`)
+            // for standalone sort and `BgzfDecompress` otherwise.
+            verify_crc: resolve_check_crc(self.check_crc, self.no_check_crc, &self.input),
             command_line: command_line.to_string(),
         }
     }
@@ -914,6 +938,16 @@ impl Command for Sort {
         }
 
         if self.verify {
+            // `--verify` reads through a separate noodles-backed reader that
+            // always verifies CRC, so the chain's `--check-crc`/`--no-check-crc`
+            // policy never reaches it. Warn rather than silently ignore a flag
+            // the user set.
+            if self.check_crc || self.no_check_crc {
+                warn!(
+                    "--check-crc/--no-check-crc have no effect with --verify: verification always \
+                     reads and checks every block; the flags apply only when sorting to --output"
+                );
+            }
             return self.execute_verify();
         }
 
@@ -1081,6 +1115,7 @@ impl Sort {
         info!("Input: {}", self.input.display());
         info!("Output: {}", output.display());
         info!("Sort order: {:?}", self.order);
+        log_check_crc(self.check_crc, self.no_check_crc, &self.input);
         if let Some(ct) = cell_tag {
             let ct_bytes = *ct;
             info!("Cell tag: {}{}", ct_bytes[0] as char, ct_bytes[1] as char);
@@ -1560,7 +1595,8 @@ mod tests {
         assert_eq!(spec.stages, vec![Stage::Sort]);
         assert_eq!(spec.threading.threads, Some(sort.threads));
         assert!(matches!(spec.source, SourceSpec::Bam(_)));
-        assert!(spec.verify_crc);
+        // File input with neither CRC flag: the file-vs-stdin default verifies.
+        assert!(spec.verify_crc, "file input must verify CRC by default");
         // --read-streams reaches the chain's BAM source (defaulted to Auto here),
         // proving the field is wired even without an explicit flag.
         assert_eq!(spec.read_streams, sort.read_streams);
@@ -1568,6 +1604,52 @@ mod tests {
             (true, SinkSpec::BamWithIndex(_)) | (false, SinkSpec::Bam(_)) => {}
             (wi, other) => panic!("write_index={wi} produced the wrong sink: {other:?}"),
         }
+    }
+
+    /// `--check-crc` / `--no-check-crc` reach `ChainSpec.verify_crc` through the
+    /// shared `resolve_check_crc` policy: explicit flag wins, else file input
+    /// verifies and stdin is trusted. This is the default-behavior change #931
+    /// signed off on (stdin used to always verify).
+    #[rstest]
+    #[case::file_default_verifies("in.bam", &[], true)]
+    #[case::file_no_check_crc_skips("in.bam", &["--no-check-crc"], false)]
+    #[case::file_check_crc_verifies("in.bam", &["--check-crc"], true)]
+    #[case::stdin_default_skips("-", &[], false)]
+    #[case::dev_stdin_default_skips("/dev/stdin", &[], false)]
+    #[case::stdin_check_crc_verifies("-", &["--check-crc"], true)]
+    #[case::stdin_no_check_crc_skips("-", &["--no-check-crc"], false)]
+    fn build_sort_chain_spec_resolves_verify_crc(
+        #[case] input: &str,
+        #[case] extra: &[&str],
+        #[case] expected: bool,
+    ) {
+        let mut args = vec!["sort", "-i", input, "-o", "out.bam", "--order", "coordinate"];
+        args.extend_from_slice(extra);
+        let sort = Sort::try_parse_from(args).expect("parse should succeed");
+        let spec = sort.build_sort_chain_spec(
+            Path::new("out.bam"),
+            Vec::new(),
+            sort.resolved_max_temp_files(fgumi_sort::soft_nofile()),
+            "fgumi sort (test)",
+        );
+        assert_eq!(spec.verify_crc, expected);
+    }
+
+    /// The two CRC flags are mutually exclusive at the CLI layer, exactly as on
+    /// `BamIoOptions`.
+    #[test]
+    fn check_crc_flags_conflict() {
+        let err = Sort::try_parse_from([
+            "sort",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--check-crc",
+            "--no-check-crc",
+        ])
+        .expect_err("--check-crc and --no-check-crc must conflict");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     /// The sorter-free phase thread helpers `Sort::phase1_threads` /
@@ -2025,6 +2107,8 @@ mod tests {
         Sort {
             input: PathBuf::from("test.bam"),
             output: None,
+            check_crc: false,
+            no_check_crc: false,
             verify: false,
             order,
             key_types: None,

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -182,6 +182,10 @@ EXAMPLES:
   # Reserve extra memory for bwa mem running in a pipeline
   fgumi sort -i input.bam -o sorted.bam --memory-reserve 12GiB --threads 4
 
+  # Skip CRC32 verification on a file you trust (stdin input already skips
+  # by default; pass --check-crc to force verification on)
+  fgumi sort -i input.bam -o sorted.bam --no-check-crc
+
   # Cede cores to the aligner during ingest, but keep the merge wide
   bwa mem -t 32 ref.fa r1.fq r2.fq | fgumi sort -i - -o sorted.bam -@ 8 --sort-threads 4
 

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -2808,7 +2808,11 @@ impl<'a> ChainBuilder<'a> {
                     // full-budget run, so data that fits the budget sorts entirely
                     // in memory with zero spills — matching legacy.
                     let read_blocks = ReadBlocks::new(total_memory, byte_limit);
-                    let inflate = InflateToArena::new(byte_limit);
+                    // The arena front is the only decode path standalone sort
+                    // takes, so the chain's CRC policy has to reach it here --
+                    // `BgzfDecompress` (which also honors `spec.verify_crc`) is
+                    // never on this path.
+                    let inflate = InflateToArena::new_with_crc(byte_limit, self.spec.verify_crc);
                     // Hand the resolved Phase-1 count (honoring `--sort-threads`,
                     // else `--threads`) to the per-chunk sort so large chunks use
                     // the parallel radix. Using the raw global `num_threads()` here

--- a/src/lib/pipeline/chains/spec.rs
+++ b/src/lib/pipeline/chains/spec.rs
@@ -39,8 +39,11 @@ pub struct ChainSpec {
     /// Whether the BAM source's BGZF decode verifies each block's CRC32. Set
     /// from the command's `--check-crc`/`--no-check-crc` policy (via
     /// [`crate::commands::common::BamIoOptions::effective_check_crc`]) so the
-    /// chain reproduces the non-chain path's CRC behavior. Inert for the SAM
-    /// source (no BGZF) and for the FASTQ source (which carries its own policy).
+    /// chain reproduces the non-chain path's CRC behavior. Honored on both BAM
+    /// decode fronts: the `BgzfDecompress` step and the sort arena front's
+    /// `InflateToArena` (the only path standalone `fgumi sort` takes). Inert for
+    /// the SAM source (no BGZF) and for the FASTQ source (which carries its own
+    /// policy).
     pub verify_crc: bool,
     /// For `@PG` line injection into the output header.
     pub command_line: String,

--- a/tests/integration/test_sort_cutover_parity.rs
+++ b/tests/integration/test_sort_cutover_parity.rs
@@ -1154,48 +1154,20 @@ fn cutover_read_streams_produce_identical_output(#[case] order: &str) {
     assert_eq!(one, auto, "--read-streams 1 vs auto must be byte-identical ({order})");
 }
 
-/// The owned engine always verified BGZF CRC32, including on stdin input
-/// (`decompress_block` has no CRC opt-out at all). Standalone `fgumi sort`'s
-/// input decode must reject a corrupted block on stdin too, not silently sort
-/// past it.
+/// Build a BAM whose *last* real BGZF body block has one footer-CRC32 bit
+/// flipped. The compressed payload is untouched and decodes to the same bytes,
+/// so the fault is detectable *only* by comparing the decompressed CRC32
+/// against the footer -- a structural decode failure can never catch it. That
+/// is what makes it a clean probe of whether a live CRC check ran.
 ///
-/// Only the block's footer CRC32 is corrupted (one bit flipped, mirroring
-/// `decompress_opts_skips_crc_on_stored_block` in `fgumi-bgzf`): the
-/// compressed payload is left untouched and decodes normally to the same
-/// bytes, so this corruption is detectable *only* by comparing the
-/// decompressed output's CRC32 against the (now-wrong) footer value. A
-/// structural decode failure could never catch it, so a pass here proves a
-/// live CRC check ran -- not just that some unrelated error-detection caught
-/// the file.
-///
-/// 20,000 records (rather than a handful) is deliberate: it forces the
-/// uncompressed SAM header + record stream well past a single 64 KiB BGZF
-/// block, so the *last* real block is a pure record (body) block, never the
-/// one `fgumi_bam_io::read_header_and_replay` decompresses in full while
-/// parsing the header via noodles. Corrupting the last block therefore
-/// exercises stdin sort's own record-decode path (the arena ingest
-/// `InflateToArena` uses for the sole-`[Stage::Sort]` chain), not just the
-/// separate header-parse tee.
-///
-/// **Not a RED/GREEN gate for the `verify_crc: true` change in
-/// `execute_sort`.** This test passes identically with or without that flag:
-/// standalone sort's `[Stage::Sort]`-only chain always takes the arena-ingest
-/// path (`InflateToArena` -> `fgumi_bgzf::decompress_into_slice`), which has
-/// no CRC opt-out and checks unconditionally regardless of `ChainSpec.verify_crc`
-/// -- the flag is only read by `build_bam_decode_preamble`'s `BgzfDecompress`,
-/// a path standalone sort never takes. It exists as a regression guard on its
-/// own terms (stdin corruption must be rejected end-to-end, through whichever
-/// layer catches it), and as a tripwire: if a future chain-topology change
-/// ever routes standalone sort through `BgzfDecompress` instead, making
-/// `verify_crc` load-bearing, a stale `effective_check_crc()`-style stdin skip
-/// would fail this test rather than silently reintroducing the regression.
-#[test]
-fn cutover_stdin_input_detects_corrupt_crc() {
-    let dir = TempDir::new().expect("create temp dir");
-    let input_bam = dir.path().join("in.bam");
-    write_bam(&input_bam, &create_minimal_header("chr1", 2_100_000), &unsorted_records(20_000));
+/// 20,000 records force the stream well past one 64 KiB block, so the last
+/// block is a pure record block and never the header block that
+/// `fgumi_bam_io::read_header_and_replay` always CRC-verifies via noodles.
+fn write_bam_with_crc_fault(dir: &Path) -> std::path::PathBuf {
+    let seed = dir.join("seed.bam");
+    write_bam(&seed, &create_minimal_header("chr1", 2_100_000), &unsorted_records(20_000));
 
-    let raw = fs::read(&input_bam).expect("read seed BAM");
+    let raw = fs::read(&seed).expect("read seed BAM");
     let mut reader = std::io::Cursor::new(raw.as_slice());
     let mut blocks = fgumi_bgzf::read_raw_blocks(&mut reader, 4_096).expect("parse BGZF blocks");
     let target_idx = blocks
@@ -1205,58 +1177,132 @@ fn cutover_stdin_input_detects_corrupt_crc() {
         .map(|(i, _)| i)
         .next_back()
         .expect("expected at least one real (non-EOF) BGZF block to corrupt");
-    assert!(
-        target_idx > 0,
-        "expected 20,000 records to span more than one real BGZF block (got only 1) -- \
-         corrupting it would land in the header-parse block instead of a pure body block"
-    );
-    let target = &mut blocks[target_idx];
-    let crc_off = target.data.len() - fgumi_bgzf::BGZF_FOOTER_SIZE;
-    target.data[crc_off] ^= 0x01;
+    assert!(target_idx > 0, "20,000 records must span more than one real BGZF block");
+    let crc_off = blocks[target_idx].data.len() - fgumi_bgzf::BGZF_FOOTER_SIZE;
+    blocks[target_idx].data[crc_off] ^= 0x01;
 
     let mut corrupted = Vec::with_capacity(raw.len());
     for block in &blocks {
         corrupted.extend_from_slice(&block.data);
     }
-    // `read_raw_blocks` silently drops BGZF EOF-marker blocks it reads (see
-    // its own doc comment), so re-append the standard marker for a
-    // well-formed, correctly-terminated stream.
+    // `read_raw_blocks` drops EOF markers; re-append one for a well-formed stream.
     corrupted.extend_from_slice(&fgumi_bgzf::BGZF_EOF);
-    let corrupted_bam = dir.path().join("corrupted.bam");
+    let corrupted_bam = dir.join("corrupted.bam");
     fs::write(&corrupted_bam, &corrupted).expect("write corrupted BAM");
+    corrupted_bam
+}
 
+/// How the corrupted BAM reaches `fgumi sort -i`.
+#[derive(Debug, Clone, Copy)]
+enum InputMode {
+    /// `-i -` with the file piped on stdin (the "trusted stream" case).
+    Stdin,
+    /// `-i <path>` (the "data at rest" case).
+    File,
+}
+
+/// End-to-end gate for #931: the CRC policy `fgumi sort` resolves from
+/// `--check-crc` / `--no-check-crc` and the input kind must be what actually
+/// runs on the standalone sort's arena decode path. A CRC-only fault is
+/// rejected exactly when the policy says verify, and sorted past (payload
+/// intact, output fully sorted) exactly when it says skip.
+///
+/// Default stdin -> skip is the deliberate behavior change from the previous
+/// always-verify: piped aligner output is trusted unless `--check-crc`.
+#[rstest]
+#[case::stdin_default_sorts_past(InputMode::Stdin, &[], true)]
+#[case::stdin_check_crc_rejects(InputMode::Stdin, &["--check-crc"], false)]
+#[case::stdin_no_check_crc_sorts_past(InputMode::Stdin, &["--no-check-crc"], true)]
+#[case::file_default_rejects(InputMode::File, &[], false)]
+#[case::file_check_crc_rejects(InputMode::File, &["--check-crc"], false)]
+#[case::file_no_check_crc_sorts_past(InputMode::File, &["--no-check-crc"], true)]
+fn cutover_check_crc_policy_on_corrupt_crc(
+    #[case] mode: InputMode,
+    #[case] extra: &[&str],
+    #[case] expect_success: bool,
+) {
+    let dir = TempDir::new().expect("create temp dir");
+    let corrupted_bam = write_bam_with_crc_fault(dir.path());
     let output_bam = dir.path().join("out.bam");
-    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
-    let output = Command::new(current_bin)
-        .args([
-            OsStr::new("sort"),
-            OsStr::new("-i"),
-            OsStr::new("-"),
-            OsStr::new("-o"),
-            output_bam.as_os_str(),
-            OsStr::new("--order"),
-            OsStr::new("coordinate"),
-        ])
-        .stdin(std::process::Stdio::from(
-            fs::File::open(&corrupted_bam).expect("open corrupted BAM to pipe"),
-        ))
-        .output()
-        .expect("failed to spawn fgumi sort on corrupted stdin input");
+    let bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
 
-    assert!(
-        !output.status.success(),
-        "fgumi sort must reject a corrupted-CRC BGZF block on stdin, not silently sort past it"
-    );
-    // Wording varies by which layer catches it (fgumi-bgzf's own "CRC32
-    // mismatch" vs. noodles' "checksum mismatch" in the header-parse tee), so
-    // accept either rather than pinning one literal message.
+    let mut cmd = Command::new(bin);
+    cmd.arg("sort");
+    match mode {
+        InputMode::Stdin => {
+            cmd.args(["-i", "-"]).stdin(std::process::Stdio::from(
+                fs::File::open(&corrupted_bam).expect("open corrupted BAM to pipe"),
+            ));
+        }
+        InputMode::File => {
+            cmd.arg("-i").arg(&corrupted_bam);
+        }
+    }
+    cmd.arg("-o").arg(&output_bam).args(["--order", "coordinate"]).args(extra);
+    let output = cmd.output().expect("failed to spawn fgumi sort");
     let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+
+    if expect_success {
+        assert!(
+            output.status.success(),
+            "{mode:?} {extra:?}: CRC skipped, so the CRC-only fault must sort past; stderr:\n{stderr}"
+        );
+        assert!(
+            !stderr.contains("crc32 mismatch") && !stderr.contains("checksum mismatch"),
+            "{mode:?} {extra:?}: no CRC error may be reported; stderr:\n{stderr}"
+        );
+        // The payload was never altered, so every record survives unchanged and ordered.
+        assert_eq!(
+            sorted_record_multiset(&output_bam),
+            sorted_record_multiset(&dir.path().join("seed.bam")),
+            "{mode:?} {extra:?}: CRC-skipped sorting must preserve record identity"
+        );
+        assert!(fgumi_verify_sorted(bin, &output_bam, "coordinate"));
+    } else {
+        assert!(
+            !output.status.success(),
+            "{mode:?} {extra:?}: CRC verified, so the fault must be rejected, not sorted past"
+        );
+        // Wording varies by layer (fgumi-bgzf "CRC32 mismatch" vs. noodles
+        // "checksum mismatch"), so accept either.
+        assert!(
+            stderr.contains("crc") || stderr.contains("checksum"),
+            "{mode:?} {extra:?}: failure must name CRC/checksum; stderr:\n{stderr}"
+        );
+        // Mid-stream failure: a truncated partial output is expected, not asserted.
+    }
+}
+
+/// `--check-crc` / `--no-check-crc` are inert under `--verify`, which reads
+/// through a separate always-verifying reader rather than the chain. Passing
+/// one must warn rather than silently do nothing (the CLI layer's
+/// characteristic failure is a flag that quietly has no effect).
+#[rstest]
+#[case::no_check_crc("--no-check-crc")]
+#[case::check_crc("--check-crc")]
+fn verify_mode_warns_that_crc_flags_are_inert(#[case] flag: &str) {
+    let dir = TempDir::new().expect("create temp dir");
+    let bam = dir.path().join("one.bam");
+    // A single record is trivially coordinate-sorted, so `--verify` succeeds and
+    // the warning is the only thing under test.
+    write_bam(&bam, &create_minimal_header("chr1", 10_000), &unsorted_records(1));
+
+    let bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let output = Command::new(bin)
+        .args([OsStr::new("sort"), OsStr::new("--verify"), OsStr::new("-i")])
+        .arg(&bam)
+        .args([OsStr::new("--order"), OsStr::new("coordinate"), OsStr::new(flag)])
+        .env("RUST_LOG", "warn")
+        .output()
+        .expect("failed to spawn fgumi sort --verify");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("crc") || stderr.contains("checksum"),
-        "expected the failure to name CRC/checksum verification as the cause; stderr:\n{stderr}"
+        output.status.success(),
+        "fgumi sort --verify must succeed on a trivially sorted BAM; stderr:\n{stderr}"
     );
-    // Unlike the upfront `--write-index`/`--threads 0` guards, this failure
-    // surfaces mid-stream (well after the output file was opened for
-    // writing), so a truncated partial output file is expected here -- not
-    // asserted against.
+    assert!(
+        stderr.contains("have no effect with --verify"),
+        "passing {flag} with --verify must warn it is inert; stderr:\n{stderr}"
+    );
 }


### PR DESCRIPTION
## What

Adds `--check-crc` / `--no-check-crc` to `fgumi sort`, the only `BamIoOptions`-style command that lacked them. The flags adopt the standard file-vs-stdin default that every other BAM command uses (`resolve_check_crc`): an explicit flag wins; otherwise file input is verified and stdin (`-` / `/dev/stdin`) is trusted and skipped. Every run logs a `CRC verify: on|off (<reason>)` line at startup.

Closes #931.

## Behavior change (deliberate)

`sort` previously pinned `verify_crc: true`, so it always verified BGZF CRC32 — including on stdin. This PR changes the **stdin default from verify to skip**: a freshly piped aligner stream (`bwa-mem3 … | fgumi sort -i -`) is trusted, since corruption there is an upstream bug rather than data at rest. Pass `--check-crc` to keep verifying piped input. File input is unchanged (still verified by default); `--no-check-crc` opts a file out. The BAM header block is always verified regardless (the noodles header tee), matching every other command.

## Why it needed plumbing (not just a flag)

The original deferral assumed flipping `verify_crc` would suffice, but standalone `fgumi sort` (`[Stage::Sort]` over a BAM source) decodes through `ReadBlocks → InflateToArena → fgumi_bgzf::decompress_into_slice`, which had no CRC toggle and always verified — `ChainSpec.verify_crc` was only read by `BgzfDecompress`, a path standalone sort never takes. So the flag is plumbed to the arena decode path:

- `fgumi-bgzf`: new `decompress_into_slice_with_crc(block, decompressor, out, verify_crc)`; the existing `decompress_into_slice` delegates with `verify_crc = true`.
- `fgumi-pipeline-io`: `InflateToArena` gains a `verify_crc` field + `new_with_crc`; `new` delegates, `new_worker_copy` propagates it to every parallel worker.
- chain builder: `add_sort` constructs the arena front with `InflateToArena::new_with_crc(byte_limit, spec.verify_crc)`.

Both `fgumi-bgzf` and `fgumi-pipeline-io` are published crates: no existing `pub` signature changed (new `_with_crc` variants only; `InflateToArena` gained a private field, constructed only via constructors).

`--verify` mode reads through a separate always-verifying reader and is unaffected by these flags; passing `--check-crc`/`--no-check-crc` alongside `--verify` emits a warning rather than silently doing nothing.

## Invariant

Only the CRC32 compare is gated by `verify_crc`. The exact-`BGZF_EOF` short-circuit, ISIZE bound, `out.len() == ISIZE`, stored-frame LEN/ISIZE, and exact-fill checks all stay unconditional — a `--no-check-crc` run still rejects a structurally malformed or short/over-long block.

## Testing

- `fgumi-bgzf`: rstest tables gate the CRC compare on both decode branches (stored + deflate), prove non-CRC faults still reject under `verify_crc = false`, and pin the EOF-marker contract.
- `fgumi-pipeline-io`: `InflateToArena` honors the policy on both branches, plus a worker-copy propagation test.
- `common.rs`: `resolve_check_crc` truth table + log-reason wording.
- `sort.rs`: `build_sort_chain_spec` resolves `verify_crc` across `{file, -, /dev/stdin} × {default, --check-crc, --no-check-crc}`; flag-conflict test.
- Integration (`test_sort_cutover_parity.rs`): end-to-end `{stdin, file} × {default, --check-crc, --no-check-crc}` table on a one-bit last-body-block CRC flip — rejected exactly when the policy says verify, sorted past intact when it says skip. This case table replaces the old always-verify stdin regression test and is the behavioral gate for the arena wiring (reverting the wiring fails exactly the three skip cells).

Full local gate green: `cargo ci-test`, `ci-fmt`, `ci-lint`, `ci-publish-order`, workspace doctests.

## Suggested reading order

Bottom-up, one commit per layer: `fgumi-bgzf` → `fgumi-pipeline-io` → chain builder → `common.rs` → `sort.rs` → integration test → docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: sort stdin output behavior changes because CRC faults are skipped by default; file input remains verified, and explicit CRC flags pin the policy. `unsafe`: none. Memory bounds, queue capacity, and thread/backpressure policy: none.

- Adds `--check-crc` and `--no-check-crc` to `fgumi sort`.
- Uses the shared file-versus-stdin CRC policy.
- Propagates CRC settings through standalone sort arena decoding.
- Preserves structural BGZF validation when CRC comparison is disabled.
- Keeps existing decompression APIs compatible.
- Logs the effective CRC setting and reason.
- Keeps `--verify` behavior unchanged and warns when CRC flags are inert.
- Adds coverage for decoder behavior, worker propagation, policy resolution, conflicts, and file/stdin integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->