### PR TITLE
feat(pipeline): add hidden --pool-scheduler override for A/B benchmarking

### DIFF
--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -1051,6 +1051,29 @@ pub struct AllowUnmappedOptions {
     pub enabled: bool,
 }
 
+/// Override for the chain-builder pool dispatch scheduler.
+///
+/// The chain engine normally chooses the pool's step-walk direction per chain:
+/// drain-bound shapes (terminal `group`/`dedup`, and a BAM `sort` source) run
+/// downstream-first (`DrainFirstScheduler`), everything else runs upstream-first
+/// (`ChainOrderScheduler`). This hidden override forces one choice regardless, so
+/// the tuning can be A/B-benchmarked on any command from a single binary without
+/// a rebuild. `Auto` is the default and changes nothing.
+///
+/// The value names match the scheduler names surfaced in `--pipeline-stats`
+/// (`drain-first` / `chain-order`), so a benchmark can correlate the flag with
+/// what actually ran.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum PoolScheduler {
+    /// Use the automatic per-chain decision (the default; no override).
+    #[default]
+    Auto,
+    /// Force downstream-first dispatch (`DrainFirstScheduler`) on every chain.
+    DrainFirst,
+    /// Force upstream-first dispatch (`ChainOrderScheduler`) on every chain.
+    ChainOrder,
+}
+
 /// Options for pipeline scheduler configuration.
 ///
 /// Controls which scheduling strategy is used for thread work assignment
