### PR TITLE
feat(compare): add the bam-roundtrip subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,17 +145,13 @@ The following external FFI calls are approved because they back core infrastruct
 - **`mach2`** (`crates/fgumi-sort/src/memory_probe.rs`, macOS only) — `task_info(TASK_VM_INFO)`
   is the only way to read `phys_footprint` (the RSS metric mimalloc reports accurately).
   Isolated to the same sub-module as the mimalloc FFI.
-- **`libc::umask`** (`crates/fgumi-sort/src/external.rs`, Unix only) — the merge command writes
-  its output through an atomic temp+persist (`MergeOutputTarget`) so a rejected/failed merge
-  never leaves a partial file. A `NamedTempFile` is created `0600`, so the persisted output must
-  be re-stamped with the mode a plain `File::create` would have produced. For a new file that is
-  `0o666 & !umask`, and reading the process `umask` requires the libc binding (POSIX `umask(2)`
-  only *sets* the mask, returning the previous value, so `process_umask` sets it to `0` and
-  restores it in the next call). The call is isolated to a single `#[allow(unsafe_code)]` site
-  with a `// SAFETY:` note; it has no preconditions and cannot fail. The read-modify-restore is
-  not atomic, so a process-global `Mutex` (`UMASK_LOCK`) serializes concurrent probes — required
-  because `fgumi_lib` is a library and callers may run merges concurrently in one process;
-  without the lock two interleaved probes could leave the process mask permanently `0`.
+
+(The former `libc::umask` merge-output re-stamp site was removed: the shared,
+`unsafe`-free `fgumi_bam_io::restamp_for_persist` — which derives the new-file
+mode by observing a one-time probe `File::create` (the kernel applies the umask
+at open time, so the process-wide umask is never mutated), cached once per
+process — is now the single home for that logic across the merge output, the BAI
+index writer, and the compare/bench commands.)
 
 ### Approved hot-path unsafe (sort engine)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,6 @@ dependencies = [
  "fgumi-raw-bam",
  "fgumi-sam",
  "fs4",
- "libc",
  "libdeflater",
  "libmimalloc-sys",
  "log",

--- a/crates/fgumi-bam-io/src/fs_mode.rs
+++ b/crates/fgumi-bam-io/src/fs_mode.rs
@@ -1,0 +1,195 @@
+//! Output file-permission helper for the atomic temp-file-then-rename pattern.
+//!
+//! The commands and sinks in the fgumi family write their outputs atomically:
+//! write to a `tempfile::NamedTempFile`, then `persist` it onto the final path
+//! so a reader never observes a partial file and a failed write leaves nothing
+//! behind. `NamedTempFile` hard-codes an owner-only `0o600` mode (a security
+//! default for scratch files), and `persist` is a rename that keeps that mode —
+//! so, without intervention, an output written this way lands `0o600` instead of
+//! the mode a plain `File::create` would have produced. That surprises group
+//! readers and downstream tools running as another user.
+//!
+//! [`restamp_for_persist`] re-stamps the temp file to that `File::create` mode
+//! before it is persisted. It derives the new-file mode by observing a one-time
+//! probe `File::create` (the kernel applies the umask atomically at open time),
+//! so this crate stays `#![deny(unsafe_code)]` — no libc / `unsafe` — and never
+//! mutates the process-wide umask. It is the single home for this logic across
+//! the mode-preserving callers: the `compare bam-roundtrip` command, the BAI
+//! index writer, and `fgumi-sort`'s merge output all route through it.
+//!
+//! A sibling module (`fgumi-metrics`'s `write_metrics_atomic`) solves the same
+//! "don't inherit `NamedTempFile`'s `0o600`" problem the other way — it stages
+//! the temp via `File::create` so the kernel applies the umask at creation. That
+//! is simpler but only covers the new-file case and couples correctness to *how*
+//! each caller creates its temp. This helper is instead **self-contained**: it
+//! is correct no matter how the temp was created, and it additionally preserves
+//! an existing destination's mode on overwrite (which the merge output requires,
+//! and the create-time approach cannot express). Keeping the temp owner-only
+//! until this final re-stamp also narrows the window in which the not-yet-
+//! finished output is group-readable.
+
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+/// Re-stamp `temp`'s permissions to the mode a plain `File::create(dest)` would
+/// leave the output with, so an atomic `NamedTempFile` → `persist(dest)` does
+/// not inherit `NamedTempFile`'s owner-only `0o600`.
+///
+/// Matches `File::create` semantics on Unix:
+/// - `dest` already exists → keep its current mode (create-truncate never
+///   changes an existing file's permissions; `std::fs::metadata` follows
+///   symlinks, so an existing symlink target's mode is used);
+/// - `dest` is new → `0o666 & !umask`.
+///
+/// Call this on the temp file **before** persisting it onto `dest`. No-op on
+/// non-Unix targets (no umask model; `NamedTempFile` does not force `0o600`).
+///
+/// # Errors
+///
+/// Returns the I/O error from `set_permissions` if the mode cannot be applied.
+#[cfg_attr(not(unix), allow(clippy::unnecessary_wraps))]
+pub fn restamp_for_persist(temp: &File, dest: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = target_file_mode(dest);
+        temp.set_permissions(std::fs::Permissions::from_mode(mode))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (temp, dest);
+    }
+    Ok(())
+}
+
+/// The `0o777` permission bits a `File::create(dest)` would leave `dest` with:
+/// the existing file's permission bits when `dest` exists, else `0o666 & !umask`.
+///
+/// Only the low `0o777` bits are considered; setuid/setgid/sticky are not
+/// re-applied (they are vanishingly rare on a BAM/index output, and this matches
+/// the merge-output path this helper replaces).
+#[cfg(unix)]
+fn target_file_mode(dest: &Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    match std::fs::metadata(dest) {
+        // Overwriting: `File::create` never changes an existing file's mode.
+        Ok(meta) => meta.permissions().mode() & 0o777,
+        // New file: the mode `File::create` would leave, `0o666 & !umask`.
+        Err(_) => new_file_mode(),
+    }
+}
+
+/// The mode a fresh `File::create` produces (`0o666 & !umask`), observed once by
+/// creating a throwaway probe file and reading its resulting permissions.
+///
+/// POSIX has no read-only `umask(2)`: the value can only be read by *setting* a
+/// new mask and capturing the previous one. Doing that — even set-to-`0` then
+/// restore — mutates the **process-wide** umask for the duration, so a
+/// `File::create` running concurrently on another thread (fgumi-sort creates
+/// spill files in parallel) could momentarily observe the cleared mask and land
+/// a world-writable file. Creating a probe file instead lets the kernel apply
+/// the umask atomically at `open(O_CREAT)` time, reading the effective new-file
+/// mode without ever touching the shared umask. The result is cached in a
+/// process-wide `OnceLock`, so the probe's handful of syscalls run at most once.
+///
+/// If the probe cannot be created (e.g. no writable temp dir), fall back to
+/// `0o644` — the mode `File::create` yields under the ubiquitous `umask 022`,
+/// and never world-writable.
+#[cfg(unix)]
+fn new_file_mode() -> u32 {
+    use std::sync::OnceLock;
+    static MODE: OnceLock<u32> = OnceLock::new();
+    *MODE.get_or_init(|| {
+        probe_new_file_mode().unwrap_or_else(|e| {
+            log::warn!("could not probe the umask; new outputs fall back to mode 0o644: {e}");
+            0o644
+        })
+    })
+}
+
+/// Create a throwaway file via `File::create` and return its `0o777` permission
+/// bits — i.e. `0o666 & !umask`, with the umask applied by the kernel rather
+/// than read from the process. The probe file and its enclosing temp dir are
+/// removed when the `TempDir` drops at the end of this function.
+#[cfg(unix)]
+fn probe_new_file_mode() -> io::Result<u32> {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir()?;
+    let probe = File::create(dir.path().join("umask-probe"))?;
+    Ok(probe.metadata()?.permissions().mode() & 0o777)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn mode_of(path: &Path) -> u32 {
+        std::fs::metadata(path).expect("stat").permissions().mode() & 0o777
+    }
+
+    /// A persisted `NamedTempFile` re-stamped for a **new** destination lands at
+    /// the same mode a plain `File::create` produces — i.e. no longer the
+    /// owner-only `0o600` that `NamedTempFile` forces. Compared against a live
+    /// `File::create` so the assertion tracks the runner's ambient umask rather
+    /// than hard-coding `0o644`.
+    #[test]
+    fn new_dest_matches_file_create_mode() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let reference_mode = {
+            let p = dir.path().join("reference");
+            std::fs::File::create(&p).expect("create reference");
+            mode_of(&p)
+        };
+
+        let tmp = tempfile::NamedTempFile::new_in(dir.path()).expect("temp");
+        assert_eq!(mode_of(tmp.path()), 0o600, "NamedTempFile should start owner-only");
+
+        let dest = dir.path().join("out"); // does not exist yet
+        restamp_for_persist(tmp.as_file(), &dest).expect("restamp");
+        tmp.persist(&dest).expect("persist");
+        assert_eq!(mode_of(&dest), reference_mode);
+    }
+
+    /// Overwriting an **existing** destination preserves that file's mode, exactly
+    /// as `File::create` (open-truncate) does — not the umask default.
+    #[test]
+    fn existing_dest_mode_is_preserved() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let dest = dir.path().join("out");
+        std::fs::File::create(&dest).expect("create dest");
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o640))
+            .expect("chmod dest");
+
+        let tmp = tempfile::NamedTempFile::new_in(dir.path()).expect("temp");
+        restamp_for_persist(tmp.as_file(), &dest).expect("restamp");
+        tmp.persist(&dest).expect("persist");
+
+        assert_eq!(mode_of(&dest), 0o640, "overwriting must preserve the existing file's mode");
+    }
+
+    /// Triggering the internal new-file-mode probe must not perturb the mode a
+    /// plain `File::create` produces. The probe observes the umask by creating a
+    /// file, so — unlike a `umask(0)`/restore read — it never mutates the
+    /// process-wide umask a concurrent `File::create` depends on. Assert a
+    /// `File::create` lands the same mode before and after a restamp. nextest
+    /// runs each test in its own process, so the `OnceLock` probe here is
+    /// genuinely first-init.
+    #[test]
+    fn probe_does_not_disturb_file_create_mode() {
+        let dir = tempfile::tempdir().expect("temp dir");
+
+        std::fs::File::create(dir.path().join("before")).expect("create before");
+        let mode_before = mode_of(&dir.path().join("before"));
+
+        // Trigger the internal umask probe via a restamp for a new destination.
+        let tmp = tempfile::NamedTempFile::new_in(dir.path()).expect("temp");
+        restamp_for_persist(tmp.as_file(), &dir.path().join("new")).expect("restamp");
+
+        std::fs::File::create(dir.path().join("after")).expect("create after");
+        let mode_after = mode_of(&dir.path().join("after"));
+
+        assert_eq!(mode_before, mode_after, "the umask probe must not change File::create's mode");
+    }
+}

