### PR TITLE
feat(cli): wire --pipeline-trace through the chain builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ docs/src/metrics/
 # Heap profiling output produced when binaries are built with the dhat-heap feature
 dhat-heap.json
 
+# Default per-tick timeline TSV written by `--pipeline-trace timeline|deep`
+# (when `--pipeline-trace-out` is not given). A diagnostic artifact, never committed.
+pipeline-trace.tsv
+
 # Scratch space for local benchmark corpora, profiles, and campaign notes.
 # Never committed: the compare-bams benchmark corpus alone is ~20 GB of BAMs.
 /ephemeral/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Expose the per-edge pipeline instrumentation ladder on the CLI: a hidden
+  `--pipeline-trace <off|summary|timeline|deep>` (with `--pipeline-trace-out` for
+  the per-tick timeline TSV) threaded through every chain-builder command, plus
+  `--pipeline-stats` on `fgumi sort`. `FGUMI_PIPELINE_TRACE` enables it without
+  the flag. Off by default (zero overhead); `summary` adds the end-of-run edge
+  table + bottleneck verdict, `timeline`/`deep` add the TSV and dwell/park
+  latency. All flags are hidden from `--help` ([#937](https://github.com/fulcrumgenomics/fgumi/pull/937)).
+
 ## [0.7.0] - 2026-08-24
 
 ### Bug Fixes

--- a/crates/fgumi-pipeline-core/src/builder.rs
+++ b/crates/fgumi-pipeline-core/src/builder.rs
@@ -96,6 +96,44 @@ impl InstrumentationLevel {
     pub fn deep(self) -> bool {
         matches!(self, Self::Deep)
     }
+
+    /// The lowercase token for this level, as accepted by [`FromStr`](std::str::FromStr) and
+    /// printed by [`Display`](std::fmt::Display).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Summary => "summary",
+            Self::Timeline => "timeline",
+            Self::Deep => "deep",
+        }
+    }
+}
+
+impl std::str::FromStr for InstrumentationLevel {
+    type Err = String;
+
+    /// Parse a `--pipeline-trace` / `FGUMI_PIPELINE_TRACE` token
+    /// (case-insensitive). Used directly as the clap value parser (the field is
+    /// typed `InstrumentationLevel`, with no `value_parser` attribute), so an
+    /// unrecognized `--pipeline-trace` value is rejected at parse time.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "off" => Ok(Self::Off),
+            "summary" => Ok(Self::Summary),
+            "timeline" => Ok(Self::Timeline),
+            "deep" => Ok(Self::Deep),
+            other => Err(format!(
+                "invalid instrumentation level '{other}' (expected: off | summary | timeline | deep)"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for InstrumentationLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -2059,6 +2097,48 @@ mod tests {
         assert_eq!(level.samples(), is_on);
         assert_eq!(level.timeline(), timeline);
         assert_eq!(level.deep(), deep);
+    }
+
+    // Each case pins a level's canonical lowercase token: `as_str`, `Display`,
+    // and the `FromStr` round-trip from that exact token all agree, so a failure
+    // names the level whose string mapping regressed.
+    #[rstest]
+    #[case::off(InstrumentationLevel::Off, "off")]
+    #[case::summary(InstrumentationLevel::Summary, "summary")]
+    #[case::timeline(InstrumentationLevel::Timeline, "timeline")]
+    #[case::deep(InstrumentationLevel::Deep, "deep")]
+    fn instrumentation_level_string_roundtrip(
+        #[case] level: InstrumentationLevel,
+        #[case] token: &str,
+    ) {
+        assert_eq!(level.as_str(), token);
+        assert_eq!(level.to_string(), token);
+        assert_eq!(token.parse::<InstrumentationLevel>().expect("parse token"), level);
+    }
+
+    // `FromStr` is case-insensitive (it lowercases before matching), so tokens in
+    // any case resolve to the same level — this is the clap value parser, so a CLI
+    // `--pipeline-trace Deep` must be accepted the same as `deep`.
+    #[rstest]
+    #[case::upper("OFF", InstrumentationLevel::Off)]
+    #[case::mixed("Summary", InstrumentationLevel::Summary)]
+    #[case::title("Timeline", InstrumentationLevel::Timeline)]
+    #[case::caps("DEEP", InstrumentationLevel::Deep)]
+    fn instrumentation_level_from_str_is_case_insensitive(
+        #[case] input: &str,
+        #[case] expected: InstrumentationLevel,
+    ) {
+        assert_eq!(input.parse::<InstrumentationLevel>().expect("parse"), expected);
+    }
+
+    #[test]
+    fn instrumentation_level_from_str_rejects_unknown() {
+        let err = "verbose".parse::<InstrumentationLevel>().expect_err("should reject");
+        assert!(err.contains("verbose"), "error should name the bad token: {err}");
+        assert!(
+            err.contains("off | summary | timeline | deep"),
+            "error should list the valid set: {err}"
+        );
     }
 
     #[test]

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -1075,6 +1075,25 @@ pub struct SchedulerOptions {
     #[arg(long = "pipeline-stats", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true, hide = true)]
     pub pipeline_stats: bool,
 
+    /// Per-edge instrumentation level: off | summary | timeline | deep.
+    ///
+    /// `summary` adds per-edge throughput/occupancy/latency + a bottleneck
+    /// verdict to the end-of-run report; `timeline` also writes a per-tick TSV
+    /// (see `--pipeline-trace-out`); `deep` adds direct dwell/park-time latency.
+    /// Diagnostic only — throughput is slightly depressed under tracing; confirm
+    /// final wall/RSS with the flag off. Overridable via `FGUMI_PIPELINE_TRACE`.
+    ///
+    /// Typed `InstrumentationLevel` with no `value_parser`: clap infers the
+    /// parser from the type's `FromStr`, so an invalid value is rejected at parse
+    /// time (mirrors `--temp-codec`'s `SpillCodec` field).
+    #[arg(long = "pipeline-trace", default_value = "off", hide = true)]
+    pub pipeline_trace: crate::pipeline::core::builder::InstrumentationLevel,
+
+    /// Path for the `--pipeline-trace timeline` per-tick TSV
+    /// (default `pipeline-trace.tsv` in the working directory).
+    #[arg(long = "pipeline-trace-out", hide = true)]
+    pub pipeline_trace_out: Option<std::path::PathBuf>,
+
     /// Timeout in seconds for deadlock detection (default: 10, 0 = disabled).
     ///
     /// When no progress is made for this duration, a warning is logged with
@@ -1103,6 +1122,41 @@ impl SchedulerOptions {
         self.pipeline_stats
     }
 
+    /// Resolve the instrumentation level from `--pipeline-trace`, with the
+    /// `FGUMI_PIPELINE_TRACE` env var taking precedence (so standalone commands
+    /// can enable it without flattening the flag). Unknown values → `Off`.
+    ///
+    /// The precedence/mapping itself lives in the pure
+    /// `resolve_instrumentation_level` (unit-tested without touching the
+    /// process environment); this accessor only supplies the env read and the
+    /// one side effect that cannot be pure: a warning when the env var holds an
+    /// unrecognized value. Unlike `--pipeline-trace` (which clap validates
+    /// against the accepted set), the env var is unvalidated, so a typo like
+    /// `FGUMI_PIPELINE_TRACE=summry` would otherwise silently disable tracing
+    /// with no signal.
+    #[must_use]
+    pub fn instrumentation_level(&self) -> crate::pipeline::core::builder::InstrumentationLevel {
+        let env = std::env::var("FGUMI_PIPELINE_TRACE").ok();
+        if let Some(value) = env.as_deref()
+            && !value.is_empty()
+            && value.parse::<crate::pipeline::core::builder::InstrumentationLevel>().is_err()
+        {
+            log::warn!(
+                "FGUMI_PIPELINE_TRACE={value:?} is not a recognized level \
+                 (off|summary|timeline|deep); pipeline tracing stays off"
+            );
+        }
+        resolve_instrumentation_level(env.as_deref(), self.pipeline_trace)
+    }
+
+    /// Path for the per-tick timeline TSV (`--pipeline-trace-out`), if set.
+    /// `None` lets [`PipelineConfig`](crate::pipeline::core::builder::PipelineConfig)
+    /// fall back to its default `pipeline-trace.tsv`.
+    #[must_use]
+    pub fn trace_path(&self) -> Option<std::path::PathBuf> {
+        self.pipeline_trace_out.clone()
+    }
+
     /// Returns the deadlock detection timeout in seconds (0 = disabled).
     #[must_use]
     pub fn deadlock_timeout_secs(&self) -> u64 {
@@ -1113,6 +1167,25 @@ impl SchedulerOptions {
     #[must_use]
     pub fn deadlock_recover_enabled(&self) -> bool {
         self.deadlock_recover
+    }
+}
+
+/// Resolve the instrumentation level from the `FGUMI_PIPELINE_TRACE` env value
+/// (`env`) and the already-parsed `--pipeline-trace` flag (`flag`): the env var,
+/// when set, takes precedence over the flag; an unrecognized (or empty) env
+/// value maps to `Off`. Pure — no env read and no logging — so the precedence
+/// contract is unit-testable in isolation from ambient process state (the env
+/// read and the unrecognized-value warning live in
+/// [`SchedulerOptions::instrumentation_level`], which cannot be pure). The flag
+/// side needs no fallback: clap already parsed it through `FromStr`.
+fn resolve_instrumentation_level(
+    env: Option<&str>,
+    flag: crate::pipeline::core::builder::InstrumentationLevel,
+) -> crate::pipeline::core::builder::InstrumentationLevel {
+    use crate::pipeline::core::builder::InstrumentationLevel;
+    match env {
+        Some(value) => value.parse().unwrap_or(InstrumentationLevel::Off),
+        None => flag,
     }
 }
 
@@ -2067,6 +2140,7 @@ pub(crate) mod test_log_capture {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipeline::core::builder::InstrumentationLevel;
 
     /// `effective_check_crc` truth table (dupblaster policy): an explicit flag
     /// always wins; with neither flag given, the policy falls back to
@@ -2677,6 +2751,8 @@ mod tests {
         let opts = SchedulerOptions {
             scheduler: SchedulerStrategy::FixedPriority,
             pipeline_stats: false,
+            pipeline_trace: InstrumentationLevel::Off,
+            pipeline_trace_out: None,
             deadlock_timeout: 10,
             deadlock_recover: false,
         };
@@ -2688,6 +2764,8 @@ mod tests {
         let opts = SchedulerOptions {
             scheduler: SchedulerStrategy::default(),
             pipeline_stats: true,
+            pipeline_trace: InstrumentationLevel::Off,
+            pipeline_trace_out: None,
             deadlock_timeout: 10,
             deadlock_recover: false,
         };
@@ -2699,6 +2777,8 @@ mod tests {
         let opts = SchedulerOptions {
             scheduler: SchedulerStrategy::default(),
             pipeline_stats: false,
+            pipeline_trace: InstrumentationLevel::Off,
+            pipeline_trace_out: None,
             deadlock_timeout: 30,
             deadlock_recover: false,
         };
@@ -2710,10 +2790,73 @@ mod tests {
         let opts = SchedulerOptions {
             scheduler: SchedulerStrategy::default(),
             pipeline_stats: false,
+            pipeline_trace: InstrumentationLevel::Off,
+            pipeline_trace_out: None,
             deadlock_timeout: 10,
             deadlock_recover: true,
         };
         assert!(opts.deadlock_recover_enabled());
+    }
+
+    // `InstrumentationLevel`'s `FromStr` is both clap's inferred parser for the
+    // `--pipeline-trace` field and the `FGUMI_PIPELINE_TRACE` parser: the four
+    // tokens parse case-insensitively; anything else is an error (clap surfaces
+    // it as a usage error on the flag; the env accessor maps it to `Off`).
+    #[rstest::rstest]
+    #[case::off("off", Some(InstrumentationLevel::Off))]
+    #[case::summary("summary", Some(InstrumentationLevel::Summary))]
+    #[case::timeline("timeline", Some(InstrumentationLevel::Timeline))]
+    #[case::deep("deep", Some(InstrumentationLevel::Deep))]
+    #[case::case_insensitive("DEEP", Some(InstrumentationLevel::Deep))]
+    #[case::unknown("bogus", None)]
+    #[case::empty("", None)]
+    fn instrumentation_level_from_str(
+        #[case] input: &str,
+        #[case] expected: Option<InstrumentationLevel>,
+    ) {
+        assert_eq!(input.parse::<InstrumentationLevel>().ok(), expected);
+    }
+
+    /// Precedence contract behind `instrumentation_level()`: the
+    /// `FGUMI_PIPELINE_TRACE` env value (when `Some`) wins over the already-parsed
+    /// `--pipeline-trace` flag; env `None` falls back to the flag; an unrecognized
+    /// env value maps to `Off`. The flag is a typed `InstrumentationLevel`, so an
+    /// invalid flag value is impossible by construction (clap rejects it) — there
+    /// is no `flag_unknown` case to test any more. Exercised through the pure
+    /// `resolve_instrumentation_level` so every case runs deterministically
+    /// regardless of the ambient `FGUMI_PIPELINE_TRACE`; the impure accessor's env
+    /// read is covered end-to-end by the sort integration tests
+    /// (`tests/integration/test_sort_pipeline_trace.rs`), where a child process
+    /// gets its own environment.
+    #[rstest::rstest]
+    // env unset → flag decides.
+    #[case::flag_only_default(None, InstrumentationLevel::Off, InstrumentationLevel::Off)]
+    #[case::flag_only_deep(None, InstrumentationLevel::Deep, InstrumentationLevel::Deep)]
+    // env set → env wins over the flag, in both directions.
+    #[case::env_overrides_flag_up(
+        Some("deep"),
+        InstrumentationLevel::Off,
+        InstrumentationLevel::Deep
+    )]
+    #[case::env_overrides_flag_down(
+        Some("off"),
+        InstrumentationLevel::Deep,
+        InstrumentationLevel::Off
+    )]
+    #[case::env_summary_over_flag_deep(
+        Some("summary"),
+        InstrumentationLevel::Deep,
+        InstrumentationLevel::Summary
+    )]
+    // unrecognized / empty env value → Off (the flag would otherwise have applied).
+    #[case::env_unknown_off(Some("summry"), InstrumentationLevel::Deep, InstrumentationLevel::Off)]
+    #[case::env_empty_off(Some(""), InstrumentationLevel::Deep, InstrumentationLevel::Off)]
+    fn resolve_instrumentation_level_precedence(
+        #[case] env: Option<&str>,
+        #[case] flag: InstrumentationLevel,
+        #[case] expected: InstrumentationLevel,
+    ) {
+        assert_eq!(resolve_instrumentation_level(env, flag), expected);
     }
 
     // ========== Tests for QueueMemoryOptions ==========

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -39,6 +39,7 @@ use crate::commands::common::{
     parse_memory_reserve, resolve_check_crc, resolve_memory_budget,
 };
 use crate::pipeline::chains::{ChainSpec, SinkSpec, SourceSpec, Stage, StageOptionsBag, build_for};
+use crate::pipeline::core::builder::InstrumentationLevel;
 
 /// Sort order for BAM files.
 ///
@@ -472,8 +473,36 @@ pub struct Sort {
     /// diag: ...") saying the single-chunk in-memory fast path was taken.
     /// Off by default: it is instrumentation for performance work, read from a
     /// log with a grep, and it is not something a normal run should show.
+    ///
+    /// This is the sort-engine's own k-way-merge-loop diagnostic; see
+    /// `--pipeline-stats` for the whole-chain per-step timing/throughput report.
     #[arg(long = "sort-stats", default_value_t = false, hide = true)]
     pub sort_stats: bool,
+
+    /// Print detailed pipeline statistics at completion (per-step timing,
+    /// throughput, contention). Hidden diagnostic; mirrors the `--pipeline-stats`
+    /// flag every chain-builder command flattens from `SchedulerOptions`. See
+    /// `--sort-stats` for the sort-engine's own merge-loop diagnostic instead.
+    #[arg(long = "pipeline-stats", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true, hide = true)]
+    pub pipeline_stats: bool,
+
+    /// Per-edge instrumentation level: off | summary | timeline | deep.
+    ///
+    /// `summary` adds per-edge throughput/occupancy/latency + a bottleneck
+    /// verdict to the end-of-run report; `timeline` also writes a per-tick TSV
+    /// (see `--pipeline-trace-out`); `deep` adds direct dwell/park-time latency.
+    /// Diagnostic only — throughput is slightly depressed under tracing; confirm
+    /// final wall/RSS with the flag off. Overridable via `FGUMI_PIPELINE_TRACE`.
+    ///
+    /// Typed `InstrumentationLevel`, parsed by its `FromStr` (no `value_parser`),
+    /// so an invalid value is rejected at parse time — matching `--temp-codec`.
+    #[arg(long = "pipeline-trace", default_value = "off", hide = true)]
+    pub pipeline_trace: InstrumentationLevel,
+
+    /// Path for the `--pipeline-trace timeline` per-tick TSV
+    /// (default `pipeline-trace.tsv` in the working directory).
+    #[arg(long = "pipeline-trace-out", hide = true)]
+    pub pipeline_trace_out: Option<std::path::PathBuf>,
 }
 
 /// Sort-stage tuning, projected out of the [`Sort`] CLI struct for the chain
@@ -828,7 +857,16 @@ impl Sort {
             threading: ThreadingOptions { threads: Some(self.threads) },
             compression: self.compression.clone(),
             // Match sibling chain commands (10s), not the derived Default (0 = monitor off).
-            scheduler: SchedulerOptions { deadlock_timeout: 10, ..Default::default() },
+            // Carry the sort command's diagnostic instrumentation flags (sort does not
+            // flatten `SchedulerOptions`, so they must be forwarded explicitly) — this
+            // is what makes `fgumi sort --pipeline-trace <level>` reach the chain.
+            scheduler: SchedulerOptions {
+                deadlock_timeout: 10,
+                pipeline_stats: self.pipeline_stats,
+                pipeline_trace: self.pipeline_trace,
+                pipeline_trace_out: self.pipeline_trace_out.clone(),
+                ..Default::default()
+            },
             // The single `--max-memory` knob bounds the inter-stage queue budget too,
             // not just the sorter buffer (see `queue_memory_options`). The queue
             // budget scales by `--threads`; the sorter's by max(threads, sort_threads).
@@ -1656,6 +1694,64 @@ mod tests {
         assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
+    /// `fgumi sort` does not flatten `SchedulerOptions`, so its `--pipeline-stats`
+    /// / `--pipeline-trace` / `--pipeline-trace-out` diagnostic flags must be
+    /// forwarded by hand into the chain spec's scheduler. A dropped forward is
+    /// invisible to a full run (tracing does not change output bytes), so assert
+    /// on the built spec directly.
+    #[test]
+    fn build_sort_chain_spec_forwards_pipeline_diagnostic_flags() {
+        let sort = Sort::try_parse_from([
+            "sort",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--pipeline-stats",
+            "--pipeline-trace",
+            "summary",
+            "--pipeline-trace-out",
+            "trace.tsv",
+        ])
+        .expect("parse should succeed");
+
+        let resolved_max_temp_files = sort.resolved_max_temp_files(fgumi_sort::soft_nofile());
+        let spec = sort.build_sort_chain_spec(
+            Path::new("out.bam"),
+            Vec::new(),
+            resolved_max_temp_files,
+            "fgumi sort (test)",
+        );
+
+        assert!(spec.scheduler.collect_stats(), "--pipeline-stats must reach the chain scheduler");
+        assert_eq!(spec.scheduler.pipeline_trace, InstrumentationLevel::Summary);
+        assert_eq!(spec.scheduler.pipeline_trace_out.as_deref(), Some(Path::new("trace.tsv")));
+        // The deadlock timeout the sort spec pins (10s) must survive alongside the
+        // forwarded flags — the `..Default::default()` spread must not clobber it.
+        assert_eq!(spec.scheduler.deadlock_timeout_secs(), 10);
+    }
+
+    /// `--pipeline-trace` is a typed `InstrumentationLevel` parsed via `FromStr`,
+    /// so clap rejects an unrecognized value at parse time (rather than the old
+    /// string field silently mapping it to `Off`).
+    #[test]
+    fn pipeline_trace_rejects_an_invalid_value() {
+        let err = Sort::try_parse_from([
+            "sort",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--pipeline-trace",
+            "bogus",
+        ])
+        .expect_err("an invalid --pipeline-trace value must be rejected at parse time");
+        assert!(
+            err.to_string().contains("invalid instrumentation level"),
+            "expected the FromStr error to name the invalid level; got: {err}"
+        );
+    }
+
     /// The sorter-free phase thread helpers `Sort::phase1_threads` /
     /// `Sort::phase2_threads` must match the engine's own formula, since
     /// they replace the CLI's only other caller of `RawExternalSorter`'s
@@ -2130,6 +2226,9 @@ mod tests {
             write_index: false,
             read_streams: fgumi_sort::ReadStreams::Auto,
             sort_stats: false,
+            pipeline_stats: false,
+            pipeline_trace: InstrumentationLevel::Off,
+            pipeline_trace_out: None,
         }
     }
 

--- a/src/lib/pipeline/chains/build_helpers.rs
+++ b/src/lib/pipeline/chains/build_helpers.rs
@@ -60,9 +60,25 @@ pub(crate) fn build_pipeline_config_for_chain(
     let mut config = PipelineConfig { threads: num_threads, ..Default::default() };
     config.deadlock_timeout_secs = scheduler.deadlock_timeout_secs();
     config.queue_memory_total = Some(queue_memory.calculate_memory_limit(num_threads)?);
-    // `main-runall`'s command-layer `SchedulerOptions` does not carry per-edge
-    // instrumentation (`--pipeline-trace`); `config.instrumentation` / `trace_path`
-    // stay at their `Off` / `None` defaults from `PipelineConfig::default()`.
+    // Per-edge instrumentation (`--pipeline-trace` / `FGUMI_PIPELINE_TRACE`),
+    // threaded through the command-layer `SchedulerOptions`. Left at `Off` / `None`
+    // when the flag/env are unset, which keeps `PipelineConfig::default()`'s
+    // zero-overhead path (no sampler thread, non-instrumented queues).
+    config.instrumentation = scheduler.instrumentation_level();
+    config.trace_path = scheduler.trace_path();
+    // A `--pipeline-trace-out` path is only consulted at `timeline`/`deep` (the
+    // levels that write the per-tick TSV). If a path was given but the *resolved*
+    // level (after the `FGUMI_PIPELINE_TRACE` override) does not write one, the
+    // flag is a silent no-op — warn rather than drop it without a trace. Checking
+    // `config.instrumentation` here, not the raw flag, keeps the env override in
+    // scope, so an env-enabled `timeline` run with a path does not false-warn.
+    if config.trace_path.is_some() && !config.instrumentation.timeline() {
+        log::warn!(
+            "--pipeline-trace-out was set but the resolved trace level ({:?}) does not write a \
+             timeline TSV (only `timeline` or `deep` do); the path is ignored",
+            config.instrumentation
+        );
+    }
 
     let user_wants_stats = scheduler.collect_stats();
     let monitor_needs_stats = config.deadlock_timeout_secs > 0;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -67,6 +67,7 @@ mod test_simplex_pipeline;
 mod test_simulate_sort;
 mod test_sort_correctness;
 mod test_sort_cutover_parity;
+mod test_sort_pipeline_trace;
 mod test_sort_stats_diagnostics;
 mod test_sort_thread_logging;
 mod test_sort_write_index;

--- a/tests/integration/test_sort_pipeline_trace.rs
+++ b/tests/integration/test_sort_pipeline_trace.rs
@@ -1,0 +1,218 @@
+//! Integration tests for the `--pipeline-trace` / `--pipeline-trace-out` /
+//! `FGUMI_PIPELINE_TRACE` instrumentation surface on `fgumi sort`.
+//!
+//! These pin the *honoring* path end-to-end: that the CLI flag (and the env
+//! var) actually reach `PipelineConfig::instrumentation` and cause the
+//! end-of-run per-edge table + bottleneck verdict to render (and the timeline
+//! TSV to be written), rather than being parsed and silently dropped — the
+//! characteristic CLI-layer failure this whole change exists to avoid. They run
+//! the built binary as a subprocess with its own environment, which is the only
+//! way to exercise the `FGUMI_PIPELINE_TRACE` precedence without mutating the
+//! test process's environment (`std::env::set_var` is `unsafe` under edition
+//! 2024, which this crate forbids).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use rstest::rstest;
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, write_bam};
+
+/// Stable substring of the end-of-run per-edge instrumentation report
+/// (`fgumi_pipeline_core::builder`, `snapshot_with_edges`) — only ever logged
+/// when the resolved instrumentation level is above `Off`.
+const EDGE_TABLE_SUBSTRING: &str = "Pipeline edges";
+
+/// Writes a small unsorted UMI BAM. A handful of families is enough: the sort
+/// chain has the same per-edge topology regardless of size, so the edge table
+/// renders whether or not the sort spills.
+fn write_fixture(path: &Path) {
+    let header = create_minimal_header("chr1", 100_000);
+    let records: Vec<_> = (0..40)
+        .flat_map(|i| create_umi_family("ACGT", 2, &format!("fam_{i:06}"), "ACGTACGTAC", 35))
+        .collect();
+    write_bam(path, &header, &records);
+}
+
+/// Runs `fgumi sort` at `info` verbosity over a fresh fixture, threading the
+/// optional `--pipeline-trace <flag>`, `--pipeline-trace-out <path>`, and
+/// `FGUMI_PIPELINE_TRACE=<env>`. Returns the captured stderr; asserts success.
+fn run_sort(flag: Option<&str>, env_trace: Option<&str>, trace_out: Option<&Path>) -> String {
+    let tmp = TempDir::new().expect("tempdir");
+    let input: PathBuf = tmp.path().join("unsorted.bam");
+    write_fixture(&input);
+    let output = tmp.path().join("sorted.bam");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_fgumi"));
+    cmd.env("RUST_LOG", "info");
+    cmd.env_remove("FGUMI_PIPELINE_TRACE");
+    if let Some(value) = env_trace {
+        cmd.env("FGUMI_PIPELINE_TRACE", value);
+    }
+    cmd.args(["sort", "-i"]).arg(&input).arg("-o").arg(&output).args(["--order", "coordinate"]);
+    if let Some(level) = flag {
+        cmd.args(["--pipeline-trace", level]);
+    }
+    if let Some(path) = trace_out {
+        cmd.arg("--pipeline-trace-out").arg(path);
+    }
+
+    let result = cmd.output().expect("run fgumi sort");
+    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+    assert!(result.status.success(), "fgumi sort failed:\n{stderr}");
+    stderr
+}
+
+/// The `--pipeline-trace` flag and the `FGUMI_PIPELINE_TRACE` env var each
+/// reach `PipelineConfig` and gate the end-of-run edge table; when both are set
+/// the env value wins (in either direction). This is the honoring path that no
+/// in-process test can reach.
+#[rstest]
+// flag alone → the level it names decides.
+#[case::flag_deep(Some("deep"), None, true)]
+#[case::default_off(None, None, false)]
+// env alone → enables tracing without the flag (the standalone-enable path).
+#[case::env_summary(None, Some("summary"), true)]
+// env set → precedence over the flag, in both directions.
+#[case::env_off_overrides_flag_deep(Some("deep"), Some("off"), false)]
+#[case::env_deep_overrides_flag_off(Some("off"), Some("deep"), true)]
+fn pipeline_trace_gates_the_edge_table(
+    #[case] flag: Option<&str>,
+    #[case] env_trace: Option<&str>,
+    #[case] expect_table: bool,
+) {
+    let stderr = run_sort(flag, env_trace, None);
+    assert_eq!(
+        stderr.contains(EDGE_TABLE_SUBSTRING),
+        expect_table,
+        "expected edge-table presence={expect_table} for flag={flag:?} env={env_trace:?}; \
+         stderr:\n{stderr}"
+    );
+}
+
+/// The valid env-precedence cases above prove tracing turns *on or off*, but not
+/// *which* level the env value resolves to: a resolver that mapped `summary` to
+/// `timeline`/`deep`, or fell back to `deep` on an unrecognized value, would slip
+/// through an on/off check. Pinning the resolved level needs a level-sensitive
+/// probe — pair each env value with a conflicting `--pipeline-trace` flag (to
+/// prove the env wins) *and* a `--pipeline-trace-out` path, then read the
+/// TSV-write behavior, which differs by resolved level: `timeline`/`deep` write
+/// the TSV, while `off`/`summary` skip it and warn the path is ignored.
+#[rstest]
+// env `summary` overrides CLI `deep`: resolves to `summary` (edge table on) but,
+// being below `timeline`, skips the TSV and warns the path is ignored — so the
+// env did *not* resolve to `deep`/`timeline`, which would have written it.
+#[case::env_summary_overrides_flag_deep(Some("deep"), "summary", true, false, true)]
+// env `deep` overrides CLI `off`: resolves to `deep` — edge table on and the TSV
+// is written, so the env did *not* resolve to `off`/`summary`.
+#[case::env_deep_overrides_flag_off(Some("off"), "deep", true, true, false)]
+// unrecognized env overrides CLI `deep`: resolves to `off` (edge table gone)
+// despite the flag; the path, now below `timeline`, is skipped with the warning.
+#[case::env_invalid_overrides_flag_deep(Some("deep"), "summry", false, false, true)]
+fn env_level_overrides_flag_and_resolves_specific_level(
+    #[case] flag: Option<&str>,
+    #[case] env_trace: &str,
+    #[case] expect_table: bool,
+    #[case] expect_tsv: bool,
+    #[case] expect_path_ignored_warning: bool,
+) {
+    let tmp = TempDir::new().expect("tempdir");
+    let trace_tsv = tmp.path().join("trace.tsv");
+    let stderr = run_sort(flag, Some(env_trace), Some(&trace_tsv));
+
+    assert_eq!(
+        stderr.contains(EDGE_TABLE_SUBSTRING),
+        expect_table,
+        "expected edge-table presence={expect_table} for flag={flag:?} env={env_trace:?}; \
+         stderr:\n{stderr}"
+    );
+    assert_eq!(
+        trace_tsv.exists(),
+        expect_tsv,
+        "expected trace-out TSV presence={expect_tsv} for flag={flag:?} env={env_trace:?}; \
+         stderr:\n{stderr}"
+    );
+    assert_eq!(
+        stderr.contains("the path is ignored"),
+        expect_path_ignored_warning,
+        "expected path-ignored warning={expect_path_ignored_warning} for flag={flag:?} \
+         env={env_trace:?}; stderr:\n{stderr}"
+    );
+}
+
+/// `--pipeline-trace <level> --pipeline-trace-out <path>` writes the per-tick
+/// timeline TSV to the requested path — proving `--pipeline-trace-out` is
+/// threaded into `PipelineConfig::trace_path`, not just parsed. Both levels that
+/// write the TSV are covered: `timeline` (the lowest such level, whose whole
+/// purpose is the TSV) and `deep`. A defect where `timeline` fails to initialize
+/// or write `trace_path` would otherwise slip through a `deep`-only test.
+#[rstest]
+#[case::timeline("timeline")]
+#[case::deep("deep")]
+fn pipeline_trace_out_writes_the_timeline_tsv(#[case] level: &str) {
+    let tmp = TempDir::new().expect("tempdir");
+    let trace_tsv = tmp.path().join("trace.tsv");
+    let stderr = run_sort(Some(level), None, Some(&trace_tsv));
+
+    assert!(stderr.contains(EDGE_TABLE_SUBSTRING), "{level} trace did not render the edge table");
+    assert!(trace_tsv.exists(), "--pipeline-trace-out path was not written:\n{stderr}");
+    let tsv = std::fs::read_to_string(&trace_tsv).expect("read trace tsv");
+    let mut lines = tsv.lines();
+    assert!(
+        lines.next().is_some_and(|header| header.starts_with("t_ms")),
+        "timeline TSV missing its `t_ms` header row:\n{tsv:.200}"
+    );
+    // The sampler writes a row per tick and a guaranteed final row for a run too
+    // short to tick, so a `timeline`/`deep` TSV always carries at least one data
+    // row — a header-only file means the per-tick writer never ran.
+    assert!(
+        lines.next().is_some(),
+        "timeline TSV has only its `t_ms` header, no per-tick data row:\n{tsv:.400}"
+    );
+}
+
+/// A `--pipeline-trace-out` path is only consulted at the levels that write the
+/// per-tick TSV (`timeline`/`deep`). When the resolved level does *not* write one
+/// (`off` or `summary`), `build_pipeline_config_for_chain` warns that the path is
+/// ignored rather than dropping it silently, and no TSV is created. This pins the
+/// warn-and-skip branch, complementing the `timeline`/`deep` honoring cases above;
+/// without it, a regression that silently swallowed the path at these levels would
+/// go unnoticed.
+#[rstest]
+#[case::off("off")]
+#[case::summary("summary")]
+fn pipeline_trace_out_ignored_below_timeline_warns(#[case] level: &str) {
+    let tmp = TempDir::new().expect("tempdir");
+    let trace_tsv = tmp.path().join("trace.tsv");
+    let stderr = run_sort(Some(level), None, Some(&trace_tsv));
+
+    assert!(
+        stderr.contains("the path is ignored"),
+        "expected a warning that the trace-out path is ignored at `{level}`:\n{stderr}"
+    );
+    assert!(
+        !trace_tsv.exists(),
+        "no timeline TSV must be written at `{level}`, but the path was created:\n{stderr}"
+    );
+}
+
+/// An unrecognized `FGUMI_PIPELINE_TRACE` value falls back to `Off` (tracing
+/// disabled) but, unlike the clap-validated flag, would otherwise do so
+/// silently — so a warning naming the bad value is emitted.
+#[test]
+fn unrecognized_env_value_warns_and_disables_tracing() {
+    let stderr = run_sort(None, Some("summry"), None);
+    assert!(
+        !stderr.contains(EDGE_TABLE_SUBSTRING),
+        "an unrecognized FGUMI_PIPELINE_TRACE must not enable tracing:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("is not a recognized level"),
+        "expected a warning naming the unrecognized FGUMI_PIPELINE_TRACE value:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("summry"),
+        "the warning must name the offending value (`summry`), not just report a bad level:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## What

Exposes the `fgumi-pipeline-core` `InstrumentationLevel` ladder (`off | summary | timeline | deep`) on the CLI. The runtime already implemented the whole facility — the occupancy sampler, the per-tick timeline TSV, the end-of-run per-edge throughput/occupancy/latency table, and the bottleneck verdict — but none of it was reachable: no command ever set `config.instrumentation` above `Off`, so it was dead-reachable. During a recent `group` regression investigation the only exposed knob (`--pipeline-stats`) actively misled (it counts in-step lock-park as "busy") and the real answer needed an external `sample(1)` profile; `deep` shows the same per-edge dwell/park attribution natively.

## How

- Hidden `--pipeline-trace <off|summary|timeline|deep>` and `--pipeline-trace-out <PATH>` on `SchedulerOptions`, so every chain-builder command inherits them via `#[command(flatten)]` (verified: `extract`/`runall` build their `ChainSpec` from `self.scheduler_opts.clone()`).
- `--pipeline-trace` is typed `InstrumentationLevel` (via `FromStr` on the core enum), used directly as the clap field with no `value_parser` — the same pattern as `--temp-codec`'s `SpillCodec`. An invalid value is rejected at parse time rather than silently mapped to `Off`.
- Standalone `fgumi sort` does **not** flatten `SchedulerOptions` (it pins its own `deadlock_timeout` and read-stream knobs), so it grows `--pipeline-stats` / `--pipeline-trace` / `--pipeline-trace-out` on the `Sort` struct and forwards them by hand into the synthetic `SchedulerOptions` in `build_sort_chain_spec`.
- `build_pipeline_config_for_chain` sets `config.instrumentation` and `config.trace_path` from the resolved level; the existing `trace_wants_stats` branch then attaches the stats `Arc` so the edge table renders once the level is above `Off` — the render side (`snapshot_with_edges`) already lived on `main`.
- `FGUMI_PIPELINE_TRACE` enables tracing without the flag (env takes precedence), so standalone commands can turn it on without flattening the flag.

All flags are `hide = true`; the default (`off`) keeps the byte-identical zero-overhead path (no sampler thread, non-instrumented queues).

## Two silent-failure guards

- The `--pipeline-trace` flag is clap-validated (its `FromStr` rejects unknown values), but `FGUMI_PIPELINE_TRACE` is read raw — an unrecognized env value (a typo) now **warns** instead of quietly disabling tracing.
- `--pipeline-trace-out` set at a level that writes no TSV (`off`/`summary`) **warns** rather than being silently dropped; the check reads the resolved level, so an env-enabled `timeline` run with a path does not false-warn.

## Context

This restores the CLI wiring from #475/#476, which merged only onto the `feat-runall` integration branch and never reached `main`. The `InstrumentationLevel` enum is exactly `off/summary/timeline/deep` on every branch — there is no separate "full" level; `summary` is the sampler, `timeline`/`deep` add the TSV.

## Verification

- `cargo ci-test` — 10203 passed, 0 failed; `cargo ci-fmt`, `cargo ci-lint` (`-D warnings`) clean.
- The precedence/mapping is factored into a pure `resolve_instrumentation_level(env, flag)` and unit-tested as a case table (env-over-flag both directions; unknown/empty env → Off); `InstrumentationLevel`'s `FromStr` is tested directly (case-insensitive tokens; unknown → error), and the flag rejecting an invalid value is pinned.
- New subprocess integration tests (`tests/integration/test_sort_pipeline_trace.rs`) pin the honoring path end-to-end: the flag and the env var each gate the edge table, the env value wins over the flag, `--pipeline-trace-out` writes the TSV, and an unrecognized env value warns and disables — none of which an in-process test can reach (`std::env::set_var` is `unsafe` under edition 2024, which the crate forbids).
- Manual end-to-end on `fgumi sort`: `--pipeline-trace deep` renders the 10-edge table + verdict and writes the TSV; the default run is byte-identical in record bodies (only the `@PG` command line differs).

## Note / deliberately deferred

- The three diagnostic fields on `Sort` (`pipeline_stats`, `pipeline_trace`, `pipeline_trace_out`) duplicate the `SchedulerOptions` fields rather than sharing a flattened sub-struct; left as-is since factoring them out would also move the pre-existing `--pipeline-stats`. Happy to extract a `PipelineDiagnosticsOptions` if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: grouping, consensus, sort order, corrected UMI output, and metrics: none; diagnostic trace TSV output is opt-in and pinned by trace settings and paths. `unsafe`: none; CLAUDE.md allowlist changes: none. Memory bounds, queue capacity, and thread/backpressure policy: none.

Fix: Expose pipeline diagnostics through hidden CLI options and `FGUMI_PIPELINE_TRACE`.

- Preserve `off` as the default.
- Forward settings through scheduler and pipeline configuration.
- Warn on invalid environment values and incompatible trace paths.
- Add parsing, precedence, wiring, and subprocess integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->