@@ -1067,6 +1090,17 @@ pub struct SchedulerOptions {
     ///   Thread 0 prioritizes reading, Thread N-1 prioritizes writing.
     #[arg(long = "scheduler", value_enum, default_value_t = SchedulerStrategy::default(), hide = true)]
     pub scheduler: SchedulerStrategy,
+
+    /// Override for the chain-builder pool dispatch scheduler (hidden; A/B knob).
+    ///
+    /// `auto` (default) uses the automatic per-chain decision; `drain-first` and
+    /// `chain-order` force one dispatch direction on every chain, for
+    /// benchmarking the tuning without a rebuild. When it overrides the automatic
+    /// choice, `ChainBuilder::build` logs a warning so a benchmark records that a
+    /// non-default scheduler ran. Unlike the legacy `--scheduler` strategy, this
+    /// IS consumed by the typed-step chain engine.
+    #[arg(long = "pool-scheduler", value_enum, default_value_t = PoolScheduler::Auto, hide = true)]
+    pub pool_scheduler: PoolScheduler,
 
     /// Print detailed pipeline statistics at completion.
     ///
@@ -1114,6 +1148,13 @@ impl SchedulerOptions {
     #[must_use]
     pub fn strategy(&self) -> SchedulerStrategy {
         self.scheduler
+    }
+
+    /// Returns the pool-dispatch scheduler override (`Auto` unless the hidden
+    /// `--pool-scheduler` flag was set). Consumed by `ChainBuilder::build`.
+    #[must_use]
+    pub fn pool_scheduler(&self) -> PoolScheduler {
+        self.pool_scheduler
     }
 
     /// Returns true if pipeline stats should be collected and printed.
@@ -2750,6 +2791,7 @@ mod tests {
     fn test_scheduler_options_strategy() {
         let opts = SchedulerOptions {
             scheduler: SchedulerStrategy::FixedPriority,
+            pool_scheduler: PoolScheduler::Auto,
             pipeline_stats: false,
             pipeline_trace: InstrumentationLevel::Off,
             pipeline_trace_out: None,
@@ -2766,6 +2808,7 @@ mod tests {
             pipeline_stats: true,
             pipeline_trace: InstrumentationLevel::Off,
             pipeline_trace_out: None,
+            pool_scheduler: PoolScheduler::Auto,
             deadlock_timeout: 10,
             deadlock_recover: false,
         };
@@ -2780,6 +2823,7 @@ mod tests {
             pipeline_trace: InstrumentationLevel::Off,
             pipeline_trace_out: None,
             deadlock_timeout: 30,
+            pool_scheduler: PoolScheduler::Auto,
             deadlock_recover: false,
         };
         assert_eq!(opts.deadlock_timeout_secs(), 30);
@@ -2794,6 +2838,7 @@ mod tests {
             pipeline_trace_out: None,
             deadlock_timeout: 10,
             deadlock_recover: true,
+            pool_scheduler: PoolScheduler::Auto,
         };
         assert!(opts.deadlock_recover_enabled());
     }

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -1761,8 +1761,16 @@ impl<'a> ChainBuilder<'a> {
         // parallel inflate), or a terminal group/dedup/clip chain (set in
         // add_group/add_dedup/add_clip, so the serial grouping spine overlaps the
         // parallel decompress front). Production-bound chains keep the default
-        // upstream-first scheduler.
-        if self.use_drain_first_scheduler {
+        // upstream-first scheduler. The hidden `--pool-scheduler` override can
+        // force either direction for A/B benchmarking; warn when it does so a
+        // benchmark records that a non-default scheduler ran.
+        let pool_override = self.spec.scheduler.pool_scheduler();
+        if let Some(warning) =
+            pool_scheduler_override_warning(pool_override, self.use_drain_first_scheduler)
+        {
+            log::warn!("{warning}");
+        }
+        if resolve_use_drain_first(pool_override, self.use_drain_first_scheduler) {
             config = config.with_scheduler(std::sync::Arc::new(
                 crate::pipeline::core::runtime::DrainFirstScheduler,
             ));
@@ -5069,6 +5077,51 @@ fn grouping_stage_wants_drain_first(stage: Stage, position: StagePosition) -> bo
     )
 }
 
+/// Resolve the effective drain-first choice from the hidden `--pool-scheduler`
+/// override and the automatic per-chain decision.
+///
+/// `Auto` defers to `auto_wants_drain_first` (the value the `add_*` methods
+/// accumulated); the explicit variants force the choice regardless, so the
+/// drain-first vs upstream-first tuning can be A/B-benchmarked on any command
+/// from a single binary. Pure (no logging) so it can be unit tested; `build`
+/// emits the override warning at the call site.
+fn resolve_use_drain_first(
+    pool_override: crate::commands::common::PoolScheduler,
+    auto_wants_drain_first: bool,
+) -> bool {
+    use crate::commands::common::PoolScheduler;
+    match pool_override {
+        PoolScheduler::Auto => auto_wants_drain_first,
+        PoolScheduler::DrainFirst => true,
+        PoolScheduler::ChainOrder => false,
+    }
+}
+
+/// The warning `build` should log when the hidden `--pool-scheduler` override
+/// forces a dispatch direction *opposite* the automatic per-chain choice, or
+/// `None` when the override defers to (or already agrees with) that choice.
+///
+/// Pure (no logging) so the message selection is unit-testable; `build` logs the
+/// returned message at the call site, mirroring `resolve_use_drain_first`. The
+/// warning exists so a benchmark's log records that a non-default scheduler ran.
+fn pool_scheduler_override_warning(
+    pool_override: crate::commands::common::PoolScheduler,
+    auto_wants_drain_first: bool,
+) -> Option<&'static str> {
+    use crate::commands::common::PoolScheduler;
+    match pool_override {
+        PoolScheduler::DrainFirst if !auto_wants_drain_first => Some(
+            "--pool-scheduler drain-first: forcing downstream-first dispatch \
+             (diagnostic override of the automatic per-chain choice)",
+        ),
+        PoolScheduler::ChainOrder if auto_wants_drain_first => Some(
+            "--pool-scheduler chain-order: forcing upstream-first dispatch \
+             (diagnostic override of the automatic per-chain choice)",
+        ),
+        _ => None,
+    }
+}
+
 /// Uniform "reference dictionary not found" error, shared by the zipper source
 /// open (`open_source`) and `add_align`, so both dict-resolution sites report
 /// the same actionable message (which paths were tried + the `samtools dict`
@@ -5089,6 +5142,7 @@ fn dict_not_found_error(reference: &std::path::Path) -> anyhow::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::common::PoolScheduler;
 
     /// A `ChainSpec` with the given stages and every other field at its
     /// simplest valid default. Mirrors `validate::tests::empty_spec` — kept as
@@ -5267,6 +5321,69 @@ mod tests {
             grouping_stage_wants_drain_first(stage, position),
             expected,
             "{stage:?} at {position:?}: drain-first opt-in mismatch"
+        );
+    }
+
+    /// Pin the hidden `--pool-scheduler` override resolution: `Auto` defers to
+    /// the automatic per-chain decision, while `DrainFirst`/`ChainOrder` force
+    /// their direction regardless of it. This is the A/B knob's whole contract,
+    /// and it is invisible to output-comparing tests (the scheduler never changes
+    /// records), so it is pinned directly against `resolve_use_drain_first`.
+    #[rstest::rstest]
+    #[case::auto_defers_to_true(PoolScheduler::Auto, true, true)]
+    #[case::auto_defers_to_false(PoolScheduler::Auto, false, false)]
+    #[case::force_drain_first_over_auto_off(PoolScheduler::DrainFirst, false, true)]
+    #[case::force_drain_first_over_auto_on(PoolScheduler::DrainFirst, true, true)]
+    #[case::force_chain_order_over_auto_on(PoolScheduler::ChainOrder, true, false)]
+    #[case::force_chain_order_over_auto_off(PoolScheduler::ChainOrder, false, false)]
+    fn resolve_use_drain_first_matrix(
+        #[case] pool_override: PoolScheduler,
+        #[case] auto_wants_drain_first: bool,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(
+            resolve_use_drain_first(pool_override, auto_wants_drain_first),
+            expected,
+            "{pool_override:?} over auto={auto_wants_drain_first}: resolution mismatch"
+        );
+    }
+
+    /// Pin the override warning `build` logs: a warning is emitted only when the
+    /// `--pool-scheduler` override forces a direction *opposite* the automatic
+    /// per-chain choice (drain-first over an upstream-first auto, or chain-order
+    /// over a drain-first auto). `Auto`, and an override that already agrees with
+    /// the automatic choice, warn nothing — so a benchmark log flags only the
+    /// runs where the knob actually changed the scheduler.
+    #[rstest::rstest]
+    #[case::auto_never_warns_off(PoolScheduler::Auto, false, None)]
+    #[case::auto_never_warns_on(PoolScheduler::Auto, true, None)]
+    #[case::drain_first_forces_over_auto_off(
+        PoolScheduler::DrainFirst,
+        false,
+        Some(
+            "--pool-scheduler drain-first: forcing downstream-first dispatch \
+              (diagnostic override of the automatic per-chain choice)"
+        )
+    )]
+    #[case::drain_first_agrees_with_auto_on(PoolScheduler::DrainFirst, true, None)]
+    #[case::chain_order_forces_over_auto_on(
+        PoolScheduler::ChainOrder,
+        true,
+        Some(
+            "--pool-scheduler chain-order: forcing upstream-first dispatch \
+              (diagnostic override of the automatic per-chain choice)"
+        )
+    )]
+    #[case::chain_order_agrees_with_auto_off(PoolScheduler::ChainOrder, false, None)]
+    fn pool_scheduler_override_warning_matrix(
+        #[case] pool_override: PoolScheduler,
+        #[case] auto_wants_drain_first: bool,
+        #[case] expected: Option<&str>,
+    ) {
+        assert_eq!(
+            pool_scheduler_override_warning(pool_override, auto_wants_drain_first),
+            expected,
+            "{pool_override:?} over auto={auto_wants_drain_first}: warning mismatch"
         );
     }
 