--- a/crates/fgumi-bam-io/src/lib.rs
+++ b/crates/fgumi-bam-io/src/lib.rs
@@ -12,6 +12,7 @@
 #![deny(unsafe_code)]
 
 pub mod format;
+pub mod fs_mode;
 pub mod grouping;
 pub mod header;
 pub mod library;
@@ -29,6 +30,7 @@ pub mod writer;
 pub(crate) mod vendored;
 
 pub use format::{FORMAT_PREFIX_LEN, InputFormat, classify_input};
+pub use fs_mode::restamp_for_persist;
 pub use grouping::{
     DecodedRecord, GroupKey, GroupKeyConfig, Grouper, compute_group_key_from_raw, name_hash_key,
 };

--- a/crates/fgumi-bam-io/src/writer.rs
+++ b/crates/fgumi-bam-io/src/writer.rs
@@ -1159,6 +1159,11 @@ pub fn write_bai_index<P: AsRef<Path>>(path: P, index: &bai::Index) -> Result<()
         .with_context(|| format!("Failed to create temp file for index in: {}", dir.display()))?;
     tmp.write_all(&buf)
         .with_context(|| format!("Failed to write index to: {}", path_ref.display()))?;
+    // Re-stamp the temp to the mode `File::create` would produce before the
+    // rename: `NamedTempFile` is owner-only (`0o600`), so the persisted `.bai`
+    // sidecar would otherwise be `0600` while the BAM it indexes is `0644`.
+    crate::fs_mode::restamp_for_persist(tmp.as_file(), path_ref)
+        .with_context(|| format!("Failed to set mode on index temp for: {}", path_ref.display()))?;
     tmp.persist(path_ref)
         .with_context(|| format!("Failed to persist index to: {}", path_ref.display()))?;
     Ok(())
@@ -1948,6 +1953,28 @@ mod tests {
         // The collision the old expression produced: distinct outputs, one index.
         assert_eq!(with_ext("foo.sorted"), with_ext("foo.other"));
         assert_ne!(bai_sidecar_path("foo.sorted"), bai_sidecar_path("foo.other"));
+    }
+
+    /// The persisted `.bai` sidecar lands at the umask-respecting mode a plain
+    /// `File::create` produces, not the owner-only `0o600` the staging
+    /// `NamedTempFile` starts with. Compared against a live `File::create` so it
+    /// tracks the runner's ambient umask.
+    #[cfg(unix)]
+    #[test]
+    fn test_write_bai_index_output_is_not_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("temp dir");
+        let reference_mode = {
+            let p = dir.path().join("reference");
+            std::fs::File::create(&p).expect("create reference");
+            std::fs::metadata(&p).expect("meta").permissions().mode() & 0o777
+        };
+
+        let path = dir.path().join("out.bam.bai");
+        write_bai_index(&path, &bai::Index::default()).expect("write bai index");
+
+        let mode = std::fs::metadata(&path).expect("stat bai").permissions().mode() & 0o777;
+        assert_eq!(mode, reference_mode, "bai sidecar must match File::create, not 0600");
     }
 
     // ---- BAI index compaction (port of htslib's compress_binning) ----

