### PR TITLE
fix(sort): restore the === Sort Phase Timing === per-phase diagnostic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,18 +416,48 @@ throughout" from "parallel phase followed by a serial tail". Note that `io_in`
 collapses to near zero once the input is in page cache — a low `io_in` means the
 run was CPU-bound *on that invocation*, not that the tool does little I/O.
 
-**2. In-tree phase timers — the primary attribution tool.** `fgumi sort` already
-carries `SortPhaseTimer` (`crates/fgumi-sort/src/external.rs`): per-phase `f64`
-accumulators, a `time()` helper wrapping each span, and a `log_summary()` that
-emits `=== Sort Phase Timing ===` at `info!` (read+decompress / in-memory sort /
-spill write / consolidation / k-way merge / write output, each with a percentage).
-Prior campaigns got full baseline phase attribution from this with **zero new
-code** — just `RUST_LOG=info`.
+**2. In-tree phase timers — the primary attribution tool.** `fgumi sort` reports
+a `=== Sort Phase Timing ===` per-phase cumulative busy-time breakdown
+(read+decompress / in-memory sort / spill write / consolidation / k-way merge /
+write output, each with a percentage). Percentages are cumulative per-step
+busy-time shares — steps may run concurrently — not wall-clock proportions.
+Standalone `fgumi sort` runs on the declarative pipeline chain, where each phase
+is a discrete step and the runtime already records every step's cumulative busy
+time; the breakdown is re-derived from that end-of-run stats snapshot
+(`SortPhaseTimingFinalizeHook`,
+`src/lib/pipeline/chains/commands/sort.rs`). Enable it with **`RUST_LOG=info` plus
+`FGUMI_PIPELINE_STATS=1`** — standalone `fgumi sort` does not accept
+`--pipeline-stats` (that flag exists only on commands that flatten it, e.g. the
+runall front-end, which honor it too). The phase-timing *report* is opt-in via
+`FGUMI_PIPELINE_STATS=1`; it does not itself add a collector, because the
+standalone sort path already attaches a `PipelineStats` collector for its
+default deadlock monitor (`deadlock_timeout: 10`). Other features may collect
+statistics regardless, so the report is what is gated, not stats collection:
 