### PR DESCRIPTION
> #941 has merged, so this PR is rebased onto `main` and now contains a single commit: the new `--pool-scheduler` flag. (The earlier `perf(group,dedup,clip)` commit was a duplicate of what shipped in #941 and has been dropped.)

## Why

The chain engine picks the pool dispatch scheduler per chain — drain-first for terminal `group`/`dedup`/`clip` and a BAM `sort` source, upstream-first otherwise. Validating that choice, or measuring whether an as-yet-unenabled command would benefit, meant building two binaries. This adds a runtime knob to A/B the tuning on any command from one build.

## What

A hidden `--pool-scheduler <auto|drain-first|chain-order>` on the shared `SchedulerOptions` (flattened into every chain command, cloned into `ChainSpec`), so it reaches `ChainBuilder::build` with no per-command wiring:

- `auto` (default) — automatic per-chain decision; **no behavior change**.
- `drain-first` / `chain-order` — force one direction on every chain.

`build()` resolves it through a pure, unit-tested `resolve_use_drain_first(override, auto)` and emits a `warn!` when it overrides the automatic choice, so a benchmark records that a non-default scheduler ran. Value names match the `--pipeline-stats` scheduler names.

- **Hidden** (`hide = true`); distinct from the legacy, chain-unwired `--scheduler` strategy flag.
- **Coverage:** rides on `SchedulerOptions`, so it reaches extract, copy-umi, correct, align, group, simplex, duplex, codec, clip, filter, dedup, retag. It does **not** reach `sort`, `zipper`, `fastq`, `downsample` (they don't flatten `SchedulerOptions`) — notably `sort` is drain-first but not overridable via this flag. Worth a follow-up if we want full coverage.

## What it already found (empirical sweep, this flag, 60M-class inputs, t8, tight reps)

| command | Δ drain-first vs chain-order | note |
| --- | --- | --- |
| group / dedup / clip | −6 … −14% | shipped in #941 (output verified) |
| retag | **−4.9%** | helps — candidate |
| simplex / codec | **−3.0 … −3.5%** | helps (modest) — candidate |
| **extract** | **+459% (5.6× slower)** | FASTQ source starved by downstream-first — must stay chain-order |

Takeaway: drain-first is **not** universally safe and **not** reliably predictable from chain shape — most commands modestly benefit, but a source-bound command (extract) is catastrophically hurt. Per-command measurement is mandatory, which is what this flag is for. Only the confirmed strong, output-identical winners (group/dedup/clip) are enabled by default (shipped in #941).

## Testing

- `resolve_use_drain_first_matrix` — 6-case `rstest` over the override × auto matrix.
- `pool_scheduler_override_warning_matrix` — 6-case `rstest` over the warning message selection.
- End-to-end: hidden from `--help`; rejects bogus values; `group --pool-scheduler chain-order` logs "forcing upstream-first"; `retag --pool-scheduler drain-first` logs "forcing downstream-first"; plain runs log nothing.
- `cargo ci-fmt`/`ci-lint` clean; existing `SchedulerOptions` unit tests updated for the new field.

Usage: `<cmd> --pool-scheduler drain-first` vs `--pool-scheduler chain-order` (same input/build) is a clean A/B; add `--pipeline-stats` to correlate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: output changes none; unsafe changes none and no `CLAUDE.md` allowlist update applies; memory bounds, queue capacity, and thread/backpressure policy changes none.

- Adds hidden `--pool-scheduler <auto|drain-first|chain-order>` support.
- Propagates the override through `ChainSpec` to `ChainBuilder::build`.
- Preserves automatic scheduling by default.
- Logs a warning when a forced mode changes the automatic choice.
- Adds resolution, validation, help visibility, warning, and default-behavior tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->