### PR TITLE
docs(book): document fgumi runall and add Reference guide pages

### DIFF
--- a/crates/xtask/src/generate_summary.rs
+++ b/crates/xtask/src/generate_summary.rs
@@ -7,6 +7,21 @@ use std::path::Path;
 use crate::generate_metrics::MetricPage;
 use crate::generate_tools::ToolPage;
 
+/// Emit one collapsible User Guide sub-group: a bracketed section header
+/// followed by a `guide/<page>.md` link for each entry whose page exists on
+/// disk. The whole group (header included) is omitted when none of its pages
+/// exist, so a stripped-down docs tree never renders an empty section.
+fn push_group(md: &mut String, docs_src: &Path, header: &str, entries: &[(&str, &str)]) {
+    if entries.iter().any(|(_, path)| docs_src.join(path).exists()) {
+        let _ = writeln!(md, "- [{header}]()");
+        for (title, path) in entries {
+            if docs_src.join(path).exists() {
+                let _ = writeln!(md, "  - [{title}]({path})");
+            }
+        }
+    }
+}
+
 /// Generate `SUMMARY.md` for mdBook from static guide pages and dynamic tool/metric pages.
 #[allow(clippy::too_many_lines)]
 pub fn generate(
@@ -28,77 +43,60 @@ pub fn generate(
         let _ = writeln!(md, "- [{}]({})", entry.0, entry.1);
     }
 
-    // Core Concepts sub-group
-    let core_concepts = [
-        ("Read Structures", "guide/read-structures.md"),
-        ("UMI Grouping", "guide/umi-grouping.md"),
-        ("Tracking Reads", "guide/tracking-reads.md"),
-    ];
-    let core_exists = core_concepts.iter().any(|(_, p)| docs_src.join(p).exists());
-    if core_exists {
-        md.push_str("- [Core Concepts]()\n");
-        for (title, path) in &core_concepts {
-            if docs_src.join(path).exists() {
-                let _ = writeln!(md, "  - [{title}]({path})");
-            }
-        }
+    // Running Pipelines — fgumi runall vs individual commands. A standalone
+    // top-level leaf, listed right after Getting Started.
+    let running = ("Running Pipelines", "guide/running-pipelines.md");
+    if docs_src.join(running.1).exists() {
+        let _ = writeln!(md, "- [{}]({})", running.0, running.1);
     }
 
-    // Consensus sub-group
-    let consensus = [
-        ("Consensus Calling", "guide/consensus-calling.md"),
-        ("Duplex Consensus Calling", "guide/duplex-consensus-calling.md"),
-    ];
-    let consensus_exists = consensus.iter().any(|(_, p)| docs_src.join(p).exists());
-    if consensus_exists {
-        md.push_str("- [Consensus Calling]()\n");
-        for (title, path) in &consensus {
-            if docs_src.join(path).exists() {
-                let _ = writeln!(md, "  - [{title}]({path})");
-            }
-        }
-    }
-
-    // Methylation sub-group
-    let methylation = [("Pipeline Guide", "guide/methylation.md")];
-    let methylation_exists = methylation.iter().any(|(_, p)| docs_src.join(p).exists());
-    if methylation_exists {
-        md.push_str("- [Methylation]()\n");
-        for (title, path) in &methylation {
-            if docs_src.join(path).exists() {
-                let _ = writeln!(md, "  - [{title}]({path})");
-            }
-        }
-    }
-
-    // NanoSeq sub-group
-    let nanoseq = [("Pipeline Guide", "guide/nanoseq.md")];
-    let nanoseq_exists = nanoseq.iter().any(|(_, p)| docs_src.join(p).exists());
-    if nanoseq_exists {
-        md.push_str("- [NanoSeq (Duplex-Seq)]()\n");
-        for (title, path) in &nanoseq {
-            if docs_src.join(path).exists() {
-                let _ = writeln!(md, "  - [{title}]({path})");
-            }
-        }
-    }
-
-    // Advanced Topics sub-group
-    let advanced = [
-        ("Best Practices", "guide/best-practices.md"),
-        ("Performance Tuning", "guide/performance-tuning.md"),
-        ("Working with Metrics", "guide/working-with-metrics.md"),
-        ("Migration from fgbio", "guide/migration-from-fgbio.md"),
-    ];
-    let advanced_exists = advanced.iter().any(|(_, p)| docs_src.join(p).exists());
-    if advanced_exists {
-        md.push_str("- [Advanced Topics]()\n");
-        for (title, path) in &advanced {
-            if docs_src.join(path).exists() {
-                let _ = writeln!(md, "  - [{title}]({path})");
-            }
-        }
-    }
+    // Sub-groups: each renders a collapsible sidebar section, omitted entirely
+    // when none of its pages exist. Standalone leaf pages (above) are listed
+    // before these so the sidebar's plain links and expandable section headers
+    // form two visually distinct zones.
+    push_group(
+        &mut md,
+        docs_src,
+        "Core Concepts",
+        &[
+            ("Read Structures", "guide/read-structures.md"),
+            ("UMI Grouping", "guide/umi-grouping.md"),
+            ("Tracking Reads", "guide/tracking-reads.md"),
+        ],
+    );
+    push_group(
+        &mut md,
+        docs_src,
+        "Consensus Calling",
+        &[
+            ("Consensus Calling", "guide/consensus-calling.md"),
+            ("Duplex Consensus Calling", "guide/duplex-consensus-calling.md"),
+        ],
+    );
+    push_group(&mut md, docs_src, "Methylation", &[("Pipeline Guide", "guide/methylation.md")]);
+    push_group(
+        &mut md,
+        docs_src,
+        "NanoSeq (Duplex-Seq)",
+        &[("Pipeline Guide", "guide/nanoseq.md")],
+    );
+    push_group(
+        &mut md,
+        docs_src,
+        "Advanced Topics",
+        &[
+            ("Best Practices", "guide/best-practices.md"),
+            ("Performance Tuning", "guide/performance-tuning.md"),
+            ("Working with Metrics", "guide/working-with-metrics.md"),
+            ("Migration from fgbio", "guide/migration-from-fgbio.md"),
+        ],
+    );
+    push_group(
+        &mut md,
+        docs_src,
+        "Reference",
+        &[("Glossary", "guide/glossary.md"), ("Troubleshooting", "guide/troubleshooting.md")],
+    );
 
     md.push('\n');
 
@@ -235,6 +233,77 @@ mod tests {
         assert!(
             !md.contains("guide/nanoseq.md"),
             "NanoSeq link should be omitted when guide is missing:\n{md}"
+        );
+    }
+
+    /// Generate `SUMMARY.md` for a docs tree that optionally contains the
+    /// Running Pipelines leaf and the Reference-group guide pages, and return
+    /// the markdown it wrote.
+    fn summary_with_pages(pages: &[&str]) -> String {
+        let tmp = TempDir::new().expect("failed to create temp dir");
+        let docs_src = tmp.path();
+        let guide_dir = docs_src.join("guide");
+        fs::create_dir_all(&guide_dir).expect("failed to create guide dir");
+        for page in pages {
+            fs::write(guide_dir.join(page), "# Page\n").expect("failed to write guide");
+        }
+        generate(docs_src, &[], &[]).expect("generate failed");
+        fs::read_to_string(docs_src.join("SUMMARY.md")).expect("failed to read SUMMARY.md")
+    }
+
+    #[test]
+    fn running_pipelines_leaf_present_when_guide_exists() {
+        let md = summary_with_pages(&["running-pipelines.md"]);
+        assert!(
+            md.contains("- [Running Pipelines](guide/running-pipelines.md)"),
+            "missing Running Pipelines leaf:\n{md}"
+        );
+    }
+
+    #[test]
+    fn running_pipelines_leaf_absent_when_guide_missing() {
+        let md = summary_with_pages(&[]);
+        assert!(
+            !md.contains("guide/running-pipelines.md"),
+            "Running Pipelines link should be omitted when guide is missing:\n{md}"
+        );
+    }
+
+    #[test]
+    fn reference_group_present_when_a_guide_exists() {
+        let md = summary_with_pages(&["glossary.md", "troubleshooting.md"]);
+        assert!(md.contains("- [Reference]()"), "missing Reference group:\n{md}");
+        assert!(md.contains("  - [Glossary](guide/glossary.md)"), "missing Glossary link:\n{md}");
+        assert!(
+            md.contains("  - [Troubleshooting](guide/troubleshooting.md)"),
+            "missing Troubleshooting link:\n{md}"
+        );
+    }
+
+    #[test]
+    fn reference_group_present_with_only_one_guide() {
+        // Pins the `.any()` group guard and the per-entry existence filter: with
+        // only Glossary present the group still renders, but the missing
+        // Troubleshooting link is omitted (an `.all()` group guard, or an
+        // unconditional per-entry emit, would fail this).
+        let md = summary_with_pages(&["glossary.md"]);
+        assert!(
+            md.contains("- [Reference]()"),
+            "Reference group should render with one guide:\n{md}"
+        );
+        assert!(md.contains("  - [Glossary](guide/glossary.md)"), "missing Glossary link:\n{md}");
+        assert!(
+            !md.contains("guide/troubleshooting.md"),
+            "Troubleshooting link should be omitted when its guide is missing:\n{md}"
+        );
+    }
+
+    #[test]
+    fn reference_group_absent_when_guides_missing() {
+        let md = summary_with_pages(&[]);
+        assert!(
+            !md.contains("- [Reference]()"),
+            "Reference group should be omitted when its guides are missing:\n{md}"
         );
     }
 }

--- a/docs/src/guide/glossary.md
+++ b/docs/src/guide/glossary.md
@@ -1,0 +1,44 @@
+# Glossary
+
+Definitions of the terms and tags used throughout this guide.
+
+## Concepts
+
+**UMI (Unique Molecular Identifier).** A short, often random, sequence attached to each original molecule before amplification. Reads that share a UMI and a mapping position are presumed to come from the same source molecule, which lets fgumi collapse PCR and sequencing duplicates into a consensus.
+
+**Template.** The pair of reads (R1 and R2) sequenced from one molecule. fgumi groups and sorts by template, not by individual reads.
+
+**Read structure.** A compact description of where UMI, template, sample-barcode, cell-barcode, and skip bases sit within each sequencing read, e.g. `8M+T` = an 8 bp UMI followed by all remaining template bases. See [Read Structures](read-structures.md).
+
+**Family / family size.** A *family* is the set of reads grouped to one source molecule; *family size* is how many templates it contains (on paired-end data a read pair counts as one template), matching the `family_sizes.txt` histogram. The distribution of family sizes is a key QC signal — see [Working with Metrics](working-with-metrics.md).
+
+**Simplex (single-strand) consensus.** A consensus built from reads of a single strand of the source molecule. Produced by `fgumi simplex`. See [Consensus Calling](consensus-calling.md).
+
+**Duplex (double-strand) consensus.** A consensus that combines evidence from *both* strands of the source molecule, which suppresses errors that occur on only one strand. Produced by `fgumi duplex`. See [Duplex Consensus Calling](duplex-consensus-calling.md).
+
+**CODEC.** A library protocol (Bae et al. 2023) in which a single read pair sequences both strands of the duplex molecule, so even one read pair can yield a duplex consensus. Produced by `fgumi codec`.
+
+**Template-coordinate order.** A sort order that keeps all reads of a template together and orders templates by the outer 5′ coordinates of the pair. It is the required input order for `fgumi group`, `fgumi dedup`, and `fgumi downsample`, and is produced by `fgumi sort --order template-coordinate`. (Use `fgumi sort`, not `samtools sort`, ahead of these commands — see [Troubleshooting](troubleshooting.md).)
+
+**Phred quality.** A base-quality score `Q = -10·log₁₀(P_error)`; higher is better (Q30 ≈ 1 error in 1000).
+
+**Pre-UMI / post-UMI error rate.** The consensus model splits sequencing error into errors that occur *before* the UMI is integrated into the molecule (`--error-rate-pre-umi`) and *after* (`--error-rate-post-umi`). See [Consensus Calling](consensus-calling.md).
+
+## Strand labels
+
+**`/A` and `/B`.** Suffixes on the `MI` tag that `fgumi group --strategy paired` assigns to the two single-strand sub-families of one duplex molecule (e.g. `1/A` and `1/B`). The `/A` sub-family is the read pair whose read 1 5′ end comes at or before read 2's, ignoring soft-clipping and reference strand. See [Tracking Reads](tracking-reads.md).
+
+**AB / BA strand.** The two strand orientations combined into a duplex consensus. Per-strand thresholds in `fgumi duplex` and `fgumi filter` take up to three values, `[duplex, AB, BA]`.
+
+## BAM tags
+
+| Tag | Set by | Meaning |
+|-----|--------|---------|
+| `RX` | `extract` | Raw UMI bases (input to `group`/`correct`). |
+| `QX` | `extract` | UMI base qualities (optional). |
+| `OX` | `correct` | Original UMI, before correction. |
+| `MI` | `group` | Molecule ID assigning each read to a UMI family; carries `/A`·`/B` suffixes under the `paired` strategy. |
+| `CB` | upstream | Cell barcode for single-cell data; reads are partitioned by `CB` before grouping, sorting, and deduplication. Not corrected by fgumi. |
+| `tc` | `zipper` | Template-coordinate sort key added to secondary/supplementary reads so they sort and deduplicate correctly. (Releases before 0.2.0 wrote this under the name `pa`, since renamed to avoid a clash with bwa-mem's `pa:f` score tag.) |
+
+Consensus callers add a family of per-read and per-base tags (`cD`, `cM`, `cE`, `cd`, `ce`, and the `a*`/`b*` single-strand variants for duplex). See [Tracking Reads](tracking-reads.md) for the full scheme.

--- a/docs/src/guide/running-pipelines.md
+++ b/docs/src/guide/running-pipelines.md
@@ -1,0 +1,146 @@
+# Running Pipelines
+
+Most fgumi work is a *pipeline*: extract UMIs, align, sort, group, call consensus, filter. You can run each stage as its own command — writing a BAM to disk between every step — or fuse a run of stages into a single streaming process with `fgumi runall`.
+
+## When to use `runall`
+
+> **Rule of thumb:** run a single stage with its own command (`fgumi sort`, `fgumi group`, `fgumi simplex`, …). Chain **two or more** stages with `fgumi runall`.
+
+`runall` streams records directly from one stage to the next, so every intermediate BAM a sequential run would write is elided. Its output is **record-identical** to running the equivalent standalone commands in turn — the same aligned records in the same order, and the same `@HD` `SO`/`GO`/`SS`, `@SQ`, and `@RG` header fields. The output is *not* byte-for-byte identical: the fused chain writes a single `@PG` record where the staged run writes one per command, and the `@HD` `VN` and `@CO` fields are not compared. Same algorithm, just without the round-trips to disk.
+
+Reach for individual commands when you want to inspect or reuse an intermediate BAM (for example, to try several filter settings against one consensus BAM), or when you need a per-stage metrics file that `runall` does not emit (see [Caveats](#caveats)).
+
+`runall` processes one input. If you have several BAMs from separate sequencing runs, combine them first with `fgumi merge --order template-coordinate`, then point `runall` at the merged file with `--start-from group`. Use `--start-from sort` only for raw aligned input that still needs sorting.
+
+## The stage model
+
+`runall` understands a fixed, linearly ordered set of stages:
+
+```text
+extract < correct < align < zipper < sort < group < consensus < filter
+```
+
+| Stage | What it does | Reads |
+|-------|--------------|-------|
+| `extract` | UMIs from FASTQ → unmapped BAM | FASTQ (`--extract::inputs`) — the only stage that reads FASTQ rather than a BAM |
+| `correct` | Correct UMIs against a fixed whitelist | unmapped BAM (`--input`) |
+| `align` | Run the aligner subprocess and zipper-merge the result | unmapped BAM (`--input`) + `--ref` + an aligner (`--aligner::preset` or `--aligner::command`) |
+| `zipper` | Merge a mapped BAM with its unmapped BAM, restoring tags | mapped BAM (`--input`) + `--unmapped` + `--ref` (with a companion `.dict`) |
+| `sort` | Sort into template-coordinate order | aligned BAM (`--input`) |
+| `group` | Group reads by UMI, assigning MI tags | template-coordinate-sorted BAM (`--input`) |
+| `consensus` | Call consensus (algorithm set by `--consensus`) | grouped, MI-tagged BAM (`--input`) |
+| `filter` | Filter/mask consensus reads | consensus BAM (`--input`) |
+
+## Selecting the slice to run
+
+Pick the slice with `--start-from` and `--stop-after` (both required). `--start-from` declares the state of your input; `--stop-after` names the last stage to run. They must satisfy `start-from ≤ stop-after` in the order above, and `--stop-after` cannot be `align` — it is start-only, so the valid stop stages are `extract`, `correct`, `zipper`, `sort`, `group`, `consensus`, and `filter`. Both are required because `runall` cannot infer either one: the same BAM could be valid input to several stages, and you may want to stop anywhere along the chain.
+
+> **Important — match the input to `--start-from`.** `runall` validates the stage *range* but **cannot** verify that your input file is actually in the state `--start-from` claims. If you pass, for example, a raw unsorted BAM to `--start-from group`, the run may fail in a later stage or silently produce incorrect output, depending on what the mismatched input trips. Confirm your input matches the declared start stage (the [stage model](#the-stage-model) table lists what each stage expects).
+
+When the slice reaches the `consensus` stage, choose the algorithm with `--consensus`:
+
+| `--consensus` | Consensus caller | Required grouping strategy |
+|---------------|------------------|----------------------------|
+| `simplex` | single-strand ([Consensus Calling](consensus-calling.md)) | `adjacency` (or `identity`/`edit`) |
+| `duplex` | double-strand ([Duplex Consensus Calling](duplex-consensus-calling.md)) | **`paired`** |
+| `codec` | CODEC duplex from single read pairs | `adjacency` (or `identity`/`edit`) |
+
+The algorithm is chosen by `--consensus`, **not** by the stage name. `--stop-after consensus` produces the same BAM as the matching `fgumi simplex`/`duplex`/`codec` command. **`--consensus duplex` requires `--group::strategy paired`** (so MIs carry the `/A`·`/B` strand suffixes duplex needs); `simplex` and `codec` require a non-paired strategy. Mismatching these is a hard error.
+
+### Automatically inserted stages
+
+You only name the *first* and *last* stages; `runall` fills in any stages in between that the chain requires. The one case that surprises people: the `align` and `zipper` stages emit reads in queryname order, but `group` needs template-coordinate order, so `runall` always inserts a `sort` step between them. For example, `--start-from extract --stop-after consensus` expands to extract → align → sort → group → consensus, and `--start-from zipper --stop-after group` expands to zipper → sort → group. You never write the inserted `sort` yourself, but you can still tune it with `--sort::*` flags.
+
+## Per-stage options
+
+Tune any stage with prefixed flags of the form `--<stage>::<flag>`. These mirror the standalone command's options exactly:
+
+| Standalone | `runall` |
+|------------|----------|
+| `fgumi sort --max-memory 4G` | `--sort::max-memory 4G` |
+| `fgumi group --strategy adjacency` | `--group::strategy adjacency` |
+| `fgumi duplex --min-reads 1,1,0` | `--duplex::min-reads 1,1,0` |
+| `fgumi extract --read-structures +T +T` | `--extract::read-structures +T +T` |
+
+Cross-cutting options stay at the top level: `--threads`, `--compression-level`, `--max-memory`, `--ref`, `--rejects`, `--stats`, `--methylation-mode`. Run `fgumi runall --help` for the full, grouped list.
+
+## Examples
+
+Each example chains two or more stages, so each one is a job for `runall` rather than a sequence of standalone commands.
+
+**Sort → group → simplex consensus**, replacing three commands and two intermediate BAMs:
+
+```bash
+fgumi runall \
+  --start-from sort --stop-after consensus --consensus simplex \
+  --input unsorted.bam --output consensus.bam \
+  --group::strategy adjacency --group::edits 1 \
+  --simplex::min-reads 1 \
+  --threads 8
+```
+
+**Group → duplex consensus** (duplex requires the `paired` strategy):
+
+```bash
+fgumi runall \
+  --start-from group --stop-after consensus --consensus duplex \
+  --input sorted.bam --output duplex.bam \
+  --group::strategy paired --group::edits 1 \
+  --duplex::min-reads 1,1,0 \
+  --threads 8
+```
+
+**Consensus → filter, fused** — no intermediate consensus BAM is written:
+
+```bash
+fgumi runall \
+  --start-from group --stop-after filter --consensus simplex \
+  --input sorted.bam --output filtered.bam \
+  --group::strategy adjacency \
+  --simplex::min-reads 1 \
+  --filter::min-reads 1 --filter::max-read-error-rate 0.025 \
+  --threads 8
+```
+
+**FASTQ → consensus**, the whole pipeline in one command (`runall` inserts `align`, `sort`, and `group`):
+
+```bash
+fgumi runall \
+  --start-from extract --stop-after consensus --consensus simplex \
+  --extract::inputs R1.fq.gz R2.fq.gz \
+  --extract::read-structures 8M+T +T \
+  --extract::sample MySample --extract::library MyLibrary \
+  --ref ref.fa --aligner::preset bwa-mem3 --output consensus.bam \
+  --group::strategy adjacency \
+  --simplex::min-reads 1 \
+  --threads 8
+```
+
+## `runall` vs. individual commands
+
+| | `runall` | Individual commands |
+|---|----------|---------------------|
+| Intermediate BAMs | none (in-memory) | written to disk between stages |
+| Output | record-identical to the command chain (header `@PG`/`@HD VN` differ) | the same records |
+| Per-stage metrics/histograms | not emitted | available (e.g. `fgumi group --metrics`) |
+| Inspect/reuse an intermediate | no | yes — the BAM is on disk |
+| Best for | production runs, multi-stage chains | single stages, debugging, metrics, experimentation |
+
+For the recommended end-to-end pipelines and parameter choices, see [Best Practices](best-practices.md).
+
+## Caveats
+
+- **No per-stage metrics.** Fused chains do not emit the metrics or histograms that standalone stages do (`fgumi group --metrics`, `simplex-metrics`, `duplex-metrics`). Run the standalone stage when you need them — see [Working with Metrics](working-with-metrics.md).
+- **No `--stop-after align`.** Raw aligner output before the zipper-merge has lost every original tag, so the earliest stop after `--start-from align` is `zipper`.
+- **Input state is not validated** against `--start-from` — see the warning under [Selecting the slice to run](#selecting-the-slice-to-run).
+- **UMI rejects are discarded when `correct` is fused mid-chain.** To capture them, run `fgumi correct --rejects` as a separate step.
+- **Strategy constraints.** `--consensus duplex` requires `--group::strategy paired`; `--consensus simplex` and `--consensus codec` require a non-paired strategy.
+- **Methylation limits.** `--methylation-mode` is rejected for any chain that includes the `align` stage — not only `--start-from align`, but also `--start-from extract`/`correct` chains that run through alignment (which insert `align` automatically) — and is unsupported with `--consensus codec`. Use it with a `simplex` or `duplex` chain that starts from an already-aligned BAM (`--start-from zipper`, `sort`, `group`, or `consensus`) and reaches the consensus stage. For EM-seq during alignment, align in command mode (`--aligner::command "bwameth.py …"`) and apply methylation as a separate downstream step. See [Methylation](methylation.md).
+- **`zipper` start needs a dictionary.** `--start-from zipper` requires `--ref` with a companion `.dict` file (create one with `samtools dict`).
+
+## See Also
+
+- [Getting Started](getting-started.md) — the step-by-step tutorial these stages come from
+- [Best Practices](best-practices.md) — recommended end-to-end pipelines and parameters
+- [Troubleshooting](troubleshooting.md) — fixes for common `runall` and sort-order errors
+- [Glossary](glossary.md) — UMI, template-coordinate, strand labels, and BAM tags

--- a/docs/src/guide/troubleshooting.md
+++ b/docs/src/guide/troubleshooting.md
@@ -1,0 +1,81 @@
+# Troubleshooting
+
+Common errors and unexpected results, with their causes and fixes.
+
+## `fgumi extract` rejects the read structures
+
+**Cause.** The number of read structures does not match the number of `--inputs` FASTQs, or a structure's fixed-length segments add up to more bases than a read contains.
+
+**Fix.** Supply exactly one read structure per FASTQ, in the same order as `--inputs`, and use `+` for the final segment so it absorbs whatever bases remain (e.g. `8M+T` rather than `8M142T` when read length varies). See [Read Structures](read-structures.md) for the syntax and worked examples.
+
+## "Input BAM must be template-coordinate sorted"
+
+```text
+Input BAM must be template-coordinate sorted (header must advertise
+SO:unsorted, GO:query, and SS:template-coordinate).
+```
+
+**Cause.** `fgumi group`, `fgumi dedup`, and `fgumi downsample` require template-coordinate order, and the input is in some other order.
+
+**Fix.** Sort with fgumi (not samtools — see below):
+
+```bash
+fgumi sort -i input.bam -o sorted.bam --order template-coordinate
+```
+
+## `samtools sort` output gives wrong grouping or dedup results
+
+**Cause.** `fgumi zipper` writes a `tc` tag on secondary/supplementary reads so they sort and deduplicate correctly. `samtools sort --template-coordinate` ignores the `tc` tag, so its output orders those reads incorrectly for `fgumi group`/`dedup`.
+
+**Fix.** Always sort with `fgumi sort --order template-coordinate` after `fgumi zipper`. Reserve `samtools sort` for plain coordinate or queryname sorting of BAMs that will not feed `group`, `dedup`, or `downsample`.
+
+## Every UMI family has size 1 (all singletons)
+
+**Cause.** Reads from the same molecule are not being grouped together. Common reasons:
+
+- The UMI length in `--read-structures` is wrong, so the wrong bases are stored in `RX`.
+- UMI diversity is high relative to depth (genuinely few duplicates).
+- The `identity` grouping strategy is splitting families on sequencing errors in the UMI.
+
+**Fix.** Verify the read structure against your library design ([Read Structures](read-structures.md)); switch from `identity` to `adjacency` so single-base UMI errors are tolerated ([UMI Grouping](umi-grouping.md)); and inspect the family-size histogram from `fgumi group --metrics` ([Working with Metrics](working-with-metrics.md)).
+
+## Low consensus yield
+
+**Cause.** `--min-reads` is set higher than most families can satisfy, or families are too small.
+
+**Fix.** Lower `--min-reads` (it is always safe to call with `--min-reads 1` and filter later), confirm UMI extraction, and run `fgumi simplex-metrics` / `fgumi duplex-metrics` on the grouped BAM to see how yield scales with depth.
+
+## Excessive duplex strand disagreement / many no-calls
+
+**Cause.** The two strands disagree at many positions, often from low input base quality or reads extending past the insert.
+
+**Fix.** Raise `--min-input-base-quality`, enable `--trim` to remove low-quality read ends, and tune the per-strand `--min-reads` triple `[duplex, AB, BA]`. See [Duplex Consensus Calling](duplex-consensus-calling.md).
+
+## Out-of-memory / process killed
+
+**Cause.** `--max-memory` bounds only the pipeline queue, and it is *per thread* by default, so total RSS scales with `--threads`. A high thread count can exceed host RAM.
+
+**Fix.** On a fixed-RAM host, use `--max-memory auto` (self-throttles to the host) or set a fixed total budget with `--max-memory <N> --memory-per-thread false`; reduce `--threads`. See the [Performance Tuning](performance-tuning.md) memory section for the full model.
+
+## `fgumi runall` produces wrong or empty output (input doesn't match `--start-from`)
+
+**Cause.** `runall` cannot verify that your input file is actually in the state `--start-from` claims. If the input is in a different state — e.g. a raw unsorted BAM passed to `--start-from group`, or an ungrouped BAM passed to `--start-from consensus` — the pipeline runs on whatever it finds. Depending on the mismatch, a downstream stage may reject the input and fail partway through (for example, stages that require template-coordinate order error if the header does not advertise it), or the run may complete but silently produce wrong (or empty) results.
+
+**Fix.** Make the input match the declared start stage. Check the BAM's sort order in its header (`samtools view -H in.bam | grep @HD`) and confirm the expected tags are present (`RX` after extract, `MI` after group). The [stage model table](running-pipelines.md#the-stage-model) lists what each start stage expects. When in doubt, start from an earlier stage so `runall` does the upstream work itself.
+
+## `--stop-after align` is rejected (runall)
+
+**Cause.** Raw aligner output before the zipper-merge has lost every original tag, so `align` is not a valid stop point.
+
+**Fix.** Use `--stop-after zipper` as the earliest stop after `--start-from align`. See [Running Pipelines](running-pipelines.md).
+
+## `fgumi group` rejects `--strategy paired` with another flag
+
+```text
+Paired strategy cannot be used with --min-umi-length
+--no-umi cannot be used with --strategy paired
+```
+
+**Cause.** The `paired` strategy (for duplex data) is incompatible with `--min-umi-length` and `--no-umi`.
+
+**Fix.** Drop the conflicting flag. Use `paired` only for duplex workflows; use `adjacency` for simplex and CODEC.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -65,6 +65,7 @@ cargo build --release
 | `duplex` | Call duplex consensus reads |
 | `codec` | Call CODEC consensus |
 | `filter` | Filter consensus reads |
+| `runall` | Fuse two or more pipeline stages into a single streaming pass (see [Running Pipelines](guide/running-pipelines.md)) |
 | `clip` | Clip overlapping read pairs |
 | `duplex-metrics` | Collect duplex metrics |
 | `review` | Review consensus variants |


### PR DESCRIPTION
## Summary

`fgumi runall` — the fused multi-stage pipeline — ships on `main` but is undocumented in the hand-written user guide. This ports the runall user-guide pages from the merged docs overhaul (#467, which landed on `feat-runall`, not `main`) as a self-contained, scoped change.

Three new guide pages, wired into the generated mdBook `SUMMARY`:

- **Running Pipelines** (`docs/src/guide/running-pipelines.md`) — the stage model (`extract < correct < align < zipper < sort < group < consensus < filter`), the `--start-from` / `--stop-after` / `--consensus` surface, the per-stage `--<stage>::<flag>` scheme, worked examples, a runall-vs-individual-commands decision, and the fused-chain caveats. Establishes the guiding rule: run one stage with its own command, chain two or more with `runall`.
- **Glossary** (`docs/src/guide/glossary.md`) — UMI, template, read structure, simplex/duplex/CODEC, the `/A`·`/B` and AB/BA strand labels, template-coordinate order, and BAM tags.
- **Troubleshooting** (`docs/src/guide/troubleshooting.md`) — common errors mapped to causes and fixes, including the runall input-state and `--stop-after align` cases.

`crates/xtask/src/generate_summary.rs` gains a "Running Pipelines" top-level leaf after Getting Started and a "Reference" sub-group (Glossary, Troubleshooting). The six repeated sidebar sub-group emissions are folded into a single `push_group` helper — the generated `SUMMARY.md` is byte-identical before and after. New unit tests mirror the existing NanoSeq pattern and pin the `.any()` group guard against partial presence.

## Scope

Deliberately narrow: this is the runall-docs slice of #467. The rest of that merge (README/CONTRIBUTING, clap help-text changes to `runall`/`codec`/`simplex`, sidebar CSS, and the Methylation/Simplex sidebar restructuring) is out of scope and handled separately.

## Accuracy

Every load-bearing claim was verified against the source that ships on `main`:

- `align` is the CLI value (`#[clap(name = "align")]` on `RunAllStage::AlignAndMerge`), and it is start-only.
- The quoted template-coordinate and paired-strategy error strings match `common.rs` / `group.rs` verbatim.
- Cross-cutting flags (`--threads`, `--compression-level`, `--max-memory`, `--ref`, `--rejects`, `--stats`, `--methylation-mode`) all exist on `runall`; a nonexistent `--raw-tag`/`--assign-tag` claim was dropped (those tags are hardcoded to `RX`/`MI`).
- Output is described as **record-identical** (not byte-for-byte): the fused chain writes a single `@PG` where the staged run writes one per command, matching `runall`'s own `long_about`.
- Methylation is documented as rejected for **any** align-bearing chain (not only `--start-from align`), valid from `zipper`/`sort`/`group`/`consensus` starts.
- The `pa` BAM tag was corrected — it is the pre-0.2.0 name for `tc`, since renamed to avoid bwa-mem's `pa:f`.

## Verification

- `cargo run -p xtask -- docs-build` (generate markdown + `mdbook build`) — clean, no warnings on the new/edited pages; all SUMMARY links and intra-page anchors resolve.
- `cargo ci-fmt`, `cargo clippy -p xtask --all-targets -- -D warnings`, and the `generate_summary` unit tests (7) all pass.
- Generated `SUMMARY.md` confirmed byte-identical after the `push_group` refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output for grouping, consensus, sort order, corrected UMIs, and metrics—none; `unsafe` changes—none, with the CLAUDE.md allowlist unchanged; memory bounds, queue capacity, and thread/backpressure policy—none.

Fix: document `fgumi runall`, glossary terms, and troubleshooting. Wire the pages into `SUMMARY.md` and add the `runall` command entry. Refactor summary generation with `push_group` while preserving byte-identical output. Add unit tests for generated links and groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->