--- a/crates/fgumi-sort/Cargo.toml
+++ b/crates/fgumi-sort/Cargo.toml
@@ -50,7 +50,6 @@ zstd = "0.13"
 voracious_radix_sort = { version = "1", features = ["voracious_multithread"] }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
 # `process` adds `getrlimit`, used by `fd_limit`. See the workspace entry.
 rustix = { workspace = true, features = ["process"] }
 

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -323,20 +323,19 @@ pub fn cb_hasher() -> ahash::RandomState {
 ///
 /// A `NamedTempFile` is created `0600`, so persisting it verbatim would silently
 /// make merged output owner-only. To preserve the semantics of the pre-atomic-temp
-/// direct write (`File::create`), the `Temp` variant carries the mode the final
-/// file must end up with (see [`target_file_mode`]) and applies it before the
-/// rename.
+/// direct write (`File::create`), [`persist`](MergeOutputTarget::persist) re-stamps
+/// the temp to the mode the final file must carry — via the shared
+/// [`fgumi_bam_io::restamp_for_persist`] — before the rename.
 enum MergeOutputTarget {
     /// A regular-file output, staged in a same-directory temp. `dest` is the
     /// resolved final path the temp is atomically renamed onto (a symlinked
     /// output is followed to its real target, so the temp is staged next to —
-    /// and renamed onto — the linked file rather than the link itself). `mode`
-    /// is the Unix mode to stamp onto the temp before persisting (`None` on
-    /// non-Unix, where file modes are managed by the platform).
+    /// and renamed onto — the linked file rather than the link itself). The temp
+    /// is re-stamped to `dest`'s `File::create` mode at persist time (see
+    /// [`persist`](MergeOutputTarget::persist)).
     Temp {
         temp: tempfile::NamedTempFile,
         dest: PathBuf,
-        mode: Option<u32>,
     },
     Stdout(PathBuf),
 }
@@ -373,10 +372,7 @@ impl MergeOutputTarget {
             .suffix(".tmp")
             .tempfile_in(&dir)
             .with_context(|| format!("failed to create a merge temp file in {}", dir.display()))?;
-        // Resolve the final mode now (before any BGZF writer threads spawn) so the
-        // umask read below is single-threaded and cannot race a concurrent create.
-        let mode = target_file_mode(&dest);
-        Ok(Self::Temp { temp, dest, mode })
+        Ok(Self::Temp { temp, dest })
     }
 
     /// The path the merged BAM is written to.
@@ -391,20 +387,17 @@ impl MergeOutputTarget {
     /// for stdout), first stamping the resolved mode so the output is not left
     /// temp-private (`0600`). Consumes `self`, disarming the RAII auto-remove.
     fn persist(self) -> Result<()> {
-        if let Self::Temp { temp, dest, mode } = self {
-            if let Some(mode) = mode {
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    temp.as_file()
-                        .set_permissions(std::fs::Permissions::from_mode(mode))
-                        .with_context(|| {
-                            format!("failed to set mode on merge temp for {}", dest.display())
-                        })?;
-                }
-                #[cfg(not(unix))]
-                let _ = mode;
-            }
+        if let Self::Temp { temp, dest } = self {
+            // Re-stamp the temp to the mode `File::create(dest)` would produce
+            // before the rename: `NamedTempFile` is `0600`, and `persist` keeps
+            // that mode, so merged output would otherwise be owner-only. The
+            // shared helper derives that mode by probing `File::create` once per
+            // process (cached) rather than mutating the process-wide umask, so it
+            // is safe under concurrent output creation regardless of when it
+            // first runs.
+            fgumi_bam_io::restamp_for_persist(temp.as_file(), &dest).with_context(|| {
+                format!("failed to set mode on merge temp for {}", dest.display())
+            })?;
             temp.persist(&dest).map_err(|e| e.error).with_context(|| {
                 format!("failed to finalize merged output at {}", dest.display())
             })?;
@@ -440,64 +433,6 @@ fn resolve_symlink_output(output: &Path) -> Result<PathBuf> {
         };
     }
     anyhow::bail!("too many levels of symbolic links while resolving output {}", output.display())
-}
-
-/// The mode the merged output file must carry, matching the pre-atomic-temp write
-/// path (`File::create`): an existing destination keeps its current mode; a new
-/// file gets `0o666 & !umask`. Returns `None` on non-Unix, where the temp's
-/// platform-managed permissions are left as-is.
-#[cfg(unix)]
-// The `not(unix)` sibling returns `None`, so the `Option` is load-bearing there.
-#[allow(clippy::unnecessary_wraps, reason = "non-unix sibling returns None")]
-fn target_file_mode(output: &Path) -> Option<u32> {
-    use std::os::unix::fs::PermissionsExt;
-    let mode = match std::fs::metadata(output) {
-        // Overwriting: `File::create` never changes an existing file's mode, so keep it.
-        Ok(meta) => meta.permissions().mode() & 0o777,
-        // New file: `File::create` opens `0o666`, then the kernel masks it with umask.
-        Err(_) => 0o666 & !process_umask(),
-    };
-    Some(mode)
-}
-
-#[cfg(not(unix))]
-fn target_file_mode(_output: &Path) -> Option<u32> {
-    None
-}
-
-/// Reads the process file-creation mask (`umask`) without leaving it changed.
-///
-/// `umask(2)` can only *set* the mask (returning the previous value), so reading it
-/// means setting it to `0` and immediately restoring it. That read-modify-restore is
-/// not atomic: two concurrent probes can interleave so the second reads the first's
-/// transient `0` and restores `0`, permanently clearing the process mask (and mis-
-/// computing every subsequent new-file mode). A process-global lock serializes the
-/// probes so each is atomic with respect to every other — needed because
-/// `fgumi_lib` is a library and callers may run merges concurrently in one process.
-#[cfg(unix)]
-fn process_umask() -> u32 {
-    use std::sync::Mutex;
-
-    // Serializes the non-atomic umask read-restore against other concurrent probes.
-    static UMASK_LOCK: Mutex<()> = Mutex::new(());
-    let _guard = UMASK_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-
-    // SAFETY: `umask` has no preconditions and cannot fail; it is `unsafe` only
-    // because it is a raw libc binding. We restore the original mask on the very
-    // next call under `UMASK_LOCK`, so the process-wide umask is unchanged on return.
-    #[allow(unsafe_code)]
-    let previous = unsafe {
-        let previous = libc::umask(0);
-        libc::umask(previous);
-        previous
-    };
-    // `libc::mode_t` is `u16` on macOS (the conversion widens) and `u32` on Linux
-    // (the conversion is a no-op), so `useless_conversion` fires only on Linux.
-    #[allow(
-        clippy::useless_conversion,
-        reason = "libc::mode_t is u16 on macOS and u32 on Linux; the From keeps this portable"
-    )]
-    u32::from(previous)
 }
 
 /// Maps read group ID -> library ordinal for O(1) comparison.
@@ -6535,6 +6470,59 @@ mod tests {
     use rstest::rstest;
 
     // ========================================================================
+    // Merge output permissions
+    // ========================================================================
+
+    /// `MergeOutputTarget::persist` must re-stamp the temp to the mode a plain
+    /// `File::create(dest)` would produce, so merged output is never left with
+    /// `NamedTempFile`'s owner-only `0o600`. The mode-derivation itself is unit-
+    /// tested in `fgumi-bam-io`; this is the merge-level guard that the
+    /// `restamp_for_persist` call is actually wired into `persist` — without it,
+    /// dropping that call ships `0o600` and nothing in this crate fails.
+    ///
+    /// Two cases mirror `File::create` semantics: a new destination lands at
+    /// `0o666 & !umask` (compared against a live `File::create` reference so the
+    /// assertion tracks the runner's umask), and overwriting an existing file
+    /// keeps that file's mode.
+    #[cfg(unix)]
+    #[rstest]
+    #[case::new_dest(None)]
+    #[case::overwrite_existing(Some(0o640))]
+    fn merge_persist_restamps_output_to_file_create_mode(#[case] preexisting_mode: Option<u32>) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let dest = dir.path().join("merged.bam");
+
+        // The mode `File::create(dest)` would leave: an existing file's own mode
+        // on overwrite, else `0o666 & !umask` observed via a live reference.
+        let expected_mode = if let Some(mode) = preexisting_mode {
+            std::fs::File::create(&dest).expect("pre-create destination");
+            std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(mode))
+                .expect("chmod destination");
+            mode
+        } else {
+            let reference = dir.path().join("reference");
+            std::fs::File::create(&reference).expect("create reference");
+            std::fs::metadata(&reference).expect("stat reference").permissions().mode() & 0o777
+        };
+
+        let target = MergeOutputTarget::create(&dest).expect("create merge target");
+        target.persist().expect("persist merge output");
+
+        let mode =
+            std::fs::metadata(&dest).expect("stat merged output").permissions().mode() & 0o777;
+        // Guard against the temp file's owner-only 0o600 leaking through -- but only when
+        // File::create's own mode differs from 0o600. Under a restrictive umask (e.g. 0o077)
+        // File::create legitimately yields 0o600, so this guard would otherwise fire on a
+        // correct result; the assert_eq below fully pins the mode in that case.
+        if expected_mode != 0o600 {
+            assert_ne!(mode, 0o600, "merged output must not inherit the temp's owner-only 0o600");
+        }
+        assert_eq!(mode, expected_mode, "persisted merge output must match File::create's mode");
+    }
+
+    // ========================================================================
     // Record-count invariant
     // ========================================================================
 
@@ -6868,47 +6856,7 @@ mod tests {
     }
 
     // ========================================================================
-    // process_umask concurrency
-    // ========================================================================
-
-    /// `process_umask` reads the mask via a non-atomic set-0-then-restore. Two
-    /// interleaved probes can leave the process mask permanently `0` (and every
-    /// probe observe the wrong value); `UMASK_LOCK` must serialize them. Read the
-    /// mask once, hammer it from many threads, and assert every probe — and the
-    /// final mask — matches the initial value. Without the lock this corrupts to
-    /// `0` reliably under contention. (Uses only `process_umask` so it introduces
-    /// no new `unsafe` site.)
-    #[cfg(unix)]
-    #[test]
-    fn test_process_umask_is_concurrency_safe() {
-        use std::thread;
-
-        let expected = process_umask();
-        let threads: Vec<_> = (0..8)
-            .map(|_| {
-                thread::spawn(move || {
-                    for _ in 0..2000 {
-                        assert_eq!(
-                            process_umask(),
-                            expected,
-                            "a concurrent probe observed a corrupted umask"
-                        );
-                    }
-                })
-            })
-            .collect();
-        for t in threads {
-            t.join().expect("umask probe thread panicked");
-        }
-        assert_eq!(
-            process_umask(),
-            expected,
-            "concurrent probes must leave the process umask unchanged"
-        );
-    }
-
-    // ========================================================================
-    // resolve_symlink_output / target_file_mode
+    // resolve_symlink_output
     // ========================================================================
 
     /// A non-symlink path — even one that does not exist yet — is returned
