### PR TITLE
feat(fastq): run BAM→FASTQ on the typed-step chain and add paired split output

### DIFF
--- a/docs/src/guide/best-practices.md
+++ b/docs/src/guide/best-practices.md
@@ -565,6 +565,63 @@ fgumi dedup --input sorted.bam --output deduped.bam \
 
 ---
 
+## Alternative: UMI-Extracted FASTQ Output (for third-party tools)
+
+Some downstream tools expect the UMI in the **FASTQ read name** rather than in a BAM tag — for example Illumina DRAGEN, which reads the UMI from the read header and, for duplex UMIs, requires the two UMIs joined with a `+`. Because `fgumi extract` already parses the UMIs, trims them off the reads, and stores them in the standard `RX` tag, `fgumi fastq --annotate-read-names` can write them straight back into the read name. This replaces the slow `umi-tools` + `samtools fastq` combination with a single fast pipeline that yields both a UMI-tagged BAM and UMI-in-header FASTQs.
+
+```mermaid
+graph TD;
+A["fgumi extract"]-->B["extracted.bam (UMI in RX tag, reads trimmed)"];
+B-->C["fgumi fastq --annotate-read-names"];
+C-->D["R1.fastq.gz / R2.fastq.gz (UMI in read name)"];
+```
+
+```bash
+# Step 1: Extract UMIs from FASTQ (UMIs trimmed off, stored in the RX tag)
+fgumi extract \
+  --inputs r1.fq.gz r2.fq.gz \
+  --read-structures 8M+T 8M+T \
+  --sample "sample_name" \
+  --library "library_name" \
+  --output extracted.bam
+
+# Step 2: Write paired, gzipped FASTQs with the UMI in the read name
+fgumi fastq \
+  --input extracted.bam \
+  --annotate-read-names \
+  --threads 8 \
+  --out1 out_R1.fastq.gz \
+  --out2 out_R2.fastq.gz \
+  --out0 /dev/null
+```
+
+Key points:
+- Set `--read-structures` in Step 1 to match where your UMIs actually live (e.g. `8M+T +T` for a UMI on R1 only). See [Read Structures](read-structures.md).
+- **DRAGEN-ready by default**: a duplex UMI stored as `RX:Z:AAAAAAAA-CCCCCCCC` becomes the read name `@readname:AAAAAAAA+CCCCCCCC` — identical to `samtools fastq -U`, and the `+`-joined format DRAGEN expects.
+- In split (`--out1`/`--out2`) mode the `/1` `/2` suffixes are omitted so R1 and R2 read names match, as in `samtools fastq -1/-2`. Reads that are neither cleanly R1 nor R2 go to `--out0` (or stdout if `--out0` is omitted).
+- Any `.gz`/`.bgz` output path is written as **BGZF** (gzip-compatible for downstream tools, yet block-indexable). Pass `--threads` to parallelize BGZF compression on compressed output.
+
+### Optional: Interleaved output and custom delimiters
+
+```bash
+# Interleaved FASTQ to stdout (e.g. to pipe elsewhere), UMI in the read name.
+# `-U` is a short alias for `--annotate-read-names`, matching `samtools fastq -U`.
+fgumi fastq --input extracted.bam -U > umi_in_name.fastq
+
+# Custom delimiters for non-DRAGEN platforms (e.g. MGI, Element, ONT):
+# underscore between the read name and UMI, and no delimiter between duplex UMIs.
+fgumi fastq --input extracted.bam --annotate-read-names \
+  --umi-name-delim _ --umi-sep '' \
+  --out1 out_R1.fastq.gz --out2 out_R2.fastq.gz
+```
+
+Options:
+- `--umi-tag`: tag(s) to read the UMI from, first present wins (default `RX,OX`)
+- `--umi-name-delim`: delimiter between the read name and the UMI (default `:`)
+- `--umi-sep`: delimiter joining duplex UMIs, replacing the stored `-` (default `+`)
+
+---
+
 ## Recommended Parameters by Application
 
 ### Variant Calling (High Sensitivity)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,7 +56,7 @@ cargo build --release
 |---------|-------------|
 | `extract` | Extract UMIs from FASTQ files |
 | `correct` | Correct UMIs based on sequence similarity |
-| `fastq` | Convert BAM to FASTQ format |
+| `fastq` | Convert BAM to FASTQ (interleaved or paired split), optionally embedding the UMI in the read name |
 | `zipper` | Merge alignments back onto the unmapped BAM, restoring its tags |
 | `sort` | Sort BAM by coordinate/queryname/template |
 | `group` | Group reads by UMI |

--- a/src/lib/commands/fastq.rs
+++ b/src/lib/commands/fastq.rs
@@ -1,20 +1,25 @@
 //! Convert BAM to FASTQ format.
 //!
-//! This tool reads a BAM file and outputs interleaved FASTQ to stdout for piping to aligners.
-//! Input should be queryname-sorted or template-coordinate sorted.
+//! Reads a BAM file and writes FASTQ, either interleaved to stdout (the default,
+//! for piping to `bwa mem -p`) or split into per-read files (`--out1`/`--out2`,
+//! plus optional `--out0`). Input should be queryname-sorted or
+//! template-coordinate sorted. The conversion runs on the typed-step pipeline.
 
-use crate::logging::OperationTimer;
+use crate::commands::common::{
+    CompressionOptions, MemoryLimit, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
+    reject_output_collisions,
+};
 use crate::sam::SamTag;
 use crate::validation::validate_input_exists;
 use anyhow::Result;
 use clap::Parser;
-use fgumi_bam_io::{create_raw_bam_reader, is_stdin_path, is_stdout_path};
+use fgumi_bam_io::{ReadStreams, is_stdin_path};
 use fgumi_raw_bam::{
     RawRecord, aux_data_slice, extract_sequence_into, find_string_tag, quality_scores_slice,
     read_name as raw_read_name,
 };