-Mirror that pattern when optimizing any other command: the phases you would name
-in a design doc are exactly the phases worth timing, it works identically on
-macOS and Linux, and it cannot be defeated by inlining or missing symbols the way
-a sampling profiler can. Prefer adding a phase timer over fighting a profiler.
+```sh
+RUST_LOG=info FGUMI_PIPELINE_STATS=1 fgumi sort -i in.bam -o out.bam --order coordinate
+# ... logs the `=== Sort Phase Timing ===` block plus the full `Pipeline
+#     end-of-run stats:` per-step table it is rolled up from.
+```
+
+The percentages are shares of cumulative per-step *busy* time (the steps run
+concurrently on the pool), not of wall clock — read them for "which phase
+dominates the sort work", and pair with `tricorder`'s `mean_load` / `--trace`
+above for the wall-clock / core-utilisation picture. The block is emitted only
+for a standalone `fgumi sort` (a sole-sort chain, where the chain's phases are
+exactly the sort's); a fused pipeline such as `runall` does not print it, and
+SAM-input parse time (a source adapter, not a sort step) is not counted. The
+library-level
+`fgumi-sort` engine still carries its own always-on `SortPhaseTimer`
+(`crates/fgumi-sort/src/external.rs`, per-phase `f64` accumulators + a
+`time()`-wrapped `log_summary()`) for callers that drive `RawExternalSorter`
+directly rather than through the chain.
+
+Mirror the phase-timing pattern when optimizing any other command: the phases
+you would name in a design doc are exactly the phases worth timing, it works
+identically on macOS and Linux, and it cannot be defeated by inlining or missing
+symbols the way a sampling profiler can. Prefer a phase breakdown over fighting a
+profiler.
 
 **3. `perf record` / `perf stat` on Linux (EC2)** when per-function or
 per-instruction attribution is genuinely required. This is the reliable path for

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -1757,6 +1757,31 @@ impl<'a> ChainBuilder<'a> {
         let user_wants_stats = self.spec.scheduler.collect_stats()
             || super::build_helpers::env_flag_enabled("FGUMI_PIPELINE_STATS");
         if user_wants_stats && let Some(s) = pipeline_stats {
+            // Re-derive the `=== Sort Phase Timing ===` per-phase breakdown from
+            // the same stats snapshot. This restores the diagnostic the retired
+            // owned engine printed (see `commands::sort::SortPhaseTimingFinalizeHook`);
+            // it reads the already-collected per-step timings, so it adds nothing
+            // to the default (stats-off) sort path. Registered before the generic
+            // stats table so the phase roll-up reads as a focused summary above
+            // the full per-step dump.
+            //
+            // Gated on a sole-`[Stage::Sort]` chain (`is_sort_terminal`), matching
+            // how `add_sort` scopes `SortSummaryFinalizeHook`. In a fused chain
+            // (an intermediate sort, e.g. `runall`'s sort→group→…) the six phase
+            // step names do NOT cleanly bound the sort's work: the terminal
+            // `BgzfCompress`/`WriteBgzfFile` sink serializes the *final* stage's
+            // output, not the sort's, and the intermediate `DecodeFromRecords` /
+            // `ParseBamRecords` adapters around the sort are unclassified — so a
+            // phase block there would misattribute the shared sink and drop
+            // adapter time. A faithful fused-chain breakdown needs step-index
+            // scoping, which is out of scope here.
+            if self.spec.is_sort_terminal() {
+                self.finalize.push(Box::new(
+                    crate::pipeline::chains::commands::sort::SortPhaseTimingFinalizeHook {
+                        stats: std::sync::Arc::clone(&s),
+                    },
+                ));
+            }
             self.finalize.push(Box::new(PipelineStatsFinalizeHook { stats: s }));
         }
 

--- a/src/lib/pipeline/chains/commands/sort.rs
+++ b/src/lib/pipeline/chains/commands/sort.rs
@@ -30,6 +30,7 @@ use log::info;
 use parking_lot::Mutex;
 
 use crate::pipeline::chains::FinalizeHook;
+use crate::pipeline::core::runtime::stats::{PipelineStats, StatsSnapshot};
 
 /// Post-pipeline summary for standalone `fgumi sort`.
 ///
@@ -60,8 +61,185 @@ impl FinalizeHook for SortSummaryFinalizeHook {
     }
 }
 
+// ─────────────────────────── Sort phase timing ───────────────────────────
+//
+// Pre-cutover, the owned `RawExternalSorter` engine emitted a
+// `=== Sort Phase Timing ===` per-phase wall-time breakdown at `info!` on every
+// sort. Standalone `fgumi sort` now runs through the declarative chain, whose
+// sort phases are modeled as discrete pipeline steps
+// (`ReadBlocks`/`InflateToArena` → `FindBoundariesAndSort`/`SortBuffer` →
+// `SpillGather`/`SpillBlockCompress`/`SpillWrite` → `SortSpillDecompress` →
+// `SortMerge` → `BgzfCompress`/`WriteBgzfFile`). The pipeline already records
+// each step's cumulative `try_run` busy time
+// (`StepStatsSnapshot::total_run_ns`) whenever a `PipelineStats` collector is
+// attached, so this hook re-derives the same per-phase breakdown from that
+// snapshot rather than re-running the retired engine. That restores the
+// `=== Sort Phase Timing ===` grep string and the project's documented
+// sort-profiling signal (see `CLAUDE.md`, "Benchmarking Notes"). It is
+// registered only when stats collection is on (`--pipeline-stats` where the
+// command exposes it, else `FGUMI_PIPELINE_STATS=1` — standalone `fgumi sort`
+// uses the env var), so the default sort path keeps its zero-overhead behavior
+// — which the external `fg-labs/mako` consumer relies on.
+
+/// The six sort phases, in pipeline order, that `=== Sort Phase Timing ===`
+/// reports. The declaration order is also the accumulator index order used by
+/// [`summarize_sort_phases`] (`phase as usize`) and the report order in
+/// [`SortPhase::ORDER`] — keep the three in sync.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SortPhase {
+    ReadDecompress,
+    InMemorySort,
+    SpillWrite,
+    Consolidation,
+    KWayMerge,
+    WriteOutput,
+}
+
+impl SortPhase {
+    /// Phases in report order. The array index equals each variant's
+    /// `as usize`, i.e. its slot in the per-phase nanosecond accumulator.
+    const ORDER: [SortPhase; 6] = [
+        SortPhase::ReadDecompress,
+        SortPhase::InMemorySort,
+        SortPhase::SpillWrite,
+        SortPhase::Consolidation,
+        SortPhase::KWayMerge,
+        SortPhase::WriteOutput,
+    ];
+
+    /// Human-readable phase label used in the log block. Mirrors the phase
+    /// names the retired owned-engine `SortPhaseTimer` printed.
+    fn label(self) -> &'static str {
+        match self {
+            SortPhase::ReadDecompress => "read + decompress",
+            SortPhase::InMemorySort => "in-memory sort",
+            SortPhase::SpillWrite => "spill write",
+            SortPhase::Consolidation => "consolidation",
+            SortPhase::KWayMerge => "k-way merge",
+            SortPhase::WriteOutput => "write output",
+        }
+    }
+
+    /// Classify a pipeline step name into its sort phase, or `None` for a step
+    /// that is not part of the sort engine (record/format adapters such as a SAM
+    /// source's parse steps, whose time is therefore not counted here).
+    ///
+    /// The arms are the `StepProfile::name` literals of the sort steps in
+    /// `crates/fgumi-pipeline-io/src/sort/` plus the shared BGZF sink, covering
+    /// the steps a sole-`[Stage::Sort]` chain runs (the only chain the timing
+    /// hook is registered on — see `ChainBuilder::build`). A sort step added or
+    /// renamed there without a matching arm here falls to `None` and is silently
+    /// omitted from the roll-up (and its `total`) — so when adding a sort step,
+    /// add its name here too.
+    ///
+    /// `sort_phase_classifier_covers_known_sort_steps` pins the arm→phase mapping
+    /// for this known set (a maintainer checklist), but note what it does NOT do:
+    /// because it asserts against the same string literals, it cannot by itself
+    /// detect an *upstream* rename or a brand-new step (those are caught at the
+    /// io layer by each step's own `assert_eq!(profile.name, …)` test, and here
+    /// only when the new name is added to both this match and that case table).
+    fn from_step_name(name: &str) -> Option<SortPhase> {
+        match name {
+            "ReadBlocks" | "InflateToArena" => Some(SortPhase::ReadDecompress),
+            "FindBoundariesAndSort" | "SortBuffer" => Some(SortPhase::InMemorySort),
+            // `CompressSpill` is the fused compress-and-write spill variant
+            // (`SortBuffer → CompressSpill → …`); `add_sort` currently wires the
+            // `SpillGather`/`SpillBlockCompress`/`SpillWrite` split instead, but
+            // classify it so the roll-up stays correct if that wiring changes.
+            "SpillGather" | "SpillBlockCompress" | "SpillWrite" | "CompressSpill" => {
+                Some(SortPhase::SpillWrite)
+            }
+            "SortSpillDecompress" => Some(SortPhase::Consolidation),
+            "SortMerge" => Some(SortPhase::KWayMerge),
+            "BgzfCompress" | "WriteBgzfFile" => Some(SortPhase::WriteOutput),
+            _ => None,
+        }
+    }
+}
+
+/// Sum each sort step's cumulative `try_run` busy time into its phase bucket,
+/// indexed by each variant's `as usize` (see [`SortPhase::ORDER`]).
+///
+/// Reads only `snapshot.steps` (`StepStatsSnapshot::total_run_ns`), which the
+/// driver populates for **every** dispatched step — the detached writer
+/// included, since `PipelineStats::record` runs on the detached thread's
+/// dispatches too (`runtime/driver.rs`). The separate `snapshot.detached` view
+/// re-counts that same time under the "N + 2" pool-vs-detached reporting split,
+/// so it is deliberately NOT added here (doing so would double-count the
+/// writer).
+fn summarize_sort_phases(snapshot: &StatsSnapshot) -> [u64; 6] {
+    let mut phase_ns = [0u64; 6];
+    for (name, stats) in &snapshot.steps {
+        if let Some(phase) = SortPhase::from_step_name(name) {
+            phase_ns[phase as usize] = phase_ns[phase as usize].saturating_add(stats.total_run_ns);
+        }
+    }
+    phase_ns
+}
+
+/// Render the `=== Sort Phase Timing ===` block from per-phase nanoseconds, or
+/// `None` when no sort phase did any work (empty or pre-work-failure stats), so
+/// a run that recorded nothing prints no misleading block.
+// Nanosecond counts → seconds/percentages for a human-readable log line only;
+// `f64` precision loss above 2^52 ns (~52 days per phase) is irrelevant to a
+// displayed figure. Mirrors `runtime::stats`'s own display-math allows.
+#[allow(clippy::cast_precision_loss)]
+fn format_sort_phase_timing(phase_ns: &[u64; 6]) -> Option<Vec<String>> {
+    let total_ns: u64 = phase_ns.iter().copied().sum();
+    if total_ns == 0 {
+        return None;
+    }
+    let total_secs = total_ns as f64 / 1e9;
+    let mut lines = Vec::with_capacity(SortPhase::ORDER.len() + 3);
+    lines.push("=== Sort Phase Timing ===".to_owned());
+    for phase in SortPhase::ORDER {
+        let ns = phase_ns[phase as usize];
+        let secs = ns as f64 / 1e9;
+        let pct = 100.0 * ns as f64 / total_ns as f64;
+        lines.push(format!("  {:<18} {secs:>9.3}s  {pct:>5.1}%", phase.label()));
+    }
+    lines.push(format!("  {:<18} {total_secs:>9.3}s  100.0%", "total"));
+    lines.push(
+        "  (cumulative per-step busy time; sort steps run concurrently, so each \
+         percentage is a share of total sort work, not of wall-clock time)"
+            .to_owned(),
+    );
+    Some(lines)
+}
+
+/// Log the `=== Sort Phase Timing ===` block for a stats snapshot, when any
+/// sort phase did work. Split out from [`SortPhaseTimingFinalizeHook`] so the
+/// roll-up + rendering can be unit-tested against a hand-built snapshot.
+fn log_sort_phase_timing(snapshot: &StatsSnapshot) {
+    if let Some(lines) = format_sort_phase_timing(&summarize_sort_phases(snapshot)) {
+        for line in lines {
+            info!("{line}");
+        }
+    }
+}
+
+/// Post-pipeline `=== Sort Phase Timing ===` diagnostic for a chain that
+/// contains a sort stage.
+///
+/// Registered by `ChainBuilder::build` only when a `PipelineStats` collector is
+/// attached AND stats output was requested (`--pipeline-stats` where exposed,
+/// else `FGUMI_PIPELINE_STATS=1`), so the default sort path pays nothing. Emits the
+/// per-phase breakdown re-derived from the end-of-run stats snapshot.
+pub(crate) struct SortPhaseTimingFinalizeHook {
+    pub(crate) stats: Arc<PipelineStats>,
+}
+
+impl FinalizeHook for SortPhaseTimingFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        log_sort_phase_timing(&self.stats.snapshot());
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     // Shares the crate-wide capturing logger (see
@@ -98,6 +276,195 @@ mod tests {
         assert!(
             !logs.iter().any(|line| line.contains("Temporary runs:")),
             "must not emit the old 'Temporary runs:' wording; got: {logs:?}"
+        );
+    }
+
+    // ── Sort phase timing (`=== Sort Phase Timing ===`) ──────────────────────
+
+    use crate::pipeline::core::runtime::stats::StepStatsSnapshot;
+
+    /// A `StepStatsSnapshot` carrying only the `total_run_ns` the phase roll-up
+    /// reads; every other counter is zero.
+    fn step_snap(total_run_ns: u64) -> StepStatsSnapshot {
+        StepStatsSnapshot {
+            try_run_total: 0,
+            progress_count: 0,
+            no_progress_count: 0,
+            contention_count: 0,
+            finished_count: 0,
+            error_count: 0,
+            total_run_ns,
+            first_progress_ns: u64::MAX,
+            last_progress_ns: 0,
+        }
+    }
+
+    /// A snapshot whose only populated field is `steps` (the field the roll-up
+    /// reads); `workers`/`detached`/`edges` empty.
+    fn snapshot_with_steps(steps: Vec<(&'static str, u64)>) -> StatsSnapshot {
+        StatsSnapshot {
+            steps: steps.into_iter().map(|(n, ns)| (n, step_snap(ns))).collect(),
+            workers: Vec::new(),
+            detached: Vec::new(),
+            edges: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn summarize_sort_phases_buckets_every_step_into_its_phase() {
+        let snap = snapshot_with_steps(vec![
+            ("ReadBlocks", 100),
+            ("InflateToArena", 200),        // read + decompress = 300
+            ("FindBoundariesAndSort", 400), // in-memory sort = 400
+            ("SpillGather", 10),
+            ("SpillBlockCompress", 20),
+            ("SpillWrite", 30),          // spill write = 60
+            ("SortSpillDecompress", 50), // consolidation = 50
+            ("SortMerge", 500),          // k-way merge = 500
+            ("BgzfCompress", 5),
+            ("WriteBgzfFile", 15), // write output = 20
+        ]);
+        let phase_ns = summarize_sort_phases(&snap);
+        assert_eq!(phase_ns[SortPhase::ReadDecompress as usize], 300);
+        assert_eq!(phase_ns[SortPhase::InMemorySort as usize], 400);
+        assert_eq!(phase_ns[SortPhase::SpillWrite as usize], 60);
+        assert_eq!(phase_ns[SortPhase::Consolidation as usize], 50);
+        assert_eq!(phase_ns[SortPhase::KWayMerge as usize], 500);
+        assert_eq!(phase_ns[SortPhase::WriteOutput as usize], 20);
+    }
+
+    /// The `SortBuffer` ingest step (the SAM/RecordBatch arena front) buckets
+    /// into in-memory sort, exercising the branch the BAM path's
+    /// `FindBoundariesAndSort` does not.
+    #[test]
+    fn summarize_maps_sort_buffer_ingest_to_in_memory_sort() {
+        let phase_ns = summarize_sort_phases(&snapshot_with_steps(vec![("SortBuffer", 42)]));
+        assert_eq!(phase_ns[SortPhase::InMemorySort as usize], 42);
+        assert_eq!(phase_ns.iter().sum::<u64>(), 42);
+    }
+
+    #[test]
+    fn summarize_ignores_non_sort_steps() {
+        // Adapter / other-stage step names (e.g. a fused sort→group chain) must
+        // not land in any sort phase bucket.
+        let phase_ns = summarize_sort_phases(&snapshot_with_steps(vec![
+            ("SortMerge", 100),
+            ("DecodeFromRecords", 999),
+            ("GroupBam", 999),
+            ("TemplatesToRecordBatch", 999),
+        ]));
+        assert_eq!(phase_ns[SortPhase::KWayMerge as usize], 100);
+        assert_eq!(
+            phase_ns.iter().sum::<u64>(),
+            100,
+            "only the SortMerge step is part of the sort engine here"
+        );
+    }
+
+    #[test]
+    fn summarize_reads_steps_total_run_ns_not_detached_busy() {
+        // The detached writer's time is recorded in BOTH steps[].total_run_ns
+        // and detached[].busy_ns; the roll-up must read steps only, or it would
+        // double-count the writer.
+        let snap = StatsSnapshot {
+            steps: vec![("WriteBgzfFile", step_snap(100))],
+            workers: Vec::new(),
+            detached: vec![(0, "WriteBgzfFile", 999_999, 0, 0)],
+            edges: Vec::new(),
+        };
+        let phase_ns = summarize_sort_phases(&snap);
+        assert_eq!(
+            phase_ns[SortPhase::WriteOutput as usize],
+            100,
+            "must count steps[].total_run_ns, not detached[].busy_ns"
+        );
+    }
+
+    /// Pins the arm→phase mapping for every sort step name the classifier
+    /// recognizes, as a maintainer checklist of the covered set. It asserts the
+    /// classifier's own literals, so it does NOT by itself catch an upstream
+    /// rename or a newly-added step (add a case here when adding a `from_step_name`
+    /// arm); it does catch an accidental change to which phase an existing name
+    /// maps to.
+    #[rstest]
+    #[case::read_blocks("ReadBlocks", SortPhase::ReadDecompress)]
+    #[case::inflate("InflateToArena", SortPhase::ReadDecompress)]
+    #[case::find_and_sort("FindBoundariesAndSort", SortPhase::InMemorySort)]
+    #[case::sort_buffer("SortBuffer", SortPhase::InMemorySort)]
+    #[case::spill_gather("SpillGather", SortPhase::SpillWrite)]
+    #[case::spill_block_compress("SpillBlockCompress", SortPhase::SpillWrite)]
+    #[case::spill_write("SpillWrite", SortPhase::SpillWrite)]
+    #[case::compress_spill("CompressSpill", SortPhase::SpillWrite)]
+    #[case::spill_decompress("SortSpillDecompress", SortPhase::Consolidation)]
+    #[case::merge("SortMerge", SortPhase::KWayMerge)]
+    #[case::bgzf_compress("BgzfCompress", SortPhase::WriteOutput)]
+    #[case::write_file("WriteBgzfFile", SortPhase::WriteOutput)]
+    fn sort_phase_classifier_covers_known_sort_steps(
+        #[case] step_name: &str,
+        #[case] expected: SortPhase,
+    ) {
+        assert_eq!(SortPhase::from_step_name(step_name), Some(expected));
+    }
+
+    #[test]
+    fn format_sort_phase_timing_emits_header_all_phases_and_percentages() {
+        let mut phase_ns = [0u64; 6];
+        phase_ns[SortPhase::ReadDecompress as usize] = 300_000_000; // 0.3s → 30%
+        phase_ns[SortPhase::KWayMerge as usize] = 700_000_000; // 0.7s → 70%
+        let lines = format_sort_phase_timing(&phase_ns).expect("nonzero total must render");
+
+        assert_eq!(lines[0], "=== Sort Phase Timing ===");
+        for phase in SortPhase::ORDER {
+            assert!(
+                lines.iter().any(|l| l.contains(phase.label())),
+                "missing a line for phase {phase:?}; got: {lines:?}"
+            );
+        }
+        assert!(
+            lines.iter().any(|l| l.contains("read + decompress") && l.contains("30.0%")),
+            "read+decompress should be 30.0%; got: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("k-way merge") && l.contains("70.0%")),
+            "k-way merge should be 70.0%; got: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("total") && l.contains("100.0%")),
+            "a total line summing to 100% is expected; got: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn format_sort_phase_timing_is_none_when_no_phase_did_work() {
+        assert!(
+            format_sort_phase_timing(&[0u64; 6]).is_none(),
+            "an all-zero snapshot must render no block"
+        );
+    }
+
+    #[test]
+    fn log_sort_phase_timing_emits_the_block_for_a_populated_snapshot() {
+        let _session = capture_logs();
+        log_sort_phase_timing(&snapshot_with_steps(vec![
+            ("SortMerge", 500_000_000),
+            ("WriteBgzfFile", 500_000_000),
+        ]));
+        let logs = captured();
+        assert!(
+            logs.iter().any(|l| l.contains("=== Sort Phase Timing ===")),
+            "expected the phase-timing header; got: {logs:?}"
+        );
+        assert!(logs.iter().any(|l| l.contains("k-way merge")), "got: {logs:?}");
+        assert!(logs.iter().any(|l| l.contains("write output")), "got: {logs:?}");
+    }
+
+    #[test]
+    fn log_sort_phase_timing_is_silent_for_an_empty_snapshot() {
+        let _session = capture_logs();
+        log_sort_phase_timing(&snapshot_with_steps(vec![]));
+        assert!(
+            !captured().iter().any(|l| l.contains("Sort Phase Timing")),
+            "no block should be logged when no sort work was recorded"
         );
     }
 }

--- a/tests/integration/test_sort_stats_diagnostics.rs
+++ b/tests/integration/test_sort_stats_diagnostics.rs
@@ -121,6 +121,54 @@ fn sort_and_capture_logs(families: usize, max_memory: &str, extra_args: &[&str])
     stderr
 }
 
+/// The stable header pinning the restored per-phase timing roll-up
+/// (`src/lib/pipeline/chains/commands/sort.rs`,
+/// `SortPhaseTimingFinalizeHook`). Emitted only when a `PipelineStats`
+/// collector is attached (`--pipeline-stats` / `FGUMI_PIPELINE_STATS=1`).
+const PHASE_TIMING_HEADER: &str = "=== Sort Phase Timing ===";
+
+/// Parse the percentage from a `=== Sort Phase Timing ===` phase line
+/// (`  <label>   <secs>s   <pct>%`), or `None` if no line contains `label`.
+/// The percentage is the last whitespace-separated token, e.g. `9.8%`.
+fn phase_timing_pct(stderr: &str, label: &str) -> Option<f64> {
+    stderr
+        .lines()
+        .find(|line| line.contains(label))
+        .and_then(|line| line.split_whitespace().last())
+        .and_then(|token| token.strip_suffix('%'))
+        .and_then(|pct| pct.trim().parse::<f64>().ok())
+}
+
+/// Runs `fgumi sort` at info verbosity with `FGUMI_PIPELINE_STATS=1` set (which
+/// force-attaches the pipeline stats collector even though standalone
+/// `fgumi sort` does not flatten `--pipeline-stats`), and returns its stderr.
+fn sort_and_capture_logs_with_pipeline_stats(
+    families: usize,
+    max_memory: &str,
+    extra_args: &[&str],
+) -> String {
+    let tmp = TempDir::new().expect("tempdir");
+    let input: PathBuf = tmp.path().join("unsorted.bam");
+    write_bam_fixture(&input, families);
+    let output = tmp.path().join("sorted.bam");
+
+    let result = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .env("RUST_LOG", "info")
+        .env("FGUMI_PIPELINE_STATS", "1")
+        .args(["sort", "-i"])
+        .arg(&input)
+        .arg("-o")
+        .arg(&output)
+        .args(["--order", "coordinate", "-m", max_memory])
+        .args(extra_args)
+        .output()
+        .expect("run fgumi sort");
+
+    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+    assert!(result.status.success(), "fgumi sort failed:\n{stderr}");
+    stderr
+}
+
 /// Runs `fgumi sort` with a small `--max-memory` (forcing spills + a real
 /// k-way merge) and returns its stderr.
 ///
@@ -204,6 +252,80 @@ fn sort_stats_gates_fast_path_note(#[case] extra_args: &[&str], #[case] expect_p
     assert!(
         !stderr.contains(MERGE_DIAG_SUBSTRING),
         "the k-way-merge diagnostic must not appear when no merge ran:\n{stderr}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Restored `=== Sort Phase Timing ===` per-phase diagnostic
+// ─────────────────────────────────────────────────────────────────────────
+//
+// The chain cutover dropped the owned engine's unconditional phase-timing
+// block (the retired `RawExternalSorter::sort` was its only caller). It is
+// restored as a roll-up derived from the pipeline's per-step timings, gated on
+// the stats collector being attached so the default sort path is unaffected.
+
+/// The `=== Sort Phase Timing ===` block is gated on the pipeline stats
+/// collector being attached: emitted on a spilling sort under
+/// `FGUMI_PIPELINE_STATS=1`, and absent on the default sort path so profiling
+/// instrumentation stays opt-in and the default path keeps its zero-overhead
+/// behavior. Mirrors this file's `sort_stats_gates_*` present/absent tables.
+#[rstest]
+#[case::enabled(true, true)]
+#[case::disabled(false, false)]
+fn sort_phase_timing_is_gated_on_pipeline_stats(
+    #[case] with_pipeline_stats: bool,
+    #[case] expect_present: bool,
+) {
+    let stderr = if with_pipeline_stats {
+        sort_and_capture_logs_with_pipeline_stats(20_000, "1M", &[])
+    } else {
+        sort_spilling(&[])
+    };
+    assert_really_spilled(&stderr);
+
+    assert_eq!(
+        stderr.contains(PHASE_TIMING_HEADER),
+        expect_present,
+        "expected `{PHASE_TIMING_HEADER}` presence={expect_present} \
+         (with_pipeline_stats={with_pipeline_stats}); stderr:\n{stderr}"
+    );
+    // When present, assert the phases that must dominate a spilling coordinate
+    // sort report a NONZERO percentage — not merely that the label is printed.
+    // The block emits every label unconditionally (a zero-time phase still
+    // prints `0.000s 0.0%`), so a label-presence check would pass even if a
+    // classifier bug routed a phase's steps to the wrong bucket; parsing the
+    // percentage catches that. (Spill write is confirmed separately by
+    // `assert_really_spilled`, and can round to 0.0% on a fast run, so it is not
+    // asserted nonzero here.)
+    if expect_present {
+        for phase in ["in-memory sort", "k-way merge", "write output"] {
+            let pct = phase_timing_pct(&stderr, phase).unwrap_or_else(|| {
+                panic!("phase-timing block missing a parseable `{phase}` line; stderr:\n{stderr}")
+            });
+            assert!(
+                pct > 0.0,
+                "phase `{phase}` reported {pct}% on a spilling sort — a mis-bucketed classifier \
+                 arm would zero a phase like this; stderr:\n{stderr}"
+            );
+        }
+    }
+}
+
+/// `--sort-stats` alone (its own merge-diagnostic flag) must NOT trigger the
+/// phase-timing block — that block is gated on the pipeline stats collector,
+/// not on `--sort-stats`. Pins the two diagnostics as independently gated so a
+/// future change cannot silently couple them.
+#[test]
+fn sort_stats_flag_alone_does_not_emit_phase_timing() {
+    let stderr = sort_spilling(&["--sort-stats"]);
+    assert_really_spilled(&stderr);
+    assert!(
+        stderr.contains(MERGE_DIAG_SUBSTRING),
+        "the --sort-stats merge diagnostic should still fire; stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(PHASE_TIMING_HEADER),
+        "--sort-stats alone must not emit the phase-timing block; stderr:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

Restores the `=== Sort Phase Timing ===` per-phase diagnostic for `fgumi sort`, which the sort-on-chain cutover (#885) dropped. Pre-cutover, the owned `RawExternalSorter` engine logged a per-phase wall-time breakdown (read+decompress / in-memory sort / spill write / consolidation / k-way merge / write output) on every sort — the tool `CLAUDE.md`'s Benchmarking Notes call "the primary attribution tool". Standalone `fgumi sort` now runs entirely through the declarative chain and never calls that engine, so the block was gone (the owned timer is now reachable only from tests). `--sort-stats` was repurposed to gate the k-way-merge scheduling counters, which are a different signal.

The chain still *models* every phase — each is a discrete pipeline step (`ReadBlocks`/`InflateToArena` → `FindBoundariesAndSort`/`SortBuffer` → `SpillGather`/`SpillBlockCompress`/`SpillWrite` → `SortSpillDecompress` → `SortMerge` → `BgzfCompress`/`WriteBgzfFile`) — and the runtime already records each step's cumulative busy time. So rather than resurrect the retired engine, this re-derives the same breakdown as a roll-up over the end-of-run pipeline stats snapshot.

## What changed

- New `SortPhaseTimingFinalizeHook` (`src/lib/pipeline/chains/commands/sort.rs`): maps each sort step name to its phase, sums the per-step `total_run_ns` into six phase buckets, and logs the `=== Sort Phase Timing ===` block (per-phase seconds + %, a total line, and a one-line note that the percentages are shares of cumulative per-step *busy* time, since the steps run concurrently). Reads `snapshot.steps` only — never the `detached` view, which would double-count the detached writer, whose time `record()` already folds into its step's `total_run_ns`.
- `ChainBuilder::build` registers the hook only for a **sole-`[Stage::Sort]`** chain (`is_sort_terminal()`), matching how `add_sort` scopes `SortSummaryFinalizeHook`, and only when a `PipelineStats` collector is already attached and stats output was requested (`FGUMI_PIPELINE_STATS=1`; standalone `fgumi sort` does not accept `--pipeline-stats`). The default sort path attaches no collector, so it pays nothing — preserving the sort engine's zero-overhead hot path (which the external `fg-labs/mako` consumer depends on). The block is deliberately not emitted for a fused/intermediate sort (e.g. `runall`'s sort→group→…): there the terminal `BgzfCompress`/`WriteBgzfFile` sink serializes the final stage's output, not the sort's, and the intermediate `DecodeFromRecords`/`ParseBamRecords` adapters around the sort are unclassified, so a phase block there would misattribute the shared sink and drop adapter time — a faithful fused breakdown needs step-index scoping, out of scope here.
- `CLAUDE.md` Benchmarking Notes §2 updated: it described the now-dead owned-engine timer as always-on ("just `RUST_LOG=info`"). It now documents the chain-derived roll-up and its `FGUMI_PIPELINE_STATS=1` + `RUST_LOG=info` invocation, and notes the library `fgumi-sort` engine still carries its own always-on `SortPhaseTimer` for callers that drive `RawExternalSorter` directly.

Enabling it:

```sh
RUST_LOG=info FGUMI_PIPELINE_STATS=1 fgumi sort -i in.bam -o out.bam --order coordinate
# === Sort Phase Timing ===
#   read + decompress      0.001s   18.3%
#   in-memory sort         0.001s   11.3%
#   spill write            0.000s    3.8%
#   consolidation          0.000s    3.7%
#   k-way merge            0.001s    9.8%
#   write output           0.003s   53.1%
#   total                  0.005s  100.0%
#   (cumulative per-step busy time; sort steps run concurrently, so each percentage is a share of total sort work, not of wall-clock time)
```

The block is emitted just above the full `Pipeline end-of-run stats:` per-step table it rolls up from.

## Tests

- Unit tests (`commands/sort.rs`): phase bucketing across all six phases; the `SortBuffer` ingest branch; non-sort steps (fused-chain adapters) ignored; reads `steps[].total_run_ns` not `detached[].busy_ns` (no double count); the rendered block's header/phases/percentages/total; `None`/silent when no phase did work; an `#[rstest]` case table pinning every recognized sort step name (incl. the currently-unwired `CompressSpill`) to its phase.
- Integration tests (`test_sort_stats_diagnostics.rs`): a real spilling `fgumi sort` under `FGUMI_PIPELINE_STATS=1` emits the block and its dominant phases (in-memory sort, k-way merge, write output) report a **nonzero** parsed percentage (so a mis-bucketed classifier arm that zeroes a phase fails, not just a missing label); the block is absent on the default path; `--sort-stats` alone (its merge-diagnostic flag) still fires but does not emit the phase block — pinning the two diagnostics as independently gated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: adds pinned diagnostic output for standalone `fgumi sort` when `FGUMI_PIPELINE_STATS=1`; no `unsafe` changes or CLAUDE.md allowlist changes; no memory-bound, queue-capacity, or thread/backpressure changes.

Restores `=== Sort Phase Timing ===` with six phase durations, percentages, total time, and cumulative busy-time guidance. Fused chains, default sort behavior, and `--sort-stats` remain unchanged.

Adds unit and integration coverage for phase attribution, output gating, formatting, empty statistics, and spilling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->