@@ -6946,29 +6894,6 @@ mod tests {
         std::os::unix::fs::symlink(&b, &a).unwrap();
         std::os::unix::fs::symlink(&a, &b).unwrap();
         assert!(resolve_symlink_output(&a).is_err());
-    }
-
-    /// Overwriting an existing destination keeps its current mode (matching
-    /// `File::create`, which never re-chmods an existing file).
-    #[cfg(unix)]
-    #[test]
-    fn test_target_file_mode_keeps_existing_file_mode() {
-        use std::os::unix::fs::PermissionsExt;
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("out.bam");
-        std::fs::write(&path, b"x").unwrap();
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
-        assert_eq!(target_file_mode(&path), Some(0o640));
-    }
-
-    /// A new destination gets `0o666 & !umask` — the mode `File::create` would
-    /// have produced — not the temp file's private `0600`.
-    #[cfg(unix)]
-    #[test]
-    fn test_target_file_mode_new_file_uses_umask() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("does-not-exist.bam");
-        assert_eq!(target_file_mode(&path), Some(0o666 & !process_umask()));
     }
 
     // ========================================================================

--- a/src/lib/commands/compare/bam_roundtrip.rs
+++ b/src/lib/commands/compare/bam_roundtrip.rs
@@ -120,6 +120,12 @@ impl Command for CompareBamRoundtrip {
 
         // Validation passed: move the staging file into place (if requested).
         if let Some(p) = &self.output {
+            // Re-stamp the staging file to the mode a plain `File::create(p)`
+            // would produce before persisting it: `NamedTempFile` is owner-only
+            // (`0o600`), and `persist` is a rename that keeps that mode, so
+            // without this the user's `--output` BAM would land 0600.
+            fgumi_bam_io::restamp_for_persist(staging.as_file(), p)
+                .with_context(|| format!("setting output permissions on {}", p.display()))?;
             staging.persist(p).map_err(|e| {
                 anyhow!("failed to move validated output into {}: {}", p.display(), e.error)
             })?;
@@ -222,6 +228,43 @@ mod tests {
         };
         cmd.execute("compare bam-roundtrip").expect("round-trip should pass parity");
         assert_eq!(count_records(output.path()).expect("count output"), 1500);
+    }
+
+    /// The `--output` BAM lands at the umask-respecting mode a plain
+    /// `File::create` produces, not the owner-only `0o600` that the staging
+    /// `NamedTempFile` starts with. Compared against a live `File::create` in
+    /// the same test so it tracks the runner's ambient umask.
+    #[cfg(unix)]
+    #[test]
+    fn execute_output_is_not_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let input = write_input_bam(10);
+        let dir = tempfile::tempdir().expect("temp dir");
+
+        // Reference mode under the ambient umask.
+        let reference_mode = std::fs::File::create(dir.path().join("reference"))
+            .expect("create reference")
+            .metadata()
+            .expect("meta")
+            .permissions()
+            .mode()
+            & 0o777;
+
+        let output = dir.path().join("out.bam");
+        let cmd = CompareBamRoundtrip {
+            input: input.path().to_path_buf(),
+            output: Some(output.clone()),
+            threads: 1,
+            compression_level: 1,
+        };
+        cmd.execute("compare bam-roundtrip").expect("round-trip should pass parity");
+
+        let mode = std::fs::metadata(&output).expect("stat output").permissions().mode() & 0o777;
+        assert_eq!(
+            mode, reference_mode,
+            "--output mode ({mode:o}) must match File::create ({reference_mode:o}), not 0600"
+        );
     }
 
     /// `--output` is written atomically: a run that fails before the parity check