-use log::{info, warn};
-use std::io::{self, BufWriter, Write, stdout};
+use log::info;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use crate::commands::command::Command;
@@ -54,18 +59,27 @@ static COMPLEMENT: [u8; 256] = {
     name = "fastq",
     about = "\x1b[38;5;72m[ALIGNMENT]\x1b[0m      \x1b[36mConvert BAM to FASTQ format\x1b[0m",
     long_about = r#"
-Convert a BAM file to interleaved FASTQ format.
+Convert a BAM file to FASTQ, either interleaved (the default, for `bwa mem -p`)
+or split into per-read files (--out1/--out2, plus optional --out0).
 
-Reads BAM records and outputs FASTQ to stdout for piping to aligners.
-Input should be queryname-sorted or template-coordinate sorted.
+Reads BAM records and, by default, writes interleaved FASTQ to stdout for piping
+to aligners. Input should be queryname-sorted or template-coordinate sorted. Any
+`.gz`/`.bgz` output path is written as BGZF (gzip-compatible, block-indexable);
+stdout is always plain text. The conversion runs on the typed-step pipeline, so
+`--threads` parallelizes both BAM decompression and BGZF output compression.
 
 EXAMPLES:
 
-  # Pipe to bwa mem for alignment
+  # Pipe interleaved FASTQ to bwa mem for alignment
   fgumi fastq -i unmapped.bam | bwa mem -t 16 -p -K 150000000 -Y ref.fa -
 
-  # With multi-threaded BAM decompression
-  fgumi fastq -i unmapped.bam -@ 4 | bwa mem -t 16 -p ref.fa -
+  # Paired split output to gzipped files (mirrors `samtools fastq -1/-2/-0`)
+  fgumi fastq -i unmapped.bam -@ 4 \
+    --out1 R1.fastq.gz --out2 R2.fastq.gz --out0 other.fastq.gz
+
+  # Embed the UMI (from the RX tag) in the read name, DRAGEN-ready
+  fgumi fastq -i extracted.bam --annotate-read-names \
+    --out1 R1.fastq.gz --out2 R2.fastq.gz --out0 /dev/null
 
   # Exclude secondary and supplementary alignments (default)
   fgumi fastq -i aligned.bam -F 0x900 | bwa mem ...
@@ -76,16 +90,17 @@ NOTES:
   matching `samtools fastq -N`. A QNAME that already carries a mate suffix
   (a re-imported BAM; the SAM spec forbids it) is not stripped, so the output
   would double it (`name/1/1`) -- same as samtools -N. Pass --no-read-suffix
-  to leave names untouched.
+  to leave names untouched. Paired split (--out1/--out2) mode always omits the
+  suffix, since the R1/R2 file already identifies the mate.
 
   Missing base qualities: a read with no stored quality (all 0xFF, the SAM
   no-quality sentinel) is emitted with a fixed Q33 ('B') per base, matching
   `samtools fastq` -- not Q93, which would falsely claim near-perfect quality.
 
-  Interleaved pairing: output is interleaved for `bwa mem -p`. If a template
-  contributes a lone mate (its pair is absent or dropped by --exclude-flags /
-  --require-flags), the R1/R2 stream desyncs; fgumi warns when the paired R1/R2
-  counts differ.
+  Interleaved pairing: for `bwa mem -p` the input must be queryname or
+  template-coordinate sorted with both mates present; a lone mate (its pair
+  absent or dropped by --exclude-flags / --require-flags) desyncs the R1/R2
+  stream. Prefer paired split (--out1/--out2) when mates may be missing.
 "#
 )]
 pub struct Fastq {
@@ -116,9 +131,10 @@ pub struct Fastq {
     #[arg(short = '@', short_alias = 't', long = "threads", default_value = "1")]
     pub threads: usize,
 
-    /// BWA -K parameter value (bases per batch). Sizes output buffer to match bwa's
-    /// batch size for optimal pipe throughput. Default matches common bwa mem usage.
-    #[arg(short = 'K', long = "bwa-chunk-size", default_value = "150000000")]
+    /// Deprecated and ignored: output batching is managed by the typed-step
+    /// pipeline (tune with `--max-memory`). Retained so existing `-K …`
+    /// invocations keep parsing; a non-default value logs a deprecation notice.
+    #[arg(short = 'K', long = "bwa-chunk-size", default_value_t = DEFAULT_BWA_CHUNK_SIZE, hide = true)]
     pub bwa_chunk_size: u64,
 
     /// Append the record's UMI to the read name, before any /1 or /2 suffix.
@@ -142,6 +158,33 @@ pub struct Fastq {
     /// expect `AAAA+CCCC`, so the stored `-` is rewritten to this value.
     #[arg(long = "umi-sep", default_value = "+")]
     pub umi_sep: String,
+
+    /// Write read 1 (R1) to this file instead of the interleaved stream; requires
+    /// `--out2`. A `.gz`/`.bgz` path is written as BGZF. Mirrors `samtools fastq -1`.
+    #[arg(short = '1', long = "out1", requires = "out2", conflicts_with = "output")]
+    pub out1: Option<PathBuf>,
+
+    /// Write read 2 (R2) to this file; requires `--out1`. A `.gz`/`.bgz` path is
+    /// written as BGZF. Mirrors `samtools fastq -2`.
+    #[arg(short = '2', long = "out2", requires = "out1", conflicts_with = "output")]
+    pub out2: Option<PathBuf>,
+
+    /// Write reads that are neither cleanly R1 nor R2 (single-end / ambiguous)
+    /// here; requires `--out1`. If omitted, such reads go to stdout, matching
+    /// `samtools fastq` without `-0`. A `.gz`/`.bgz` path is written as BGZF.
+    #[arg(short = '0', long = "out0", requires = "out1")]
+    pub out0: Option<PathBuf>,
+
+    /// Pipeline scheduler diagnostics (`--pipeline-stats`, deadlock detection).
+    #[command(flatten)]
+    pub scheduler: SchedulerOptions,
+
+    /// Pipeline queue-memory limits (`--max-memory`, …). The conversion runs on
+    /// the typed-step pipeline; these cap the in-flight queue memory. Defaults to
+    /// a lean fastq budget (see `FASTQ_DEFAULT_QUEUE_MEMORY_MB`); pass
+    /// `--max-memory` to override.
+    #[command(flatten)]
+    pub queue_memory: QueueMemoryOptions,
 }
 
 /// Parse flag values supporting both decimal and hex (0x) notation.
@@ -154,233 +197,229 @@ fn parse_flags(s: &str) -> Result<u16, String> {
 }
 
 impl Fastq {
-    /// Run the BAM-to-FASTQ conversion loop against the given writer.
-    ///
-    /// Extracted so `execute` can dispatch between stdout (the default piping
-    /// path) and a file (`--output`) without duplicating the conversion loop.
-    fn run_with_writer<W: Write>(&self, writer: &mut W) -> Result<()> {
-        use fgumi_raw_bam::flags as raw_flag_bits;
-        let timer = OperationTimer::new("Converting BAM to FASTQ");
+    /// Build the optional UMI-in-read-name annotation, validating the tag list
+    /// up front. Returns `None` when `--annotate-read-names` is off.
+    fn build_umi_header(&self) -> Result<Option<UmiNameAnnotation>> {
+        if self.annotate_read_names {
+            info!("UMI in read name: from tag(s) {}", self.umi_tag.join(","));
+            Ok(Some(UmiNameAnnotation::new(&self.umi_tag, &self.umi_name_delim, &self.umi_sep)?))
+        } else {
+            Ok(None)
+        }
+    }
 
+    /// Log the shared conversion configuration once at run start.
+    ///
+    /// Paired split output always omits the `/1` `/2` suffix (the R1/R2 file
+    /// already identifies the mate), so the suffix line reports the *effective*
+    /// behavior — not the raw `--no-read-suffix` flag, which paired mode ignores.
+    fn log_config(&self) {
         info!("Input: {}", self.input.display());
         info!("Threads: {}", self.threads);
         info!("Exclude flags: 0x{:X}", self.exclude_flags);
         info!("Require flags: 0x{:X}", self.require_flags);
-        info!("Read name suffix: {}", if self.no_suffix { "disabled" } else { "enabled" });
-        info!("BWA chunk size: {} bases", self.bwa_chunk_size);
-
-        let (mut reader, _header) = create_raw_bam_reader(&self.input, self.threads)?;
-
-        let mut total_records: u64 = 0;
-        let mut written_records: u64 = 0;
-        // Track paired R1/R2 balance to detect singletons that would desync the
-        // interleaved stream under `bwa mem -p` (FASTQ3-02).
-        let mut paired_r1_written: u64 = 0;
-        let mut paired_r2_written: u64 = 0;
-
-        // Batch tracking (mirrors bwa's logic)
-        let mut bases_this_batch: u64 = 0;
-        let mut records_this_batch: usize = 0;
-
-        // Reusable buffers to avoid per-record allocations
-        let mut buffers = FastqRecordBuffers::with_capacity(512);
-        let mut record = RawRecord::new();
-
-        // Resolve the UMI annotation config once, outside the per-record loop.
-        let umi_annotation = if self.annotate_read_names {
-            Some(UmiNameAnnotation::new(&self.umi_tag, &self.umi_name_delim, &self.umi_sep)?)
+        let suffix = if self.out1.is_some() {
+            "omitted (paired split)"
+        } else if self.no_suffix {
+            "disabled"
         } else {
-            None
+            "enabled"
         };
+        info!("Read name suffix: {suffix}");
+    }
 
-        loop {
-            let n = reader.read_record(&mut record)?;
-            if n == 0 {
-                break; // EOF
-            }
-            total_records += 1;
+    /// Build the per-stage [`FastqOptions`] — the single source of truth for the
+    /// flag filters, read-name suffix behavior, and UMI-in-read-name config the
+    /// encode step needs, shared by the interleaved and paired-split chain specs.
+    fn to_fastq_options(&self) -> Result<FastqOptions> {
+        Ok(FastqOptions {
+            exclude_flags: self.exclude_flags,
+            require_flags: self.require_flags,
+            no_suffix: self.no_suffix,
+            umi_header: self.build_umi_header()?,
+        })
+    }
 
-            let flags = record.flags();
+    /// Assemble the typed-step [`ChainSpec`] for a BAM → FASTQ conversion:
+    /// `SourceSpec::Bam` → `Stage::Fastq` → the given `sink`.
+    ///
+    /// [`ChainSpec`]: crate::pipeline::chains::ChainSpec
+    fn build_chain_spec(
+        &self,
+        sink: crate::pipeline::chains::SinkSpec,
+        command_line: &str,
+    ) -> Result<crate::pipeline::chains::ChainSpec> {
+        use crate::pipeline::chains::{ChainSpec, SourceSpec, Stage, StageOptionsBag};
 
-            // Filter by flags
-            if (flags & self.exclude_flags) != 0 {
-                continue;
-            }
-            if (flags & self.require_flags) != self.require_flags {
-                continue;
-            }
+        Ok(ChainSpec {
+            stages: vec![Stage::Fastq],
+            source: SourceSpec::Bam(self.input.clone()),
+            sink,
+            stage_opts: StageOptionsBag {
+                fastq: Some(self.to_fastq_options()?),
+                ..Default::default()
+            },
+            threading: ThreadingOptions::new(self.threads),
+            compression: CompressionOptions { compression_level: FASTQ_GZIP_LEVEL },
+            scheduler: self.scheduler.clone(),
+            queue_memory: self.resolve_queue_memory(),
+            async_reader: false,
+            // fastq exposes no read-stream knob; keep the plain sequential reader.
+            read_streams: ReadStreams::Fixed(1),
+            // Match the default CRC policy every other command uses: verify a file
+            // source, skip for stdin (which cannot be re-decoded to re-check).
+            verify_crc: !is_stdin_path(&self.input),
+            command_line: command_line.to_string(),
+        })
+    }
 
-            // Get sequence length for batch tracking
-            let seq_len = record.l_seq() as usize;
+    /// Assemble the [`ChainSpec`] for paired-split BAM → FASTQ:
+    /// `SourceSpec::Bam` → `Stage::Fastq` → `SinkSpec::FastqPaired`. Only the
+    /// sink differs from [`Self::build_chain_spec`]; every other field is shared.
+    ///
+    /// [`ChainSpec`]: crate::pipeline::chains::ChainSpec
+    fn build_paired_chain_spec(
+        &self,
+        command_line: &str,
+    ) -> Result<crate::pipeline::chains::ChainSpec> {
+        // clap `requires` guarantees out2 is present whenever out1 is, and
+        // execute() only calls this when out1.is_some().
+        let out1 = self.out1.clone().expect("out1 present in paired mode");
+        let out2 = self.out2.clone().expect("out2 present in paired mode");
+        let sink =
+            crate::pipeline::chains::SinkSpec::FastqPaired { out1, out2, out0: self.out0.clone() };
+        self.build_chain_spec(sink, command_line)
+    }
 
-            // Write FASTQ record
-            write_fastq_record(
-                &mut *writer,
-                &record,
-                flags,
-                self.no_suffix,
-                &mut buffers,
-                umi_annotation.as_ref(),
-            )?;
-            written_records += 1;
-            if (flags & raw_flag_bits::PAIRED) != 0 {
-                if (flags & raw_flag_bits::FIRST_SEGMENT) != 0 {
-                    paired_r1_written += 1;
-                }
-                if (flags & raw_flag_bits::LAST_SEGMENT) != 0 {
-                    paired_r2_written += 1;
-                }
-            }
+    /// Resolve the queue-memory options for the chain.
+    ///
+    /// FASTQ blocks are small and the chain is a short linear
+    /// source → encode → write pipeline, so the sort/consensus-sized default
+    /// (768 MiB *per thread*) is wildly oversized and would inflate RSS as
+    /// `--threads` scales. When the flags are left at that default, a lean fixed
+    /// total ([`FASTQ_DEFAULT_QUEUE_MEMORY_MB`]) is substituted; any explicit
+    /// `--max-memory` / `--memory-per-thread` override is honored untouched. (A
+    /// user who explicitly passes the default value is indistinguishable from not
+    /// passing it and gets the lean budget — harmless, since 768 MiB/thread is
+    /// never what a fastq conversion wants.)
+    ///
+    /// The "is it the default?" test compares against [`QueueMemoryOptions::default`]
+    /// rather than a hardcoded byte count, so it cannot silently stop firing if
+    /// that default is ever changed in `common.rs`.
+    fn resolve_queue_memory(&self) -> QueueMemoryOptions {
+        let mut qm = self.queue_memory.clone();
+        let default = QueueMemoryOptions::default();
+        let is_default = matches!(
+            (&qm.max_memory, &default.max_memory),
+            (MemoryLimit::Fixed(a), MemoryLimit::Fixed(b)) if a == b
+        ) && qm.memory_per_thread == default.memory_per_thread;
+        if is_default {
+            qm.max_memory =
+                MemoryLimit::Fixed(FASTQ_DEFAULT_QUEUE_MEMORY_MB as usize * 1024 * 1024);
+            qm.memory_per_thread = false;
+        }
+        qm
+    }
 
-            // Track batch progress
-            bases_this_batch += seq_len as u64;
-            records_this_batch += 1;
-
-            // Flush at batch boundary (like bwa: bases >= K AND record count is even)
-            if bases_this_batch >= self.bwa_chunk_size && records_this_batch.is_multiple_of(2) {
-                writer.flush()?;
-                bases_this_batch = 0;
-                records_this_batch = 0;
+    /// Reject a write target that resolves to the same file as the `--input`
+    /// BAM, which would clobber the file being read (mirrors `retag`/`copy_umi`).
+    ///
+    /// The input BAM always exists, so it canonicalises; any output that
+    /// canonicalises to the same path is rejected before a writer truncates it.
+    /// This also catches a symlinked or `./`-spelled output that resolves to the
+    /// input. Stdin input (`-`/`/dev/stdin`) has no filesystem entity to
+    /// canonicalise and cannot be clobbered, so the guard no-ops there.
+    ///
+    /// Output-vs-output collisions — two paths naming one destination, and the
+    /// stdout-multiplexing case — are handled separately by
+    /// [`reject_output_collisions`], which shares the same `(path, flag)` slice.
+    fn reject_write_aliasing_input(&self, outputs: &[(&Path, &str)]) -> Result<()> {
+        let Ok(input_canon) = std::fs::canonicalize(&self.input) else {
+            return Ok(());
+        };
+        for (path, flag) in outputs {
+            if std::fs::canonicalize(path).is_ok_and(|canon| canon == input_canon) {
+                anyhow::bail!(
+                    "{flag} '{}' is the same file as --input '{}'; choose a different path",
+                    path.display(),
+                    self.input.display()
+                );
             }
         }
-
-        // Final flush
-        writer.flush()?;
-
-        // FASTQ3-02: this is interleaved output. If the paired R1/R2 counts differ,
-        // at least one template contributed a lone mate (its pair was absent or
-        // dropped by `--exclude-flags`/`--require-flags`), which desyncs R1/R2 pairing
-        // for every subsequent read under `bwa mem -p`. Warn rather than fail —
-        // single-end input and deliberate mate filtering are legitimate uses.
-        //
-        // NOTE: this is a best-effort NET-count heuristic, not per-QNAME pairing. Two
-        // singletons that cancel — one template drops its R2, another drops its R1 —
-        // leave R1==R2 and are NOT detected here (a robust check would need per-read-name
-        // pairing, impractical for a streaming converter). So the absence of a warning
-        // does not guarantee a perfectly-synced interleaved stream.
-        if paired_r1_written != paired_r2_written {
-            // Net imbalance, a lower bound on the true singleton count: canceling
-            // singletons (one template drops its R2, another its R1) leave R1==R2
-            // and are not counted here (see NOTE above).
-            let net_imbalance = paired_r1_written.abs_diff(paired_r2_written);
-            warn!(
-                "Interleaved FASTQ paired-read counts differ (R1={paired_r1_written}, \
-                 R2={paired_r2_written}): net R1/R2 imbalance of {net_imbalance} (at least \
-                 {net_imbalance} singleton mate(s)) will desync R1/R2 pairing under \
-                 `bwa mem -p`. Ensure the input is queryname/template-coordinate sorted with \
-                 both mates present, or reconsider `--exclude-flags` (0x{:X}) / `--require-flags` \
-                 (0x{:X}).",
-                self.exclude_flags, self.require_flags
-            );
-        }
-
-        info!("Read {total_records} records, wrote {written_records} FASTQ records");
-        timer.log_completion(written_records);
         Ok(())
     }
-}
-
-/// Refuse an `--output` that would clobber the `--input` BAM.
-///
-/// `File::create(path)` truncates before the input is opened in
-/// `run_with_writer`, so an `--output` naming the same file silently destroys
-/// the input data. Lexical equality catches the obvious case; canonicalising
-/// both sides also catches `./in.bam` vs `in.bam`, symlinks, and absolute vs
-/// relative paths pointing at the same file.
-///
-/// # Errors
-///
-/// Returns an error if `output` and `input` name the same file, or if either
-/// path exists but cannot be canonicalised.
-fn reject_output_clobbering_input(input: &Path, output: Option<&PathBuf>) -> Result<()> {
-    let Some(output) = output else { return Ok(()) };
-
-    // Stdin has no filesystem entity to canonicalise -- `canonicalize("-")`
-    // fails with `NotFound` -- and cannot name the output file, so there is
-    // nothing to clobber. Without this the guard turns `--input -` into a
-    // confusing IO error whenever `--output` happens to already exist.
-    if is_stdin_path(input) {
-        return Ok(());
-    }
-
-    // Likewise stdout: `-` names a stream, not a file, so it cannot clobber the
-    // input — and a stray `-` file left in the working directory must not make
-    // this guard canonicalise something that is not the destination.
-    if is_stdout_path(output) {
-        return Ok(());
-    }
-
-    let same_path = output == input
-        || (output.exists() && std::fs::canonicalize(output)? == std::fs::canonicalize(input)?);
-    if same_path {
-        anyhow::bail!(
-            "--output {} must differ from --input {} (would truncate the input BAM)",
-            output.display(),
-            input.display()
-        );
-    }
-    Ok(())
 }
 
 impl Command for Fastq {
-    fn execute(&self, _command_line: &str) -> Result<()> {
+    fn execute(&self, command_line: &str) -> Result<()> {
         validate_input_exists(&self.input, "Input BAM")?;
-        reject_output_clobbering_input(&self.input, self.output.as_ref())?;
 
-        match &self.output {
-            // `-` and `/dev/stdout` name the stream that omitting `--output`
-            // already writes. Spelling it out is what makes this command follow
-            // the same `-` convention as the rest of the CLI; before, `-o -`
-            // created a regular file called `-`.
-            Some(path) if is_stdout_path(path) => self.write_to_stdout(),
-            // A `.gz`/`.bgz` output path must actually be compressed. Writing plain
-            // text under a `.gz` name produces a file every downstream tool rejects.
-            // BGZF is gzip-compatible, so `zcat`/`gzip -d` read it, and it stays
-            // block-indexable.
-            Some(path) if is_gzip_output_path(path) => {
-                let file = std::fs::File::create(path)?;
-                let mut writer = BgzfFastqWriter::new(file, BGZF_OUTPUT_COMPRESSION_LEVEL);
-                self.run_with_writer(&mut writer)?;
-                // Append the BGZF EOF marker so the stream is not seen as truncated.
-                writer.finish()?;
-                Ok(())
-            }
-            Some(path) => {
-                let file = std::fs::File::create(path)?;
-                let mut writer = BufWriter::with_capacity(FASTQ_BUF_CAPACITY, file);
-                self.run_with_writer(&mut writer)?;
-                // `BufWriter`'s `Drop` flushes but discards the error, so a failed
-                // final write — a full disk here — would leave a truncated FASTQ
-                // behind an exit code of zero. Flush explicitly to report it, as
-                // the `.gz` arm's `finish` already does.
-                writer.flush()?;
-                Ok(())
-            }
-            None => self.write_to_stdout(),
+        if self.bwa_chunk_size != DEFAULT_BWA_CHUNK_SIZE {
+            info!(
+                "--bwa-chunk-size ({}) is deprecated and ignored; output batching is now managed \
+                 by the pipeline (tune with --max-memory)",
+                self.bwa_chunk_size
+            );
         }
-    }
-}
 
-/// Output buffer size — 64MB, for efficient pipe throughput.
-const FASTQ_BUF_CAPACITY: usize = 64 * 1024 * 1024;
+        // Refuse to clobber the input BAM or route two streams to the same file
+        // before opening anything (a sink truncates its path on create). Only
+        // user-specified outputs are checked; the default interleaved stdout
+        // (`self.output == None`) names no file and is skipped. `reject_output_collisions`
+        // handles output-vs-output (including stdout multiplexing and `./`/symlink
+        // aliases, with `/dev/null` exempt); `reject_write_aliasing_input` handles
+        // output-vs-input.
+        let mut outputs: Vec<(&Path, &str)> = Vec::new();
+        if let Some(p) = &self.output {
+            outputs.push((p.as_path(), "--output"));
+        }
+        if let Some(p) = &self.out1 {
+            outputs.push((p.as_path(), "--out1"));
+        }
+        if let Some(p) = &self.out2 {
+            outputs.push((p.as_path(), "--out2"));
+        }
+        if let Some(p) = &self.out0 {
+            outputs.push((p.as_path(), "--out0"));
+        }
+        // Paired mode with no `--out0` routes "other" (single-end / ambiguous)
+        // reads to stdout (`SinkSpec::FastqPaired`), so register that implicit
+        // stdout target; otherwise `--out1 -` (or `--out2 -`) would multiplex
+        // onto the same stdout the "other" stream uses and slip past the guard.
+        if self.out1.is_some() && self.out0.is_none() {
+            outputs.push((Path::new("-"), "--out0 (default: stdout)"));
+        }
+        reject_output_collisions(&outputs)?;
+        self.reject_write_aliasing_input(&outputs)?;
 
-impl Fastq {
-    /// Writes uncompressed FASTQ to stdout.
-    ///
-    /// Uncompressed regardless of how stdout was asked for: this stream is meant
-    /// to be piped into an aligner, which wants plain FASTQ.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if a record cannot be written, or if the final flush
-    /// fails — `EPIPE` when the aligner on the other end exits early. Dropping
-    /// the [`BufWriter`] would swallow that flush error and report success on a
-    /// truncated stream.
-    fn write_to_stdout(&self) -> Result<()> {
-        let mut writer = BufWriter::with_capacity(FASTQ_BUF_CAPACITY, stdout().lock());
-        self.run_with_writer(&mut writer)?;
-        writer.flush()?;
-        Ok(())
+        self.log_config();
+
+        // Paired split output (`-1`/`-2`, optionally `-0`) runs through the
+        // typed-step chain: BAM source → Stage::Fastq 3-way encode → three
+        // per-file raw writers (BGZF for `.gz`), all sharing one work-stealing
+        // pool. clap guarantees `--out1`/`--out2` come together and conflict with
+        // `--output`, so `out1.is_some()` is the paired-mode discriminant.
+        if let Some(out1) = &self.out1 {
+            let out2 = self.out2.as_ref().expect("out2 present in paired mode");
+            info!("R1 -> {}", out1.display());
+            info!("R2 -> {}", out2.display());
+            match &self.out0 {
+                Some(out0) => info!("other -> {}", out0.display()),
+                None => info!("other -> stdout"),
+            }
+            return crate::pipeline::chains::build_for(
+                self.build_paired_chain_spec(command_line)?,
+            )?
+            .run();
+        }
+
+        // Interleaved output runs through the same chain: BAM source →
+        // Stage::Fastq encode (pool-spread) → one raw writer (BGZF for `.gz`).
+        // `-` (or an omitted `--output`) writes to stdout.
+        let output = self.output.clone().unwrap_or_else(|| PathBuf::from("-"));
+        info!("Output -> {}", output.display());
+        let sink = crate::pipeline::chains::SinkSpec::Fastq(output);
+        crate::pipeline::chains::build_for(self.build_chain_spec(sink, command_line)?)?.run()
     }
 }
 
@@ -408,58 +447,28 @@ fn encode_quality_into(quals: &[u8], out: &mut Vec<u8>) {
     }
 }
 
-/// BGZF compression level used for `.gz`/`.bgz` FASTQ output.
+/// Default `--bwa-chunk-size`; kept only so a non-default value can be detected
+/// and a deprecation notice logged. Output batching is managed by the pipeline
+/// now, so the value is otherwise ignored (see [`Fastq::execute`]).
+const DEFAULT_BWA_CHUNK_SIZE: u64 = 150_000_000;
+
+/// BGZF compression level for `.gz`/`.bgz`/`.bgzf` FASTQ output.
 ///
 /// 6 is the zlib/bgzip default: a middle trade-off between output size and CPU,
-/// appropriate for an intermediate file handed straight to an aligner.
-const BGZF_OUTPUT_COMPRESSION_LEVEL: u32 = 6;
+/// appropriate for an intermediate file handed straight to an aligner. Carried
+/// on the chain's [`CompressionOptions`] and applied by the sink's `BgzfCompress`
+/// step.
+const FASTQ_GZIP_LEVEL: u32 = 6;
 
-/// Returns `true` if `path` names a gzip-family output that must be compressed.
-fn is_gzip_output_path(path: &std::path::Path) -> bool {
-    path.extension()
-        .and_then(|e| e.to_str())
-        .is_some_and(|e| e.eq_ignore_ascii_case("gz") || e.eq_ignore_ascii_case("bgz"))
-}
-
-/// `io::Write` adapter that block-compresses FASTQ text as BGZF.
+/// Lean default total in-flight queue-memory budget (MiB) for `fgumi fastq` when
+/// the user leaves `--max-memory` at its per-thread default.
 ///
-/// BGZF is gzip-compatible, so any consumer that reads `.gz` reads this, while the
-/// output stays block-indexable. The BGZF EOF marker is appended on drop-free
-/// finalization (`finish`), which `Write::flush` alone must not do — flush can be
-/// called mid-stream.
-struct BgzfFastqWriter<W: Write> {
-    inner: W,
-    compressor: fgumi_bgzf::InlineBgzfCompressor,
-}
-
-impl<W: Write> BgzfFastqWriter<W> {
-    fn new(inner: W, compression_level: u32) -> Self {
-        Self { inner, compressor: fgumi_bgzf::InlineBgzfCompressor::new(compression_level) }
-    }
-
-    /// Flushes remaining buffered bytes and appends the BGZF EOF marker so the
-    /// stream is complete and tools do not report a truncated file.
-    fn finish(&mut self) -> io::Result<()> {
-        self.compressor.flush()?;
-        self.compressor.write_blocks_to(&mut self.inner)?;
-        self.inner.write_all(&fgumi_bgzf::BGZF_EOF)?;
-        self.inner.flush()
-    }
-}
-
-impl<W: Write> Write for BgzfFastqWriter<W> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.compressor.write_all(buf)?;
-        // Drain any blocks the compressor completed so memory stays bounded.
-        self.compressor.write_blocks_to(&mut self.inner)?;
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.compressor.write_blocks_to(&mut self.inner)?;
-        self.inner.flush()
-    }
-}
+/// FASTQ blocks are small and the chain is a short linear
+/// source → encode → write pipeline, so the sort/consensus-sized default
+/// (768 MiB/thread) is wildly oversized; a modest fixed total keeps RSS flat as
+/// `--threads` scales while staying well above the pipeline's steady-state
+/// working set. See [`Fastq::resolve_queue_memory`].
+const FASTQ_DEFAULT_QUEUE_MEMORY_MB: u64 = 256;
 
 /// How to append a record's UMI to its read name.
 ///
@@ -637,17 +646,19 @@ pub(crate) fn classify_segment(flags: u16) -> Segment {
     }
 }
 
-/// Returns `true` if `path` should be written compressed (ends in
-/// `.gz`/`.bgz`/`.bgzf`).
+/// Returns `true` if `path` names a gzip-family output that must be written as
+/// BGZF — extension `gz`/`bgz`/`bgzf`, matched case-insensitively.
 ///
-/// KNOWN DIVERGENCE — reconcile in the fastq WIRING PR: this is case-SENSITIVE
-/// and also matches `.bgzf`, whereas the live standalone equivalent
-/// [`is_gzip_output_path`] is case-INSENSITIVE and matches only `gz`/`bgz`. The
-/// two decide the same thing ("is this output gzip-compressed?") and should be a
-/// single shared function once the fastq stage is wired onto the chain; they
-/// cannot diverge in observable behavior today because this path is dormant.
+/// The single gzip-detection function for `fgumi fastq`: it decides both the
+/// interleaved `-o` sink and each paired `-1`/`-2`/`-0` sink (through the chain
+/// builder's `wire_fastq_output`). Case-insensitive so `OUT.FQ.GZ` is still
+/// compressed rather than written as plain text under a `.GZ` name.
 pub(crate) fn path_is_gzip(path: &Path) -> bool {
-    matches!(path.extension().and_then(|e| e.to_str()), Some("gz" | "bgz" | "bgzf"))
+    path.extension().and_then(|e| e.to_str()).is_some_and(|e| {
+        e.eq_ignore_ascii_case("gz")
+            || e.eq_ignore_ascii_case("bgz")
+            || e.eq_ignore_ascii_case("bgzf")
+    })
 }
 
 // ==== ported from feat-runall for the chain builder (R2) ====
@@ -694,18 +705,6 @@ mod tests {
     }
 
     #[rstest]
-    #[case::gz_lower("out.fq.gz", true)]
-    #[case::gz_upper("OUT.FQ.GZ", true)]
-    #[case::bgz("out.fq.bgz", true)]
-    #[case::plain_fq("out.fq", false)]
-    #[case::plain_fastq("out.fastq", false)]
-    #[case::no_extension("out", false)]
-    #[case::gz_in_stem("out.gz.fq", false)]
-    fn test_is_gzip_output_path(#[case] path: &str, #[case] expected: bool) {
-        assert_eq!(is_gzip_output_path(std::path::Path::new(path)), expected);
-    }
-
-    #[rstest]
     // Default delimiters reproduce `samtools fastq -U`: name:UMI, duplex `-` -> `+`.
     #[case::simplex_umi(Some(("RX", &b"ACGT"[..])), ":", "+", "read1:ACGT")]
     #[case::duplex_umi(Some(("RX", &b"ACGT-TTTT"[..])), ":", "+", "read1:ACGT+TTTT")]
@@ -741,39 +740,6 @@ mod tests {
     #[test]
     fn test_umi_name_annotation_rejects_empty_tag_list() {
         assert!(UmiNameAnnotation::new(&[], ":", "+").is_err());
-    }
-
-    /// The BGZF writer must emit a real, decompressible BGZF stream terminated by
-    /// the EOF marker — a plain-text file under a `.gz` name is exactly the bug
-    /// this path exists to prevent.
-    #[test]
-    fn test_bgzf_fastq_writer_round_trips() {
-        let payload = b"@read1\nACGT\n+\nIIII\n@read2\nTTTT\n+\nJJJJ\n";
-        let mut out: Vec<u8> = Vec::new();
-        {
-            let mut writer = BgzfFastqWriter::new(&mut out, BGZF_OUTPUT_COMPRESSION_LEVEL);
-            writer.write_all(payload).expect("write");
-            writer.finish().expect("finish");
-        }
-
-        // Real BGZF/gzip magic, not plain text.
-        assert_eq!(&out[..2], &[0x1f, 0x8b], "output must carry gzip magic");
-        assert_ne!(&out[..1], b"@", "output must not be plain FASTQ text");
-
-        // Terminated by the BGZF EOF marker so readers do not see a truncated file.
-        assert!(out.ends_with(&fgumi_bgzf::BGZF_EOF), "BGZF stream must end with the EOF marker");
-
-        // And it decompresses back to exactly what went in.
-        let mut cursor = std::io::Cursor::new(&out);
-        let blocks = fgumi_bgzf::read_raw_blocks(&mut cursor, 64).expect("read blocks");
-        let mut decompressor = libdeflater::Decompressor::new();
-        let mut decoded = Vec::new();
-        for block in &blocks {
-            decoded.extend_from_slice(
-                &fgumi_bgzf::decompress_block(block, &mut decompressor).expect("decompress block"),
-            );
-        }
-        assert_eq!(decoded, payload);
     }
 
     /// Write reverse complement of sequence bytes to a buffer (test helper).
@@ -944,56 +910,12 @@ mod tests {
         assert_eq!(output, vec![73, 63, 33]);
     }
 
-    /// Resolve a case-table path spec against `dir`. `-` and `/dev/stdin` are
-    /// returned verbatim; anything else names a file inside `dir`.
-    fn resolve_path(dir: &std::path::Path, spec: &str) -> PathBuf {
-        if spec == "-" || spec == "/dev/stdin" { PathBuf::from(spec) } else { dir.join(spec) }
-    }
-
-    /// The clobber guard must reject an `--output` that names the `--input`
-    /// file, and must exempt stdin: `canonicalize("-")` fails with `NotFound`,
-    /// so canonicalising a stdin input would turn `--input -` into a confusing
-    /// IO error the moment `--output` happens to already exist.
-    #[rstest]
-    #[case::stdin_dash_with_existing_output("-", "out.fq", true, true)]
-    #[case::stdin_dev_stdin_with_existing_output("/dev/stdin", "out.fq", true, true)]
-    #[case::stdin_dash_with_new_output("-", "out.fq", false, true)]
-    #[case::distinct_paths_output_exists("in.bam", "out.fq", true, true)]
-    #[case::distinct_paths_output_missing("in.bam", "out.fq", false, true)]
-    #[case::output_is_input("in.bam", "in.bam", true, false)]
-    fn test_reject_output_clobbering_input(
-        #[case] input: &str,
-        #[case] output: &str,
-        #[case] output_exists: bool,
-        #[case] accepted: bool,
-    ) {
-        let dir = tempfile::TempDir::new().expect("create temp dir");
-        std::fs::write(dir.path().join("in.bam"), b"not a real bam").expect("write input");
-
-        let input_path = resolve_path(dir.path(), input);
-        let output_path = resolve_path(dir.path(), output);
-        if output_exists && !output_path.exists() {
-            std::fs::write(&output_path, b"prior run").expect("write output");
-        }
-
-        let result = reject_output_clobbering_input(&input_path, Some(&output_path));
-        assert_eq!(
-            result.is_ok(),
-            accepted,
-            "unexpected verdict for --input {input} --output {output}: {result:?}"
-        );
-        if !accepted {
-            let err = result.expect_err("case expects rejection").to_string();
-            assert!(err.contains("must differ"), "unexpected error message: {err}");
-        }
-    }
-
-    /// No `--output` means FASTQ goes to stdout, so there is nothing to clobber.
-    #[test]
-    fn test_reject_output_clobbering_input_allows_no_output() {
-        reject_output_clobbering_input(&PathBuf::from("in.bam"), None)
-            .expect("stdout output has nothing to clobber");
-    }
+    // Output-vs-output collision detection is provided by the reused
+    // `reject_output_collisions` helper (tested in `common.rs`), and the
+    // output-vs-input clobber guard (`reject_write_aliasing_input`) is exercised
+    // end-to-end by the integration tests (`test_fastq_output_same_as_input_rejected`,
+    // `_symlink_to_input_rejected`, `_paired_duplicate_output_rejected`), so no
+    // unit test duplicates them here.
 
     #[test]
     fn test_quality_encoding_edge_cases() {
@@ -1061,17 +983,18 @@ mod tests {
         assert_eq!(opts.passes_filters(flags), expected);
     }
 
-    /// `path_is_gzip` matches `gz`/`bgz`/`bgzf`, case-sensitively. See the fn's
-    /// KNOWN DIVERGENCE note vs the live `is_gzip_output_path` (the uppercase
-    /// case below pins that divergence, to be reconciled at fastq wiring).
+    /// `path_is_gzip` matches `gz`/`bgz`/`bgzf` as the final extension,
+    /// case-insensitively (so `OUT.FQ.GZ` is still compressed), and does not
+    /// match `.gz` mid-stem.
     #[rstest]
     #[case::gz("out.fq.gz", true)]
+    #[case::gz_upper("OUT.FQ.GZ", true)]
     #[case::bgz("out.fq.bgz", true)]
     #[case::bgzf("out.fq.bgzf", true)]
+    #[case::bgzf_mixed_case("out.fq.BgzF", true)]
     #[case::plain_fq("out.fq", false)]
     #[case::no_extension("out", false)]
     #[case::gz_in_stem("out.gz.fq", false)]
-    #[case::uppercase_not_matched("OUT.FQ.GZ", false)]
     fn path_is_gzip_matches_gz_bgz_bgzf(#[case] path: &str, #[case] expected: bool) {
         assert_eq!(path_is_gzip(std::path::Path::new(path)), expected);
     }

--- a/tests/integration/test_fastq_command.rs
+++ b/tests/integration/test_fastq_command.rs
@@ -5,12 +5,13 @@
 use clap::Parser;
 use fgumi_lib::commands::command::Command;
 use fgumi_lib::commands::fastq::Fastq;
+use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use std::fs;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
@@ -390,7 +391,10 @@ fn test_fastq_output_same_as_input_rejected() {
     .expect("failed to parse fastq args");
     let err =
         cmd.execute("fgumi fastq").expect_err("execute must reject identical --input/--output");
-    assert!(err.to_string().contains("must differ"), "unexpected error message: {err}");
+    assert!(
+        err.to_string().contains("is the same file as --input"),
+        "unexpected error message: {err}"
+    );
 
     // Most importantly: the input BAM must not have been truncated.
     let input_size_after = std::fs::metadata(&input_bam).expect("stat input").len();
@@ -424,7 +428,10 @@ fn test_fastq_output_symlink_to_input_rejected() {
     .expect("failed to parse fastq args");
     let err =
         cmd.execute("fgumi fastq").expect_err("execute must reject --output symlinked to --input");
-    assert!(err.to_string().contains("must differ"), "unexpected error message: {err}");
+    assert!(
+        err.to_string().contains("is the same file as --input"),
+        "unexpected error message: {err}"
+    );
 
     // The input BAM must not have been truncated through the symlink.
     let input_size_after = std::fs::metadata(&input_bam).expect("stat input").len();
@@ -542,4 +549,770 @@ fn test_fastq_gz_output_is_real_bgzf() {
     assert_eq!(expected.lines().count(), 8, "plain-path oracle: two records, four lines each");
     assert!(text.starts_with("@readA\n"), "decompressed FASTQ should start with readA");
     assert_eq!(text, expected, "BGZF output must decompress to the plain-path FASTQ byte-for-byte");
+}
+
+// ============================================================================
+// Paired split output (`-1`/`-2`/`-0`) — the BAM→FASTQ paired path on the chain.
+// ============================================================================
+
+/// Build a BAM from explicit records `(name, flags, seq, qual_ascii, rx)`,
+/// written in the given order. `rx` adds an `RX` tag (UMI) when `Some`.
+fn create_bam_with_records(path: &PathBuf, records: &[(&str, u16, &str, &str, Option<&str>)]) {
+    let header = create_minimal_header("chr1", 10000);
+    let mut writer = bam::io::Writer::new(fs::File::create(path).expect("create BAM"));
+    writer.write_header(&header).expect("write header");
+    for (name, flag_bits, seq, qual, rx) in records {
+        let q: Vec<u8> = qual.bytes().map(|b| b - 33).collect();
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes()).sequence(seq.as_bytes()).qualities(&q).flags(*flag_bits);
+        if let Some(rx) = rx {
+            b.add_string_tag(SamTag::RX, rx.as_bytes());
+        }
+        let rec = b.build();
+        writer.write_alignment_record(&header, &to_record_buf(&rec)).expect("write record");
+    }
+    writer.try_finish().expect("finish BAM");
+}
+
+/// Names in the order they appear (record names, suffixes included if any).
+fn names(records: &[(String, String, String)]) -> Vec<String> {
+    records.iter().map(|(n, _, _)| n.clone()).collect()
+}
+
+/// Paired split routes R1 → `--out1`, R2 → `--out2`, and single-end/ambiguous
+/// reads → `--out0`, mirroring `samtools fastq -1/-2/-0`, and omits the `/1` `/2`
+/// suffix so R1 and R2 read names match.
+#[test]
+fn test_fastq_paired_split_routes_and_omits_suffix() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    let (r1, r2, r0) =
+        (dir.path().join("r1.fq"), dir.path().join("r2.fq"), dir.path().join("r0.fq"));
+    create_bam_with_records(
+        &input,
+        &[
+            ("p1", flags::PAIRED | flags::FIRST_SEGMENT, "ACGTACGT", "IIIIIIII", None),
+            ("p1", flags::PAIRED | flags::LAST_SEGMENT, "TTTTGGGG", "JJJJJJJJ", None),
+            ("p2", flags::PAIRED | flags::FIRST_SEGMENT, "AAAACCCC", "KKKKKKKK", None),
+            ("p2", flags::PAIRED | flags::LAST_SEGMENT, "GGGGAAAA", "LLLLLLLL", None),
+            // Single-end (neither FIRST nor LAST) → "other".
+            ("solo", 0, "CCCCTTTT", "MMMMMMMM", None),
+            // Ambiguous (BOTH segment bits set) → "other" via a separate
+            // routing branch than the single-end case above.
+            (
+                "ambig",
+                flags::PAIRED | flags::FIRST_SEGMENT | flags::LAST_SEGMENT,
+                "GATTACAG",
+                "NNNNNNNN",
+                None,
+            ),
+        ],
+    );
+
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-1",
+        r1.to_str().unwrap(),
+        "-2",
+        r2.to_str().unwrap(),
+        "-0",
+        r0.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect("paired fastq");
+
+    let (rec1, rec2, rec0) =
+        (parse_fastq_records(&r1), parse_fastq_records(&r2), parse_fastq_records(&r0));
+    // Assert full record identity (name, sequence, quality), not just routing:
+    // a transcode that corrupted a quality string or a later record's sequence
+    // would pass a names-only or `[0]`-only check. Split mode omits the `/1` `/2`
+    // suffix, so R1 and R2 names match.
+    assert_eq!(
+        rec1,
+        vec![
+            ("p1".into(), "ACGTACGT".into(), "IIIIIIII".into()),
+            ("p2".into(), "AAAACCCC".into(), "KKKKKKKK".into()),
+        ],
+        "R1 file: FIRST_SEGMENT reads, in order, no /1 suffix"
+    );
+    assert_eq!(
+        rec2,
+        vec![
+            ("p1".into(), "TTTTGGGG".into(), "JJJJJJJJ".into()),
+            ("p2".into(), "GGGGAAAA".into(), "LLLLLLLL".into()),
+        ],
+        "R2 file: LAST_SEGMENT reads, in order, no /2 suffix"
+    );
+    assert_eq!(
+        rec0,
+        vec![
+            ("solo".into(), "CCCCTTTT".into(), "MMMMMMMM".into()),
+            ("ambig".into(), "GATTACAG".into(), "NNNNNNNN".into()),
+        ],
+        "out0 file: the single-end read and the both-segment-bits ambiguous read"
+    );
+}
+
+/// Degenerate record: an empty `SEQ` with zero-length quality still fans out to
+/// the correct branch and round-trips as the four-line record `@name\n\n+\n\n`.
+/// Here `extract_sequence_into` and `encode_quality_into` both produce empty
+/// buffers — a path no other paired-split case exercises (every other builder
+/// caller passes a non-empty seq/qual).
+#[test]
+fn test_fastq_paired_split_emits_degenerate_empty_record() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    let (r1, r2, r0) =
+        (dir.path().join("r1.fq"), dir.path().join("r2.fq"), dir.path().join("r0.fq"));
+    create_bam_with_records(
+        &input,
+        &[("empty", flags::PAIRED | flags::FIRST_SEGMENT, "", "", None)],
+    );
+
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-1",
+        r1.to_str().unwrap(),
+        "-2",
+        r2.to_str().unwrap(),
+        "-0",
+        r0.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect("degenerate paired fastq");
+
+    // FIRST_SEGMENT with empty seq/qual → R1 as `@empty\n\n+\n\n`.
+    assert_eq!(
+        fs::read_to_string(&r1).expect("read r1"),
+        "@empty\n\n+\n\n",
+        "R1 must carry the empty-seq record round-tripped as @empty\\n\\n+\\n\\n"
+    );
+    assert!(fs::read_to_string(&r2).expect("read r2").is_empty(), "R2 file must be byte-empty");
+    assert!(fs::read_to_string(&r0).expect("read r0").is_empty(), "out0 file must be byte-empty");
+}
+
+/// An input with only R1 records must still complete (not hang): the encode
+/// step emits an empty block on the R2 and "other" branches for every batch, so
+/// their reorder stages are never starved. The R2/other files come out empty.
+#[test]
+fn test_fastq_paired_split_only_r1_completes_with_empty_r2() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    let (r1, r2, r0) =
+        (dir.path().join("r1.fq"), dir.path().join("r2.fq"), dir.path().join("r0.fq"));
+    create_bam_with_records(
+        &input,
+        &[
+            ("a", flags::PAIRED | flags::FIRST_SEGMENT, "ACGT", "IIII", None),
+            ("b", flags::PAIRED | flags::FIRST_SEGMENT, "TTTT", "JJJJ", None),
+        ],
+    );
+
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "--threads",
+        "4",
+        "-1",
+        r1.to_str().unwrap(),
+        "-2",
+        r2.to_str().unwrap(),
+        "-0",
+        r0.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect("paired fastq with only R1s");
+
+    assert_eq!(names(&parse_fastq_records(&r1)), vec!["a", "b"], "all R1s present");
+    assert!(fs::read_to_string(&r2).expect("read r2").is_empty(), "R2 file is empty");
+    assert!(fs::read_to_string(&r0).expect("read r0").is_empty(), "out0 file is empty");
+}
+
+/// Symmetric to the R1-only case (sibling parity): an input with only R2
+/// (`LAST_SEGMENT`) records must still complete (not hang) — the encode step emits
+/// an empty block on the R1 and "other" branches for every batch, so their
+/// reorder stages are never starved. The R1/other files come out empty.
+#[test]
+fn test_fastq_paired_split_only_r2_completes_with_empty_r1() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    let (r1, r2, r0) =
+        (dir.path().join("r1.fq"), dir.path().join("r2.fq"), dir.path().join("r0.fq"));
+    create_bam_with_records(
+        &input,
+        &[
+            ("a", flags::PAIRED | flags::LAST_SEGMENT, "ACGT", "IIII", None),
+            ("b", flags::PAIRED | flags::LAST_SEGMENT, "TTTT", "JJJJ", None),
+        ],
+    );
+
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "--threads",
+        "4",
+        "-1",
+        r1.to_str().unwrap(),
+        "-2",
+        r2.to_str().unwrap(),
+        "-0",
+        r0.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect("paired fastq with only R2s");
+
+    assert_eq!(names(&parse_fastq_records(&r2)), vec!["a", "b"], "all R2s present");
+    assert!(fs::read_to_string(&r1).expect("read r1").is_empty(), "R1 file is empty");
+    assert!(fs::read_to_string(&r0).expect("read r0").is_empty(), "out0 file is empty");
+}
+
+/// A `.gz` paired output is real BGZF and decompresses byte-for-byte to the
+/// plain-path FASTQ.
+#[test]
+fn test_fastq_paired_split_gz_is_valid_bgzf() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    create_bam_with_records(
+        &input,
+        &[
+            ("p1", flags::PAIRED | flags::FIRST_SEGMENT, "ACGTACGT", "IIIIIIII", None),
+            ("p1", flags::PAIRED | flags::LAST_SEGMENT, "TTTTGGGG", "JJJJJJJJ", None),
+        ],
+    );
+    let plain_r1 = dir.path().join("plain_r1.fq");
+    let plain_r2 = dir.path().join("plain_r2.fq");
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-1",
+        plain_r1.to_str().unwrap(),
+        "-2",
+        plain_r2.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect("plain paired");
+
+    let gz_r1 = dir.path().join("r1.fq.gz");
+    let gz_r2 = dir.path().join("r2.fq.gz");
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-1",
+        gz_r1.to_str().unwrap(),
+        "-2",
+        gz_r2.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect("gz paired");
+
+    let bytes = fs::read(&gz_r1).expect("read gz r1");
+    assert_eq!(&bytes[..2], &[0x1f, 0x8b], "R1.gz must carry gzip magic");
+    assert!(bytes.ends_with(&fgumi_bgzf::BGZF_EOF), "R1.gz must end with the BGZF EOF marker");
+
+    // Sibling-sink parity: the R2 `.gz` sink must be BGZF too, else a per-sink
+    // compression bug (plain text under a `.gz` name) would slip past the
+    // R1-only checks above.
+    let r2_bytes = fs::read(&gz_r2).expect("read gz r2");
+    assert_eq!(&r2_bytes[..2], &[0x1f, 0x8b], "R2.gz must carry gzip magic");
+    assert!(r2_bytes.ends_with(&fgumi_bgzf::BGZF_EOF), "R2.gz must end with the BGZF EOF marker");
+
+    // Sibling-sink parity: format checks alone pass on an empty or wrong R2
+    // stream, so decompress R2 and pin it to the exact R2 record too.
+    let mut r2_cursor = std::io::Cursor::new(&r2_bytes);
+    let r2_blocks = fgumi_bgzf::read_raw_blocks(&mut r2_cursor, 64).expect("read r2 blocks");
+    let mut r2_decompressor = libdeflater::Decompressor::new();
+    let mut r2_decoded = Vec::new();
+    for block in &r2_blocks {
+        r2_decoded.extend_from_slice(
+            &fgumi_bgzf::decompress_block(block, &mut r2_decompressor).expect("decompress r2"),
+        );
+    }
+    let expected_r2 = fs::read(&plain_r2).expect("read plain r2");
+    assert!(!expected_r2.is_empty(), "plain-path R2 oracle must be non-empty");
+    assert_eq!(
+        expected_r2,
+        b"@p1\nTTTTGGGG\n+\nJJJJJJJJ\n".to_vec(),
+        "oracle: the single R2 record"
+    );
+    assert_eq!(r2_decoded, expected_r2, "R2.gz must decompress to the plain-path R2 byte-for-byte");
+
+    let mut cursor = std::io::Cursor::new(&bytes);
+    let blocks = fgumi_bgzf::read_raw_blocks(&mut cursor, 64).expect("read blocks");
+    let mut decompressor = libdeflater::Decompressor::new();
+    let mut decoded = Vec::new();
+    for block in &blocks {
+        decoded.extend_from_slice(
+            &fgumi_bgzf::decompress_block(block, &mut decompressor).expect("decompress"),
+        );
+    }
+    let expected = fs::read(&plain_r1).expect("read plain r1");
+    // Guard the oracle itself: if a shared defect made both paths emit nothing,
+    // an empty-vs-empty comparison would pass vacuously. Pin the actual R1 record.
+    assert!(!expected.is_empty(), "plain-path oracle must be non-empty");
+    assert_eq!(expected, b"@p1\nACGTACGT\n+\nIIIIIIII\n".to_vec(), "oracle: the single R1 record");
+    assert_eq!(decoded, expected, "R1.gz must decompress to the plain-path R1 byte-for-byte");
+}
+
+/// Assert `path` is a real BGZF stream (gzip magic + BGZF EOF marker) whose
+/// decompressed bytes equal `expected_plain` exactly. Shared by the mixed-case
+/// suffix test so each sink is pinned to content, not just format.
+fn assert_bgzf_decompresses_to(path: &Path, expected_plain: &[u8], label: &str) {
+    let bytes = fs::read(path).unwrap_or_else(|e| panic!("read {label}: {e}"));
+    assert_eq!(&bytes[..2], &[0x1f, 0x8b], "{label} must carry gzip magic");
+    assert!(bytes.ends_with(&fgumi_bgzf::BGZF_EOF), "{label} must end with the BGZF EOF marker");
+    let mut cursor = std::io::Cursor::new(&bytes);
+    let blocks = fgumi_bgzf::read_raw_blocks(&mut cursor, 64).expect("read blocks");
+    let mut decompressor = libdeflater::Decompressor::new();
+    let mut decoded = Vec::new();
+    for block in &blocks {
+        decoded.extend_from_slice(
+            &fgumi_bgzf::decompress_block(block, &mut decompressor).expect("decompress"),
+        );
+    }
+    assert!(!expected_plain.is_empty(), "{label} oracle must be non-empty");
+    assert_eq!(decoded, expected_plain, "{label} must decompress to the plain-path bytes");
+}
+
+/// Compressed-suffix detection is case-insensitive and spans the `bgzf`/`bgz`
+/// arms, not just lowercase `.gz`: an R1 `.bgzf` sink and an uppercase R2 `.BGZ`
+/// sink must both emit BGZF (not plain text under a compressed name). Mirrors
+/// `test_fastq_paired_split_gz_is_valid_bgzf` for the other suffix-table arms.
+#[test]
+fn test_fastq_paired_split_mixed_case_bgzf_suffixes() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    create_bam_with_records(
+        &input,
+        &[
+            ("p1", flags::PAIRED | flags::FIRST_SEGMENT, "ACGTACGT", "IIIIIIII", None),
+            ("p1", flags::PAIRED | flags::LAST_SEGMENT, "TTTTGGGG", "JJJJJJJJ", None),
+        ],
+    );
+
+    // Plain-path oracles for byte-for-byte content comparison.
+    let plain_r1 = dir.path().join("plain_r1.fq");
+    let plain_r2 = dir.path().join("plain_r2.fq");
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-1",
+        plain_r1.to_str().unwrap(),
+        "-2",
+        plain_r2.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect("plain paired");
+    let expected_r1 = fs::read(&plain_r1).expect("read plain r1");
+    let expected_r2 = fs::read(&plain_r2).expect("read plain r2");
+
+    // R1 exercises the lowercase `.bgzf` arm; R2 the uppercase `.BGZ` arm.
+    let bgzf_r1 = dir.path().join("r1.bgzf");
+    let bgz_r2 = dir.path().join("r2.BGZ");
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-1",
+        bgzf_r1.to_str().unwrap(),
+        "-2",
+        bgz_r2.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect("mixed-case bgzf paired");
+
+    assert_bgzf_decompresses_to(&bgzf_r1, &expected_r1, "R1.bgzf");
+    assert_bgzf_decompresses_to(&bgz_r2, &expected_r2, "R2.BGZ");
+}
+
+/// `--annotate-read-names` appends the UMI in paired-split mode too: a duplex
+/// UMI `AAAA-CCCC` becomes `name:AAAA+CCCC`, a simplex UMI `name:GGGG`.
+#[test]
+fn test_fastq_paired_split_annotates_umi() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    let (r1, r2) = (dir.path().join("r1.fq"), dir.path().join("r2.fq"));
+    create_bam_with_records(
+        &input,
+        &[
+            ("dup", flags::PAIRED | flags::FIRST_SEGMENT, "ACGT", "IIII", Some("AAAA-CCCC")),
+            ("dup", flags::PAIRED | flags::LAST_SEGMENT, "TTTT", "JJJJ", Some("AAAA-CCCC")),
+            ("smp", flags::PAIRED | flags::FIRST_SEGMENT, "GGGG", "KKKK", Some("GGGG")),
+            ("smp", flags::PAIRED | flags::LAST_SEGMENT, "CCCC", "LLLL", Some("GGGG")),
+        ],
+    );
+
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "--annotate-read-names",
+        "-1",
+        r1.to_str().unwrap(),
+        "-2",
+        r2.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect("annotated paired fastq");
+
+    // Duplex `-` rewritten to `+`; simplex passed through. R1 and R2 names match.
+    assert_eq!(names(&parse_fastq_records(&r1)), vec!["dup:AAAA+CCCC", "smp:GGGG"]);
+    assert_eq!(names(&parse_fastq_records(&r2)), vec!["dup:AAAA+CCCC", "smp:GGGG"]);
+}
+
+/// `--out1` without `--out2` is a clap error (they are required together).
+/// Assert the specific `MissingRequiredArgument` kind, not just `is_err()`: a
+/// parse failure for any unrelated reason (e.g. `-1`/`-2` renamed or removed —
+/// the "flag silently does nothing" failure this test exists to catch) would
+/// satisfy a bare `is_err()`.
+#[test]
+fn test_fastq_paired_requires_out2() {
+    let err = Fastq::try_parse_from(["fastq", "-i", "in.bam", "-1", "r1.fq"])
+        .expect_err("--out1 without --out2 must be rejected by clap");
+    assert_eq!(
+        err.kind(),
+        clap::error::ErrorKind::MissingRequiredArgument,
+        "--out1 without --out2 must fail as a missing-required-argument error, got: {err}"
+    );
+}
+
+/// `--out1`/`--out2` conflict with the interleaved `--output`. Assert the
+/// specific `ArgumentConflict` kind (see `test_fastq_paired_requires_out2` for
+/// why `is_err()` alone is too weak).
+#[test]
+fn test_fastq_paired_conflicts_with_output() {
+    let err = Fastq::try_parse_from([
+        "fastq", "-i", "in.bam", "-o", "out.fq", "-1", "r1.fq", "-2", "r2.fq",
+    ])
+    .expect_err("--output with --out1/--out2 must be rejected by clap");
+    assert_eq!(
+        err.kind(),
+        clap::error::ErrorKind::ArgumentConflict,
+        "--output with --out1/--out2 must fail as an argument-conflict error, got: {err}"
+    );
+}
+
+/// Paired `--out1 -` (R1 → stdout) with `--out2` a file and `--out0` omitted must
+/// be rejected: with no `--out0`, "other" reads default to stdout too, so R1 and
+/// the "other" stream would interleave on one stdout. The implicit stdout target
+/// must reach the collision guard even though it is not a user-specified path.
+#[test]
+fn test_fastq_paired_out1_stdout_collides_with_default_other_stdout() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    create_bam_with_records(
+        &input,
+        &[("p1", flags::PAIRED | flags::FIRST_SEGMENT, "ACGT", "IIII", None)],
+    );
+
+    let r2 = dir.path().join("r2.fq");
+    let err = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-1",
+        "-", // R1 → stdout
+        "-2",
+        r2.to_str().unwrap(),
+        // no --out0: "other" also defaults to stdout, colliding with -1 -
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect_err("--out1 - with a default-stdout --out0 must be rejected");
+    assert!(err.to_string().contains("stdout"), "got: {err}");
+    assert!(!r2.exists(), "collision rejection must occur before opening the R2 sink");
+}
+
+/// Two paired outputs naming the same file are rejected before any write —
+/// including when the two spellings differ only by a leading `./` and the file
+/// does not yet exist, the alias case a naive lexical or exists()-gated check
+/// misses (two sink threads would truncate one physical file).
+#[test]
+fn test_fastq_paired_duplicate_output_rejected() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    create_bam_with_records(
+        &input,
+        &[("p1", flags::PAIRED | flags::FIRST_SEGMENT, "ACGT", "IIII", None)],
+    );
+
+    // Identical spellings.
+    let same = dir.path().join("same.fq");
+    let err = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-1",
+        same.to_str().unwrap(),
+        "-2",
+        same.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect_err("identical -1/-2 paths must be rejected");
+    assert!(err.to_string().contains("write to"), "got: {err}");
+    assert!(!same.exists(), "rejection must happen before any sink is opened");
+
+    // Aliased spellings of a not-yet-existing file: `<dir>/out.fq` vs
+    // `<dir>/./out.fq`. Both are absolute (no cwd mutation, so this is safe under
+    // thread-parallel `cargo test`), neither exists yet, and both canonicalize to
+    // one path — the alias case an exists()-gated or lexical check would miss.
+    let plain = dir.path().join("out.fq");
+    let dotted = dir.path().join(".").join("out.fq");
+    let err = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-1",
+        plain.to_str().unwrap(),
+        "-2",
+        dotted.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect_err("`out.fq` and `./out.fq` are the same file and must be rejected");
+    assert!(err.to_string().contains("write to"), "got: {err}");
+    assert!(!plain.exists(), "rejection must happen before any sink is opened");
+
+    // `--out0` participates in the same collision guard, but the cases above
+    // only pair `-1` with `-2`. A guard built from the R1/R2 pair alone would
+    // let `-1 p -0 p` open one physical file from two sink threads. Pair
+    // `--out0` with `--out1` to cover the third slot.
+    let shared = dir.path().join("shared.fq");
+    let distinct = dir.path().join("distinct.fq");
+    let err = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-1",
+        shared.to_str().unwrap(),
+        "-2",
+        distinct.to_str().unwrap(),
+        "-0",
+        shared.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect_err("--out0 colliding with --out1 must be rejected");
+    assert!(err.to_string().contains("write to"), "got: {err}");
+    assert!(!shared.exists(), "rejection must happen before any sink is opened");
+}
+
+/// Run `fgumi fastq` in paired-split mode with the given `--out1`/`--out2`/`--out0`
+/// paths and assert that it is rejected because one of them is `--input`, before
+/// any sink is opened — the input BAM must be left byte-for-byte intact. Shared by
+/// the direct-path and symlink alias tests below.
+fn assert_paired_output_alias_rejected(input: &Path, out1: &Path, out2: &Path, out0: &Path) {
+    let input_size_before = std::fs::metadata(input).expect("stat input").len();
+    let err = Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-1",
+        out1.to_str().unwrap(),
+        "-2",
+        out2.to_str().unwrap(),
+        "-0",
+        out0.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect_err("a paired output aliasing --input must be rejected");
+    assert!(err.to_string().contains("is the same file as --input"), "got: {err}");
+    // The guard runs before any sink is opened, so the input BAM is untouched.
+    let input_size_after = std::fs::metadata(input).expect("stat input").len();
+    assert_eq!(
+        input_size_before, input_size_after,
+        "input BAM was truncated/clobbered by a paired output aliasing --input"
+    );
+}
+
+/// Each paired output (`--out1`, `--out2`, `--out0`) pointing directly at `--input`
+/// must be rejected before any write — the paired-path analogue of the interleaved
+/// `test_fastq_output_same_as_input_rejected`. All four flags route through the same
+/// `reject_write_aliasing_input` over the `(path, flag)` output slice, but only the
+/// single `--output` case was covered until now.
+#[test]
+fn test_fastq_paired_output_same_as_input_rejected() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    create_bam_with_records(
+        &input,
+        &[("p1", flags::PAIRED | flags::FIRST_SEGMENT, "ACGT", "IIII", None)],
+    );
+    let r1 = dir.path().join("r1.fq");
+    let r2 = dir.path().join("r2.fq");
+    let other = dir.path().join("other.fq");
+
+    // Exactly one output aliases --input in each case; the siblings are distinct
+    // valid paths so clap's `requires` chain is satisfied and the only collision
+    // under test is <aliased> == --input.
+    assert_paired_output_alias_rejected(&input, &input, &r2, &other); // --out1
+    assert_paired_output_alias_rejected(&input, &r1, &input, &other); // --out2
+    assert_paired_output_alias_rejected(&input, &r1, &r2, &input); // --out0
+}
+
+/// The same guard must also catch a paired output reached through a symlink that
+/// resolves to `--input` — a lexical `PathBuf` compare misses this, so the
+/// validator canonicalises both sides. Paired-path analogue of the interleaved
+/// `test_fastq_output_symlink_to_input_rejected`.
+#[cfg(unix)]
+#[test]
+fn test_fastq_paired_output_symlink_to_input_rejected() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    create_bam_with_records(
+        &input,
+        &[("p1", flags::PAIRED | flags::FIRST_SEGMENT, "ACGT", "IIII", None)],
+    );
+    let link = dir.path().join("alias.link");
+    std::os::unix::fs::symlink(&input, &link).expect("create symlink");
+    let r1 = dir.path().join("r1.fq");
+    let r2 = dir.path().join("r2.fq");
+    let other = dir.path().join("other.fq");
+
+    // The symlink resolves to --input, so it must be rejected in each output slot.
+    assert_paired_output_alias_rejected(&input, &link, &r2, &other); // --out1
+    assert_paired_output_alias_rejected(&input, &r1, &link, &other); // --out2
+    assert_paired_output_alias_rejected(&input, &r1, &r2, &link); // --out0
+}
+
+/// Paired split honors `-F`/`-f` flag filters the same way the interleaved path
+/// does (sibling-path parity): a read excluded by `--exclude-flags` never
+/// reaches any of `--out1`/`--out2`/`--out0`, and `--require-flags` keeps only
+/// matching reads.
+#[test]
+fn test_fastq_paired_split_applies_flag_filters() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    let (r1, r2, r0) =
+        (dir.path().join("r1.fq"), dir.path().join("r2.fq"), dir.path().join("r0.fq"));
+    // p1 is a normal pair; dup is a duplicate-flagged (0x400) pair that
+    // --exclude-flags must drop from every output.
+    create_bam_with_records(
+        &input,
+        &[
+            ("p1", flags::PAIRED | flags::FIRST_SEGMENT, "ACGTACGT", "IIIIIIII", None),
+            ("p1", flags::PAIRED | flags::LAST_SEGMENT, "TTTTGGGG", "JJJJJJJJ", None),
+            ("dup", flags::PAIRED | flags::FIRST_SEGMENT | flags::DUPLICATE, "AAAA", "IIII", None),
+            ("dup", flags::PAIRED | flags::LAST_SEGMENT | flags::DUPLICATE, "CCCC", "JJJJ", None),
+        ],
+    );
+
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-F",
+        "0x400", // exclude duplicates
+        "-1",
+        r1.to_str().unwrap(),
+        "-2",
+        r2.to_str().unwrap(),
+        "-0",
+        r0.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect("filtered paired fastq");
+
+    // Only p1 survives; the duplicate-flagged pair is dropped from all outputs.
+    assert_eq!(names(&parse_fastq_records(&r1)), vec!["p1"], "R1: duplicate excluded");
+    assert_eq!(names(&parse_fastq_records(&r2)), vec!["p1"], "R2: duplicate excluded");
+    assert!(fs::read_to_string(&r0).expect("read r0").is_empty(), "out0: nothing routed here");
+
+    // Require-flags is the sibling direction: `-f`/`--require-flags` keeps only
+    // reads whose flags include every required bit, so requiring 0x400 keeps the
+    // duplicate-flagged pair and drops the normal one — the inverse of the
+    // exclude case above.
+    let (rf1, rf2, rf0) =
+        (dir.path().join("rf1.fq"), dir.path().join("rf2.fq"), dir.path().join("rf0.fq"));
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-f",
+        "0x400", // require duplicates
+        "-1",
+        rf1.to_str().unwrap(),
+        "-2",
+        rf2.to_str().unwrap(),
+        "-0",
+        rf0.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect("require-flags paired fastq");
+
+    // Only the duplicate-flagged pair matches the required flag.
+    assert_eq!(names(&parse_fastq_records(&rf1)), vec!["dup"], "R1: only required kept");
+    assert_eq!(names(&parse_fastq_records(&rf2)), vec!["dup"], "R2: only required kept");
+    assert!(fs::read_to_string(&rf0).expect("read rf0").is_empty(), "out0: nothing routed here");
+}
+
+/// `-K`/`--bwa-chunk-size` is deprecated and ignored: a run passing it still
+/// succeeds and produces the same output as one that omits it (the value no
+/// longer affects batching, which the pipeline now manages).
+#[test]
+fn test_fastq_bwa_chunk_size_deprecated_but_accepted() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = dir.path().join("in.bam");
+    create_paired_bam(
+        &input,
+        vec![("read1", "ACGTACGT", "IIIIIIII", "TGCATGCA", "IIIIIIII", false)],
+    );
+
+    let with_k = dir.path().join("with_k.fq");
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-K",
+        "12345", // arbitrary non-default value; must be accepted and ignored
+        "-o",
+        with_k.to_str().unwrap(),
+    ])
+    .expect("`-K <value>` must still parse")
+    .execute("fgumi fastq")
+    .expect("`-K` is deprecated but must not fail the run");
+
+    let without_k = dir.path().join("without_k.fq");
+    Fastq::try_parse_from([
+        "fastq",
+        "-i",
+        input.to_str().unwrap(),
+        "-o",
+        without_k.to_str().unwrap(),
+    ])
+    .expect("parse")
+    .execute("fgumi fastq")
+    .expect("baseline run");
+
+    // The ignored knob must not change the output. Guard the oracle: if a shared
+    // defect made both runs emit nothing, a bare `read(&with_k) == read(&without_k)`
+    // would pass vacuously, so assert the output is non-empty first.
+    let with_k_bytes = fs::read(&with_k).expect("read with_k");
+    assert!(!with_k_bytes.is_empty(), "oracle must be non-empty, not both-empty");
+    assert_eq!(
+        with_k_bytes,
+        fs::read(&without_k).expect("read without_k"),
+        "--bwa-chunk-size must not affect output (it is ignored)"
+    );
 }


### PR DESCRIPTION
Ports the `fgumi fastq` changes from #482 onto current `main`.

`fgumi fastq` was the last command still running on a standalone reader loop; every other command already runs on the declarative typed-step chain, and the paired-split chain wiring #482 introduced (`SinkSpec::FastqPaired`, the 3-way encode step, `Process3`, `WriteRawFile`) has been sitting on `main` with no production constructor. This wires it up.

## What's here

`execute()` now builds a `ChainSpec` (`SourceSpec::Bam` → `Stage::Fastq` → `SinkSpec::Fastq`/`FastqPaired`) and runs it through `build_for(spec).run()` for both output shapes, so the per-file BGZF writers share one work-stealing pool. The legacy `run_with_writer`/`write_to_stdout` loop and the ad-hoc `BgzfFastqWriter` are retired.

- **Paired split output** (`--out1`/`-1`, `--out2`/`-2`, optional `--out0`/`-0`) mirrors `samtools fastq -1/-2/-0`: R1 → `--out1`, R2 → `--out2`, single-end/ambiguous → `--out0` (or stdout when omitted), with the `/1` `/2` suffix omitted (the file identifies the mate). clap enforces `--out1`/`--out2` together and mutually exclusive with `--output`.
- **Output-collision / input-clobber guards** reuse the existing `reject_output_collisions` helper (shared with clip/codec — handles stdout multiplexing, `/dev/null`, and `./`/symlink aliases) plus a `reject_write_aliasing_input` check mirroring `retag`/`copy_umi`.
- **`path_is_gzip`** is now the single, case-insensitive `gz`/`bgz`/`bgzf` detector, resolving the dormant-vs-live divergence noted in-tree.
- **`--bwa-chunk-size`** is deprecated and ignored (the pipeline manages batching); a non-default value logs a notice. Queue memory defaults to a lean fixed 256 MiB total (derived from `QueueMemoryOptions::default()`) so RSS stays flat as `--threads` scales.