--- a/src/lib/commands/compare/bam_roundtrip.rs
+++ b/src/lib/commands/compare/bam_roundtrip.rs
@@ -1,0 +1,404 @@
+//! `fgumi compare bam-roundtrip` — Phase 3 bench-prep gate.
+//!
+//! Runs the new typed-step DSL pipeline (`ReadBgzfBlocks → BgzfDecompress
+//! → FindBamBoundaries → DecodeRecords → GroupBam → SerializeBamRecords
+//! → BgzfCompress → WriteBgzfFile`) on an input BAM and writes the output
+//! to a temp file, then compares record-count parity to the input.
+//!
+//! Phase 3's bench gate is **partial**: it asserts only that the input and
+//! output hold the same *number* of records. It does not assert byte-for-byte
+//! equivalence of the header (which `WriteBgzfFile` rewrites with a fresh BGZF
+//! compressor) nor of record *order* — the chain routes through `GroupBam`,
+//! which canonicalizes within-template order (see `run_bam_roundtrip`), so a
+//! multi-record template whose input order is non-canonical round-trips
+//! reordered while still passing this count check. Phase 4's `--preset correct`
+//! is the original design's full equivalence gate.
+
+use anyhow::{Context, Result, anyhow};
+use clap::Parser;
+use std::path::{Path, PathBuf};
+
+use crate::commands::command::Command;
+use crate::pipeline::steps::{RoundtripConfig, run_bam_roundtrip};
+
+/// Run the new pipeline as a no-op chain on an input BAM and assert
+/// record-count parity.
+#[derive(Debug, Parser)]
+#[command(
+    name = "bam-roundtrip",
+    about = "Run the new pipeline on a BAM and verify record-count parity"
+)]
+pub struct CompareBamRoundtrip {
+    /// Input BAM file.
+    #[arg(index = 1)]
+    pub input: PathBuf,
+
+    /// Optional output BAM path. If unset, output goes to a tempfile and
+    /// is discarded after the comparison.
+    #[arg(long = "output")]
+    pub output: Option<PathBuf>,
+
+    /// Worker threads (1–1024). The chain runs its BAM reader and writer on
+    /// separate worker threads when 2+ are given; a single thread falls back to
+    /// the fused single-thread path. The upper bound is a guard against a
+    /// pathological value allocating that many worker slots and OS threads —
+    /// `PipelineConfig` propagates the count unclamped, so it is bounded here.
+    #[arg(
+        short = 't',
+        long = "threads",
+        default_value = "4",
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=1024)
+    )]
+    pub threads: usize,
+
+    /// BGZF compression level for the output (0–12).
+    #[arg(
+        long = "compression-level",
+        default_value = "1",
+        value_parser = clap::value_parser!(u32).range(0..=12)
+    )]
+    pub compression_level: u32,
+}
+
+impl Command for CompareBamRoundtrip {
+    fn execute(&self, _command_line: &str) -> Result<()> {
+        // Fail early with a clear message if the input is missing, matching the
+        // sibling compare subcommands rather than surfacing a raw open error.
+        crate::validation::validate_file_exists(&self.input, "Input BAM")?;
+
+        // Guard against pointing --output at the input BAM, which would
+        // overwrite the file while it is still being read.
+        if let Some(p) = &self.output
+            && paths_refer_to_same_file(&self.input, p)
+        {
+            return Err(anyhow!(
+                "--output {} would clobber the input BAM {} (choose a different output path)",
+                p.display(),
+                self.input.display()
+            ));
+        }
+
+        // Always write to a temporary staging file, then move it into place only
+        // after the parity check passes. This keeps --output atomic: a failed run
+        // (or a parity mismatch) never leaves a truncated or unverified BAM at the
+        // requested path — the staging file is discarded on any early return. When
+        // --output is given, the staging file is created in that file's own
+        // directory so the final persist is a same-filesystem rename, not a
+        // cross-device copy.
+        let staging = match &self.output {
+            Some(p) => {
+                let dir = p
+                    .parent()
+                    .filter(|d| !d.as_os_str().is_empty())
+                    .unwrap_or_else(|| Path::new("."));
+                tempfile::NamedTempFile::new_in(dir).context("create staging tempfile")?
+            }
+            None => tempfile::NamedTempFile::new().context("create tempfile")?,
+        };
+        let staging_path = staging.path().to_path_buf();
+
+        let cfg = RoundtripConfig::auto_tuned(self.threads)
+            .with_compression_level(self.compression_level);
+
+        log::info!(
+            "bam-roundtrip: input={} output={} threads={}",
+            self.input.display(),
+            self.output.as_deref().unwrap_or(&staging_path).display(),
+            self.threads
+        );
+        run_bam_roundtrip(&self.input, &staging_path, cfg)
+            .with_context(|| format!("run_bam_roundtrip on {}", self.input.display()))?;
+
+        // Record-count parity check against the staging file.
+        let input_n = count_records(&self.input)?;
+        let output_n = count_records(&staging_path)?;
+        if input_n != output_n {
+            return Err(anyhow!(
+                "bam-roundtrip record count mismatch: input={input_n}, output={output_n}"
+            ));
+        }
+
+        // Validation passed: move the staging file into place (if requested).
+        if let Some(p) = &self.output {
+            staging.persist(p).map_err(|e| {
+                anyhow!("failed to move validated output into {}: {}", p.display(), e.error)
+            })?;
+        }
+        log::info!("bam-roundtrip: PASS — {input_n} records round-tripped");
+        Ok(())
+    }
+}
+
+/// Returns `true` if `a` and `b` resolve to the same on-disk file.
+///
+/// When both files already exist, compares filesystem identity (device + inode
+/// on Unix) so that *hard links* to the same file are caught as well as symlinks
+/// — a hard link shares the input's inode but has a distinct canonical path that
+/// path comparison alone would miss, letting `--output` overwrite the input BAM
+/// mid-run. Falls back to canonical-path comparison, then to a literal path
+/// comparison, when either file does not exist yet (e.g. a fresh `--output`
+/// whose parent cannot be resolved) so an exact-string match is still rejected.
+fn paths_refer_to_same_file(a: &std::path::Path, b: &std::path::Path) -> bool {
+    // Prefer filesystem identity when both paths exist: `std::fs::metadata`
+    // follows symlinks, so this also collapses symlink aliases onto their target,
+    // and unlike a canonical-path compare it detects hard links (same dev+inode,
+    // different path).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if let (Ok(ma), Ok(mb)) = (std::fs::metadata(a), std::fs::metadata(b)) {
+            return ma.dev() == mb.dev() && ma.ino() == mb.ino();
+        }
+    }
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        // If either side can't be canonicalized (e.g. `b` doesn't exist yet),
+        // fall back to a direct comparison so an exact-string match is still
+        // rejected.
+        _ => a == b,
+    }
+}
+
+fn count_records(path: &std::path::Path) -> Result<u64> {
+    use fgumi_bam_io::PipelineReaderOpts;
+    use fgumi_raw_bam::RawRecord;
+
+    let (mut reader, _hdr) =
+        fgumi_bam_io::create_raw_bam_reader_with_opts(path, 1, PipelineReaderOpts::default())
+            .with_context(|| format!("open BAM {}", path.display()))?;
+    let mut record = RawRecord::default();
+    let mut n: u64 = 0;
+    loop {
+        match reader.read_record(&mut record).context("read_record")? {
+            0 => break,
+            _ => n += 1,
+        }
+    }
+    Ok(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
+    use noodles::sam::Header;
+
+    /// Write a small valid BAM of `n` records to a temp file for the command to
+    /// consume.
+    fn write_input_bam(n: usize) -> tempfile::NamedTempFile {
+        use noodles::sam::alignment::io::Write as _;
+        let tmp = tempfile::NamedTempFile::new().expect("create temp BAM");
+        let header = Header::default();
+        let mut writer =
+            noodles::bam::io::Writer::new(std::fs::File::create(tmp.path()).expect("create BAM"));
+        writer.write_header(&header).expect("write header");
+        for i in 0..n {
+            let record: RawRecord = SamBuilder::new()
+                .read_name(format!("read{i:07}").as_bytes())
+                .sequence(&[b'A'; 60])
+                .qualities(&[30; 60])
+                .flags(flags::FIRST_SEGMENT)
+                .build();
+            let buf = fgumi_raw_bam::raw_record_to_record_buf(&record, &header)
+                .expect("raw_record_to_record_buf");
+            writer.write_alignment_record(&header, &buf).expect("write record");
+        }
+        writer.try_finish().expect("finish BAM");
+        tmp
+    }
+
+    /// Happy path: a real BAM round-trips to an explicit `--output` and the
+    /// parity check inside `execute` passes.
+    #[test]
+    fn execute_roundtrips_to_explicit_output() {
+        let input = write_input_bam(1500);
+        let output = tempfile::NamedTempFile::new().expect("create output path");
+        let cmd = CompareBamRoundtrip {
+            input: input.path().to_path_buf(),
+            output: Some(output.path().to_path_buf()),
+            threads: 4,
+            compression_level: 1,
+        };
+        cmd.execute("compare bam-roundtrip").expect("round-trip should pass parity");
+        assert_eq!(count_records(output.path()).expect("count output"), 1500);
+    }
+
+    /// `--output` is written atomically: a run that fails before the parity check
+    /// passes must not leave a partial or unverified BAM at the requested path.
+    /// Here the output's directory does not exist, so staging fails early — and
+    /// the requested `--output` path must not exist afterward.
+    #[test]
+    fn execute_does_not_create_output_on_early_failure() {
+        let input = write_input_bam(10);
+        let dir = tempfile::tempdir().expect("temp dir");
+        let missing_output = dir.path().join("no_such_subdir").join("out.bam");
+        let cmd = CompareBamRoundtrip {
+            input: input.path().to_path_buf(),
+            output: Some(missing_output.clone()),
+            threads: 4,
+            compression_level: 1,
+        };
+        cmd.execute("compare bam-roundtrip").expect_err("staging into a missing dir must error");
+        assert!(!missing_output.exists(), "no output must be left behind on failure");
+    }
+
+    /// `--threads` is range-checked at parse time (1..=1024) so a pathological
+    /// value is rejected by clap before it reaches `PipelineConfig`, which
+    /// propagates the worker count unclamped.
+    #[test]
+    fn rejects_out_of_range_threads() {
+        for ok in ["1", "4", "1024"] {
+            assert!(
+                CompareBamRoundtrip::try_parse_from(["bam-roundtrip", "in.bam", "-t", ok]).is_ok(),
+                "threads {ok} should parse"
+            );
+        }
+        for bad in ["0", "1025"] {
+            assert!(
+                CompareBamRoundtrip::try_parse_from(["bam-roundtrip", "in.bam", "-t", bad])
+                    .is_err(),
+                "threads {bad} must be rejected at parse time"
+            );
+        }
+    }
+
+    /// A single worker is a valid configuration: the linear read->...->write
+    /// chain is fusible, so `threads=1` runs on the fused single-thread path and
+    /// still passes the parity check.
+    #[test]
+    fn execute_succeeds_at_one_thread() {
+        let input = write_input_bam(500);
+        let output = tempfile::NamedTempFile::new().expect("create output path");
+        let cmd = CompareBamRoundtrip {
+            input: input.path().to_path_buf(),
+            output: Some(output.path().to_path_buf()),
+            threads: 1,
+            compression_level: 1,
+        };
+        cmd.execute("compare bam-roundtrip").expect("threads=1 should round-trip");
+        assert_eq!(count_records(output.path()).expect("count output"), 500);
+    }
+
+    /// A missing input file is rejected up front with a clear message, matching
+    /// the sibling compare subcommands rather than surfacing a raw open error.
+    #[test]
+    fn execute_rejects_missing_input() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let cmd = CompareBamRoundtrip {
+            input: dir.path().join("does_not_exist.bam"),
+            output: None,
+            threads: 4,
+            compression_level: 1,
+        };
+        // Assert it is the up-front validation error (naming "Input BAM"), not a
+        // raw open error from deep in the chain — a bare `expect_err` would also
+        // pass if `validate_file_exists` were removed and `read_bam` surfaced the
+        // open failure instead, so pin the contract the doc-comment claims.
+        let err = cmd.execute("compare bam-roundtrip").expect_err("missing input must error");
+        assert!(
+            err.to_string().contains("Input BAM"),
+            "missing input must be rejected by up-front validation; got: {err}"
+        );
+    }
+
+    /// Pointing `--output` at the input BAM must be rejected: the chain reads the
+    /// input while writing the output, so clobbering it would corrupt the run.
+    #[test]
+    fn execute_rejects_output_clobbering_input() {
+        let input = write_input_bam(1);
+        let cmd = CompareBamRoundtrip {
+            input: input.path().to_path_buf(),
+            output: Some(input.path().to_path_buf()),
+            threads: 4,
+            compression_level: 1,
+        };
+        let err = cmd.execute("compare bam-roundtrip").expect_err("clobber must error");
+        assert!(err.to_string().contains("clobber"), "unexpected error: {err}");
+    }
+
+    /// `--compression-level` is range-checked at parse time so an out-of-range
+    /// value is rejected by clap before any work runs — the value otherwise
+    /// reaches `InlineBgzfCompressor::new`, which panics for anything above 12.
+    #[test]
+    fn rejects_out_of_range_compression_level() {
+        // In range (0..=12) parses.
+        for level in ["0", "1", "12"] {
+            assert!(
+                CompareBamRoundtrip::try_parse_from([
+                    "bam-roundtrip",
+                    "in.bam",
+                    "--compression-level",
+                    level,
+                ])
+                .is_ok(),
+                "level {level} should parse"
+            );
+        }
+        // Out of range is rejected by the value_parser, not by a later panic.
+        assert!(
+            CompareBamRoundtrip::try_parse_from([
+                "bam-roundtrip",
+                "in.bam",
+                "--compression-level",
+                "13",
+            ])
+            .is_err(),
+            "compression level 13 must be rejected at parse time"
+        );
+    }
+
+    /// The same-file guard canonicalizes, so a genuinely distinct path spelling
+    /// that resolves to one file is caught, while two distinct files are not.
+    /// The symlink case is what a naive literal `a == b` implementation would
+    /// miss — `Path` equality normalizes away `.` but not a symlink indirection.
+    #[test]
+    fn same_file_guard_matches_distinct_spellings() {
+        let f = tempfile::NamedTempFile::new().expect("temp file");
+        let abs = f.path().to_path_buf();
+        assert!(paths_refer_to_same_file(&abs, &abs), "identical paths must match");
+
+        let other = tempfile::NamedTempFile::new().expect("temp file 2");
+        assert!(!paths_refer_to_same_file(&abs, other.path()), "distinct files must not match");
+
+        // A symlink is a distinct path spelling that only canonicalization
+        // collapses onto its target; a literal path comparison would not.
+        #[cfg(unix)]
+        {
+            let link = abs.with_extension("link");
+            std::os::unix::fs::symlink(&abs, &link).expect("create symlink");
+            assert_ne!(link, abs, "the symlink path differs literally from its target");
+            assert!(
+                paths_refer_to_same_file(&abs, &link),
+                "a symlink to the input must be caught by canonicalization"
+            );
+            std::fs::remove_file(&link).ok();
+        }
+    }
+
+    /// A hard link shares the input's inode but has a genuinely distinct
+    /// canonical path, so a path-only comparison misses it. Filesystem-identity
+    /// matching (device + inode) is what catches an `--output` hard-linked to the
+    /// input, which would otherwise overwrite the source file mid-run.
+    #[cfg(unix)]
+    #[test]
+    fn same_file_guard_matches_hard_link() {
+        let f = tempfile::NamedTempFile::new().expect("temp file");
+        let target = f.path().to_path_buf();
+        let link = target.with_extension("hardlink");
+        std::fs::hard_link(&target, &link).expect("create hard link");
+
+        // Both paths canonicalize to themselves — the hard link is not a symlink,
+        // so canonicalization does not collapse the two spellings.
+        assert_ne!(
+            std::fs::canonicalize(&target).expect("canon target"),
+            std::fs::canonicalize(&link).expect("canon link"),
+            "a hard link has a distinct canonical path from its target"
+        );
+        assert!(
+            paths_refer_to_same_file(&target, &link),
+            "a hard link to the input must be caught by filesystem identity"
+        );
+        std::fs::remove_file(&link).ok();
+    }
+}

--- a/src/lib/commands/compare/mod.rs
+++ b/src/lib/commands/compare/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides commands to compare BAM files and metrics files
 //! for testing and validation of fgumi output against other tools.
 
+pub mod bam_roundtrip;
 pub mod bams;
 pub(crate) mod engines;
 pub mod metrics;
@@ -14,6 +15,7 @@ use crate::commands::command::Command;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
+pub use bam_roundtrip::CompareBamRoundtrip;
 pub use bams::CompareBams;
 pub use metrics::CompareMetrics;
 
@@ -60,6 +62,7 @@ impl Command for Compare {
 #[derive(Subcommand, Debug)]
 pub enum CompareCommand {
     Bams(CompareBams),
+    BamRoundtrip(CompareBamRoundtrip),
     Metrics(CompareMetrics),
 }
 
@@ -67,6 +70,7 @@ impl CompareCommand {
     fn execute(&self, command_line: &str) -> Result<()> {
         match self {
             Self::Bams(cmd) => cmd.execute(command_line),
+            Self::BamRoundtrip(cmd) => cmd.execute(command_line),
             Self::Metrics(cmd) => cmd.execute(command_line),
         }
     }

--- a/src/lib/pipeline/steps/mod.rs
+++ b/src/lib/pipeline/steps/mod.rs
@@ -38,6 +38,7 @@ pub mod extract;
 pub mod group;
 pub mod parse;
 pub mod process;
+pub mod roundtrip;
 pub mod serialize;
 pub mod serialize_processed;
 pub mod sink;
@@ -47,6 +48,7 @@ pub mod templates_to_records;
 pub mod tuning;
 pub mod types;
 
+pub use roundtrip::{RoundtripConfig, run_bam_roundtrip};
 pub use tuning::BamPipelineTuning;
 pub use types::{
     BamTemplateBatch, BgzfBlock, DecodedRecordBatch, DecompressedBlock, RecordBatch,

--- a/src/lib/pipeline/steps/roundtrip.rs
+++ b/src/lib/pipeline/steps/roundtrip.rs
@@ -1,0 +1,339 @@
+//! End-to-end no-op BAM round-trip helper. Wires the full block-level
+//! BAM chain (`ReadBgzfBlocks → BgzfDecompress → FindBamBoundaries →
+//! DecodeRecords → GroupBam → SerializeBamRecords → BgzfCompress →
+//! WriteBgzfFile`) and runs it against an input BAM, producing an output
+//! BAM. Convenience for the `fgumi compare bam-roundtrip <bam>`
+//! gate (Phase 3 bench-prep) and for any caller that wants to drive the
+//! framework end-to-end on a real BAM.
+
+use std::io;
+use std::path::Path;
+
+use fgumi_bam_io::PipelineReaderOpts;
+
+use crate::pipeline::core::builder::{Pipeline, PipelineConfig};
+use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+use crate::pipeline::steps::bgzf::decompress::BgzfDecompress;
+use crate::pipeline::steps::boundaries::bam::FindBamBoundaries;
+use crate::pipeline::steps::group::bam::GroupBam;
+use crate::pipeline::steps::parse::decode::DecodeRecords;
+use crate::pipeline::steps::serialize::SerializeBamRecords;
+use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
+use crate::pipeline::steps::source::read_bam::read_bam;
+use crate::pipeline::steps::tuning::BamPipelineTuning;
+use fgumi_bam_io::GroupKeyConfig;
+
+/// Configuration for [`run_bam_roundtrip`]. Backed by
+/// [`BamPipelineTuning`] which mirrors legacy `auto_tuned` defaults
+/// (`blocks_per_batch` 16-64 by thread count, `template_batch_size=500`,
+/// etc.).
+///
+/// This is intentionally a thin newtype over [`BamPipelineTuning`] rather than a
+/// bare type alias: it is the seam where round-trip-only knobs would attach
+/// (e.g. a future `--verify` mode) without widening the shared tuning struct.
+/// Until such a knob exists its two methods delegate straight through.
+#[derive(Debug, Clone, Copy)]
+pub struct RoundtripConfig {
+    pub tuning: BamPipelineTuning,
+}
+
+impl RoundtripConfig {
+    /// Auto-tune for `threads` workers. Equivalent to
+    /// `RoundtripConfig { tuning: BamPipelineTuning::auto_tuned(threads) }`.
+    #[must_use]
+    pub fn auto_tuned(threads: usize) -> Self {
+        Self { tuning: BamPipelineTuning::auto_tuned(threads) }
+    }
+
+    /// Override the BGZF compression level on the underlying tuning.
+    #[must_use]
+    pub fn with_compression_level(mut self, level: u32) -> Self {
+        self.tuning = self.tuning.with_compression_level(level);
+        self
+    }
+}
+
+impl Default for RoundtripConfig {
+    fn default() -> Self {
+        Self::auto_tuned(4)
+    }
+}
+
+/// Run the full block-level BAM chain on `input` and write the output to
+/// `output`. The output holds the same *set* of records as the input (same
+/// count, same per-record bytes) modulo header `@PG` (Phase 3 has no `@PG`
+/// mutation).
+///
+/// Record order is **not** byte-for-byte preserved for multi-record templates:
+/// the chain routes through `GroupBam`, whose `Template::from_records`
+/// canonicalizes within-template order (R1 before R2; supplementary/secondary
+/// reads regrouped to match fgbio). Templates already in canonical order round
+/// trip unchanged, but e.g. an input `[R1-primary, R1-supplementary, R2-primary]`
+/// comes back as `[R1-primary, R2-primary, R1-supplementary]`. The CLI gate over
+/// this function checks record *count* only, so it does not observe that
+/// reordering.
+///
+/// # Errors
+///
+/// Returns I/O errors from file open / read / write, BAM parsing errors,
+/// or `BuildError` propagated as `io::Error::other` if the pipeline graph
+/// is malformed. Returns an error (rather than panicking) if the configured
+/// compression level is outside `0..=12` or the thread count is outside
+/// `1..=1024`.
+///
+/// **Output is not written atomically.** `WriteBgzfFile::new` creates `output`
+/// and writes the BGZF header before the chain runs, so an error returned from
+/// `build`/`run` (a pipeline or write failure) can leave a truncated or
+/// partial file at `output`. The `compare bam-roundtrip` CLI stages its output
+/// through a `NamedTempFile` and renames on success, so it never exposes a
+/// partial file; direct library callers that need that guarantee must stage and
+/// rename themselves.
+pub fn run_bam_roundtrip(input: &Path, output: &Path, cfg: RoundtripConfig) -> io::Result<()> {
+    let t = cfg.tuning;
+    // Validate the compression level and thread count up front — before the
+    // output file is created — so an out-of-range value returns an error
+    // instead of panicking deep inside `InlineBgzfCompressor::new` (compression)
+    // or the worker-thread spawn loop in `Pipeline::run` (threads). The CLI
+    // guards both with clap `value_parser` ranges, but this function is public
+    // API and a direct caller must get an error, not a panic. `auto_tuned`
+    // floors `threads` to 1, so this catches a `RoundtripConfig` whose `tuning`
+    // was built with a raw 0 or an unbounded count.
+    if t.compression_level > 12 {
+        return Err(io::Error::other(format!(
+            "compression level {} is out of range (expected 0..=12)",
+            t.compression_level
+        )));
+    }
+    if !(1..=1024).contains(&t.threads) {
+        return Err(io::Error::other(format!(
+            "thread count {} is out of range (expected 1..=1024)",
+            t.threads
+        )));
+    }
+    let opts = PipelineReaderOpts::default();
+    let (read_step, header) = read_bam(input, opts, t.blocks_per_batch, t.per_step_byte_limit)?;
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(read_step)
+        .chain(BgzfDecompress::new(t.per_step_byte_limit))
+        .chain(FindBamBoundaries::new(t.per_step_byte_limit))
+        // DecodeRecords does parse + per-record GroupKey computation
+        // (CIGAR walk + tag scan + library/cell-barcode hashing) in one
+        // parallel pass. Matches the legacy pipeline's combined Decode
+        // step; drops the intermediate Parse → Decode queue.
+        // `GroupKeyConfig::default()` (empty library index, no cell tag) is used
+        // deliberately: this round-trip validates byte-equivalence only and does
+        // not exercise UMI/library/cell grouping (`GroupBam` batches by qname
+        // regardless), so the computed group key does not affect output bytes.
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), t.per_step_byte_limit))
+        .chain(GroupBam::new(t.template_batch_size, t.per_step_byte_limit))
+        .chain(SerializeBamRecords::new(t.per_step_byte_limit))
+        .chain(BgzfCompress::new(t.compression_level, t.per_step_byte_limit, false))
+        .chain(
+            WriteBgzfFile::new(output, &header, t.compression_level)
+                .map_err(|e| io::Error::other(format!("WriteBgzfFile::new: {e}")))?,
+        )
+        .into_sink_marker();
+    let pipeline =
+        builder.build().map_err(|e| io::Error::other(format!("Pipeline::build: {e:?}")))?;
+    pipeline
+        .run(PipelineConfig { threads: t.threads, ..Default::default() })
+        .map_err(|e| io::Error::other(format!("Pipeline::run: {e:?}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use fgumi_bam_io::PipelineReaderOpts;
+    use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
+    use noodles::sam::Header;
+    use rstest::rstest;
+
+    /// Write `records` to a temp BAM, in order, and return the temp file (kept
+    /// alive by the caller so the on-disk file persists for the round-trip).
+    fn write_bam(records: &[RawRecord]) -> tempfile::NamedTempFile {
+        use noodles::sam::alignment::io::Write as _;
+        let tmp = tempfile::NamedTempFile::new().expect("create temp BAM");
+        let header = Header::default();
+        let mut writer =
+            noodles::bam::io::Writer::new(std::fs::File::create(tmp.path()).expect("create BAM"));
+        writer.write_header(&header).expect("write header");
+        for record in records {
+            let buf = fgumi_raw_bam::raw_record_to_record_buf(record, &header)
+                .expect("raw_record_to_record_buf");
+            writer.write_alignment_record(&header, &buf).expect("write record");
+        }
+        writer.try_finish().expect("finish BAM");
+        tmp
+    }
+
+    /// Read every record body from a BAM, in file order, as raw bytes. Two BAMs
+    /// hold the same records in the same order iff these vectors are equal:
+    /// `RawRecord` derefs to its record-body `[u8]`, so byte equality is record
+    /// identity (name, flags, SEQ, QUAL, CIGAR, tags — everything but the
+    /// header, which the round-trip legitimately re-serializes).
+    fn record_bodies(path: &Path) -> Vec<Vec<u8>> {
+        let (mut reader, _hdr) =
+            fgumi_bam_io::create_raw_bam_reader_with_opts(path, 1, PipelineReaderOpts::default())
+                .expect("open BAM");
+        let mut record = RawRecord::default();
+        let mut bodies = Vec::new();
+        while reader.read_record(&mut record).expect("read_record") != 0 {
+            bodies.push(record.to_vec());
+        }
+        bodies
+    }
+
+    /// A heterogeneous input that exercises the paths a count-only check misses:
+    /// enough singleton records to span multiple BGZF blocks and template
+    /// batches (`template_batch_size` defaults to 500); a multi-record template
+    /// (paired R1/R2 sharing one QNAME, so a drop/duplicate *within* a template
+    /// is visible); and degenerate records (unmapped, empty SEQ) that a
+    /// fixed-shape input would never cover.
+    fn varied_records() -> Vec<RawRecord> {
+        let mut records = Vec::new();
+        // Bulk singletons across several blocks/batches.
+        for i in 0..1500 {
+            records.push(
+                SamBuilder::new()
+                    .read_name(format!("read{i:07}").as_bytes())
+                    .sequence(&[b'A'; 60])
+                    .qualities(&[30; 60])
+                    .flags(flags::FIRST_SEGMENT)
+                    .build(),
+            );
+        }
+        // Multi-record template: two mates under one QNAME, emitted adjacently.
+        records.push(
+            SamBuilder::new()
+                .read_name(b"pair_template")
+                .sequence(&[b'C'; 40])
+                .qualities(&[35; 40])
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .build(),
+        );
+        records.push(
+            SamBuilder::new()
+                .read_name(b"pair_template")
+                .sequence(&[b'G'; 40])
+                .qualities(&[35; 40])
+                .flags(flags::PAIRED | flags::LAST_SEGMENT)
+                .build(),
+        );
+        // Degenerate: unmapped, empty SEQ/QUAL.
+        records.push(SamBuilder::new().read_name(b"empty_seq").flags(flags::UNMAPPED).build());
+        records
+    }
+
+    /// The core contract of the no-op round-trip: the output holds exactly the
+    /// input records, byte-for-byte, in the same order — not merely the same
+    /// count. Runs at 1, 2, and 4 threads: threads=1 takes the fused
+    /// single-thread path, threads>=2 the scheduled pool where the reader/writer
+    /// affinity split takes effect, so all three must agree.
+    #[rstest]
+    fn roundtrip_preserves_records_identically(#[values(1, 2, 4)] threads: usize) {
+        let input = write_bam(&varied_records());
+        let output = tempfile::NamedTempFile::new().expect("create output BAM");
+
+        run_bam_roundtrip(input.path(), output.path(), RoundtripConfig::auto_tuned(threads))
+            .unwrap_or_else(|e| panic!("run_bam_roundtrip at threads={threads}: {e}"));
+
+        assert_eq!(
+            record_bodies(output.path()),
+            record_bodies(input.path()),
+            "round-trip at threads={threads} did not reproduce the input records identically"
+        );
+    }
+
+    /// An empty BAM (header only, zero records) must round-trip to an empty BAM,
+    /// not error and not fabricate records — the drain path has to flush a chain
+    /// that never sees an input record.
+    #[test]
+    fn roundtrip_handles_empty_input() {
+        let input = write_bam(&[]);
+        let output = tempfile::NamedTempFile::new().expect("create output BAM");
+
+        run_bam_roundtrip(input.path(), output.path(), RoundtripConfig::auto_tuned(4))
+            .expect("run_bam_roundtrip on empty input");
+
+        assert!(record_bodies(output.path()).is_empty(), "empty input must yield empty output");
+    }
+
+    /// A compression level above 12 returns an error from the library API
+    /// instead of panicking deep in `InlineBgzfCompressor::new`, and does so
+    /// without creating the output file.
+    #[test]
+    fn out_of_range_compression_level_errors_without_touching_output() {
+        let input = write_bam(&varied_records());
+        let out_dir = tempfile::tempdir().expect("temp dir");
+        let output = out_dir.path().join("should_not_exist.bam");
+
+        let cfg = RoundtripConfig::auto_tuned(4).with_compression_level(13);
+        let err = run_bam_roundtrip(input.path(), &output, cfg)
+            .expect_err("compression level 13 must error, not panic");
+        assert!(err.to_string().contains("compression level"), "unexpected error: {err}");
+        assert!(!output.exists(), "no output file should be created on a config error");
+    }
+
+    /// A thread count outside `1..=1024` returns an error from the library API
+    /// instead of attempting an unbounded worker-thread spawn (which panics on
+    /// the first failed `thread::Builder::spawn`), and does so without creating
+    /// the output file. `auto_tuned` floors to 1 but does not cap, so a large
+    /// count reaches this guard; the CLI caps it at parse time, but a direct
+    /// library caller must get an error, not a panic.
+    #[test]
+    fn out_of_range_thread_count_errors_without_touching_output() {
+        let input = write_bam(&varied_records());
+        let out_dir = tempfile::tempdir().expect("temp dir");
+        let output = out_dir.path().join("should_not_exist.bam");
+
+        let cfg = RoundtripConfig::auto_tuned(2000);
+        let err = run_bam_roundtrip(input.path(), &output, cfg)
+            .expect_err("thread count 2000 must error, not spawn 2000 threads");
+        assert!(err.to_string().contains("thread count"), "unexpected error: {err}");
+        assert!(!output.exists(), "no output file should be created on a config error");
+    }
+
+    /// A multi-record template whose input order is non-canonical round-trips
+    /// with the same record *set* but reordered: the chain routes through
+    /// `GroupBam`, which canonicalizes within-template order (R1 before R2).
+    /// This pins the behavior `run_bam_roundtrip`'s doc calls out — the
+    /// round-trip preserves records, not per-template order — which the
+    /// canonical-order inputs in `varied_records` cannot exercise.
+    #[test]
+    fn non_canonical_template_order_is_canonicalized() {
+        // Emit the mates R2-then-R1 (non-canonical); GroupBam will swap them.
+        let r2 = SamBuilder::new()
+            .read_name(b"pair")
+            .sequence(&[b'G'; 40])
+            .qualities(&[35; 40])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT)
+            .build();
+        let r1 = SamBuilder::new()
+            .read_name(b"pair")
+            .sequence(&[b'C'; 40])
+            .qualities(&[35; 40])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+            .build();
+        let input = write_bam(&[r2, r1]);
+        let output = tempfile::NamedTempFile::new().expect("create output BAM");
+
+        run_bam_roundtrip(input.path(), output.path(), RoundtripConfig::auto_tuned(1))
+            .expect("run_bam_roundtrip");
+
+        let in_bodies = record_bodies(input.path());
+        let out_bodies = record_bodies(output.path());
+
+        // The record set is preserved (same count, same per-record bytes)...
+        let (mut in_sorted, mut out_sorted) = (in_bodies.clone(), out_bodies.clone());
+        in_sorted.sort();
+        out_sorted.sort();
+        assert_eq!(out_sorted, in_sorted, "the record set must be preserved");
+        // ...but the non-canonical [R2, R1] input is emitted canonicalized, so
+        // the file order changes — which the count-only CLI gate cannot see.
+        assert_ne!(out_bodies, in_bodies, "non-canonical template order must be canonicalized");
+    }
+}


### PR DESCRIPTION
Two logical commits — suggested reading order below.

## 1. `feat(compare): add the bam-roundtrip subcommand`

Adds `fgumi compare bam-roundtrip <bam>`, a bench-prep gate that runs the typed-step BAM chain (`ReadBgzfBlocks → BgzfDecompress → FindBamBoundaries → DecodeRecords → GroupBam → SerializeBamRecords → BgzfCompress → WriteBgzfFile`) as a no-op pass over an input BAM and verifies record-count parity with the input. The `run_bam_roundtrip` / `RoundtripConfig` helper lands in `pipeline::steps`.

- `--output` is optional; when given, output is written to a staging temp file and persisted into place only after the parity check passes, with a same-file guard (symlink + hard-link, via device+inode) that rejects clobbering the input mid-read.
- `--threads` (1–1024) and `--compression-level` (0–12) are range-checked at parse time; `run_bam_roundtrip` re-validates both since it is public API a direct caller could reach with an out-of-range value.
- The chain routes through `GroupBam`, which canonicalizes within-template record order, so the round-trip preserves the record *set* but not per-template byte order — spelled out in the helper doc, the command doc, and a dedicated test so the count-only gate is not mistaken for a byte-for-byte check.

Ported near-verbatim from the already-merged `#863` on `main-runall` (which `main` did not have); the only source adaptation is `BgzfCompress::new`'s new `index_bam` argument (`false`, matching the in-tree `build_full_chain` reference).

## 2. `fix(io): re-stamp atomic temp-persist outputs to the File::create mode`

While wiring `--output`, the atomic temp-then-persist pattern surfaced a pre-existing wart: a `NamedTempFile` is created `0o600`, and `persist` is a rename that keeps that mode, so outputs written this way land owner-only instead of the umask-derived mode `File::create` produces. This affected `compare bam-roundtrip --output` and every `.bai` index sidecar (`write_bai_index`, reached by `review`, `sort`'s index, and the chain write sink).

- Adds one shared helper, `fgumi_bam_io::restamp_for_persist`, that re-stamps the temp to the `File::create(dest)` mode before the rename — preserving an existing destination's mode on overwrite, else `0o666 & !umask` for a new file. It reads the umask via rustix's **safe** `process::umask`, cached once per process in a `OnceLock`, so `fgumi-bam-io` stays `#![deny(unsafe_code)]` with a single umask probe process-wide.
- Routes the three atomic-output sites through it (`compare bam-roundtrip`, `write_bai_index`, `fgumi-sort`'s `MergeOutputTarget`), which lets `fgumi-sort` **drop its own `unsafe libc::umask` binding**, the `UMASK_LOCK` mutex, and the now-unused `libc` dependency; the corresponding CLAUDE.md unsafe-allowlist entry is removed.
- `fgumi-metrics` already solves the same problem the create-time way (`File::create` staging); the helper doc reconciles the two approaches and explains why the shared one reads the umask (self-contained, and it must also preserve an existing destination's mode, which the create-time approach cannot express).

The existing merge-output mode integration tests (preserve an existing `0o644` dest; umask for a new file) continue to pass, now exercising the shared helper.

## Testing

`cargo ci-fmt`, `cargo ci-lint` (clippy pedantic), and the full `cargo ci-test` (10190 tests) all pass. New coverage: `run_bam_roundtrip` byte-identity across 1/2/4 threads plus empty-input, out-of-range, and non-canonical-template cases; the command's atomic `--output`, same-file guard (symlink + hard link), and range checks; the shared helper's new-dest / existing-dest / umask-non-destructive cases; and end-to-end `--output` and `.bai` mode assertions compared against a live `File::create`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: The command can canonicalize within-template record order; record-count parity and round-trip tests pin the record set, while grouping, consensus, corrected UMIs, and metrics are none. No unsafe code is added, and `CLAUDE.md` matches the allowlist. No queue-capacity or backpressure policy changes; the command validates 1–1024 threads.

Fix: Add `compare bam-roundtrip` with validated settings, atomic verified output, alias protection, and shared output-mode restoration for round-trip, BAI, and sort outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->