## Behavior changes worth calling out

- The old interleaved R1/R2 net-count desync **warning** (FASTQ3-02) is gone, as it was in #482 — the chain interleaved encode does not track that count. Prefer paired split (`--out1`/`--out2`) when mates may be missing.
- A `.bgzf` interleaved output path (`-o out.bgzf`) is now written as BGZF rather than plain text under a `.bgzf` name (the old detector matched only `gz`/`bgz`). This is a fix.

## Validation

- Byte-identical to `samtools fastq` for interleaved, `-1/-2/-0`, reverse-complement R2, and `.gz` (decompressed); empty-input completes without hanging; all error guards exercised.
- `cargo ci-fmt` / `cargo ci-lint` clean; full suite green.
- Self-reviewed with a CodeRabbit-style pass and a multi-agent deep review; findings addressed (output-alias dedup gap, paired-mode suffix log line, queue-memory default derivation, added paired filter/`-K`/alias coverage and a stronger `.gz` oracle).

Relates to #480 / #482.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: `fgumi fastq` output changes for interleaved and paired-split routing, pinned by typed-step routing and integration tests; grouping, consensus, sort order, corrected UMIs, and metrics are none; `unsafe` changes are none, and the `CLAUDE.md` allowlist is unchanged; queue memory uses a fixed 256 MiB default with shared work-stealing backpressure. Fix: use the typed-step chain with validation guards and integration tests.

- Replaces the standalone FASTQ loop with a declarative typed-step chain.
- Adds interleaved and paired-split output with `--out1`, `--out2`, and optional `--out0`.
- Adds output-collision, input-clobbering, and paired-output validation.
- Handles `gz`, `bgz`, and `bgzf` suffixes case-insensitively.
- Writes compressed output as BGZF.
- Connects UMI annotation to FASTQ read names.
- Deprecates and ignores non-default `--bwa-chunk-size`.
- Removes the obsolete mate-count desynchronization warning.
- Adds documentation and integration coverage for routing, validation, compression, UMI annotation, filtering, and deprecated-option behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->