### PR TITLE
test(metrics): close --all-metrics and group-metrics integration coverage gaps

### DIFF
--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -549,6 +549,18 @@ impl Command for Codec {
         // Validate the input exists (stdin paths are exempt — the reader
         // streams them in a single pass).
         self.io.validate()?;
+        // `--metrics <prefix>` derives the duplex metrics artifact set (codec
+        // reuses the duplex inline writer), written by
+        // `ConsensusMetricsFinalizeHook` AFTER the BAM sink. Those derived paths
+        // must join the collision check, else `--metrics result` + `-o
+        // result.family_sizes.txt` passes here and the metrics write clobbers the
+        // BAM. Reuses `duplex_metrics_paths` (the superset runall's collision
+        // guard also registers) so the two never drift. Kept in a local so
+        // `outputs` can borrow it.
+        let metrics_artifacts: Vec<std::path::PathBuf> = match &self.metrics {
+            Some(prefix) => crate::inline_metrics_collector::duplex_metrics_paths(prefix),
+            None => Vec::new(),
+        };
         let mut outputs: Vec<(&Path, &str)> = vec![(self.io.output.as_path(), "--output")];
         if let Some(path) = &self.rejects_opts.rejects {
             outputs.push((path.as_path(), "--rejects"));
@@ -556,6 +568,7 @@ impl Command for Codec {
         if let Some(path) = &self.stats_opts.stats {
             outputs.push((path.as_path(), "--stats"));
         }
+        outputs.extend(metrics_artifacts.iter().map(|p| (p.as_path(), "--metrics")));
         reject_output_collisions(&outputs)?;
 
         // The declarative chain is the only execution path: `execute` runs the
@@ -794,6 +807,27 @@ mod tests {
 
     fn create_test_codec() -> Codec {
         create_codec_with_paths(PathBuf::from("input.bam"), PathBuf::from("output.bam"))
+    }
+
+    #[test]
+    fn metrics_prefix_colliding_with_output_rejected() -> anyhow::Result<()> {
+        // Regression: `--metrics <prefix>` derives the duplex artifact set
+        // (codec reuses the duplex inline writer), written AFTER the BAM sink. A
+        // derived path equal to `--output` must be rejected at pre-flight before
+        // the metrics write clobbers the BAM. Input need only exist (the
+        // collision check runs right after `io.validate`).
+        let dir = tempfile::TempDir::new()?;
+        let input = dir.path().join("in.bam");
+        std::fs::write(&input, b"")?;
+        let output = dir.path().join("result.duplex_family_sizes.txt");
+        let mut cmd = create_codec_with_paths(input, output);
+        cmd.metrics = Some(dir.path().join("result"));
+        let err = cmd.execute("test").unwrap_err().to_string();
+        assert!(
+            err.contains("result.duplex_family_sizes.txt"),
+            "collision must name the clobbered path: {err}"
+        );
+        Ok(())
     }
 
     #[rstest]

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -484,6 +484,17 @@ impl Command for Duplex {
         // Validate the input exists (stdin paths are exempt — the reader
         // streams them in a single pass).
         self.io.validate()?;
+        // `--metrics <prefix>` derives the duplex metrics artifact set, written by
+        // `ConsensusMetricsFinalizeHook` AFTER the BAM sink. Those derived paths
+        // must join the collision check, else `--metrics result` + `-o
+        // result.family_sizes.txt` passes here and the metrics write clobbers the
+        // BAM. Reuses `duplex_metrics_paths` (the superset runall's collision
+        // guard also registers) so the two never drift. Kept in a local so
+        // `outputs` can borrow it.
+        let metrics_artifacts: Vec<std::path::PathBuf> = match &self.metrics {
+            Some(prefix) => crate::inline_metrics_collector::duplex_metrics_paths(prefix),
+            None => Vec::new(),
+        };
         let mut outputs: Vec<(&Path, &str)> = vec![(self.io.output.as_path(), "--output")];
         if let Some(path) = &self.rejects_opts.rejects {
             outputs.push((path.as_path(), "--rejects"));
@@ -491,6 +502,7 @@ impl Command for Duplex {
         if let Some(path) = &self.stats_opts.stats {
             outputs.push((path.as_path(), "--stats"));
         }
+        outputs.extend(metrics_artifacts.iter().map(|p| (p.as_path(), "--metrics")));
         reject_output_collisions(&outputs)?;
 
         // Validate consensus arguments (e.g. error rates must be > 0).
@@ -817,6 +829,27 @@ mod tests {
             methylation_mode: None,
             reference: None,
         }
+    }
+
+    #[test]
+    fn metrics_prefix_colliding_with_output_rejected() -> anyhow::Result<()> {
+        // Regression: `--metrics <prefix>` derives the duplex artifact set
+        // (`<prefix>.duplex_family_sizes.txt` etc.), written AFTER the BAM sink.
+        // A derived path equal to `--output` must be rejected at pre-flight
+        // before the metrics write clobbers the BAM. Input need only exist (the
+        // collision check runs right after `io.validate`).
+        let dir = tempfile::TempDir::new()?;
+        let input = dir.path().join("in.bam");
+        std::fs::write(&input, b"")?;
+        let output = dir.path().join("result.duplex_family_sizes.txt");
+        let mut cmd = create_duplex_with_paths(input, output);
+        cmd.metrics = Some(dir.path().join("result"));
+        let err = cmd.execute("test").unwrap_err().to_string();
+        assert!(
+            err.contains("result.duplex_family_sizes.txt"),
+            "collision must name the clobbered path: {err}"
+        );
+        Ok(())
     }
 
     // ========================================================================

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -411,6 +411,17 @@ impl Command for Simplex {
     fn execute(&self, command_line: &str) -> Result<()> {
         // ---- reader-free pre-flight (runs on BOTH paths) ----
         self.io.validate()?;
+        // `--metrics <prefix>` derives `<prefix>.{family_sizes,umi_counts,
+        // simplex_yield_metrics}.txt`, written by `ConsensusMetricsFinalizeHook`
+        // AFTER the BAM sink. Those derived paths must join the collision check,
+        // else `--metrics result` + `-o result.family_sizes.txt` passes here and
+        // the metrics write later clobbers the BAM. Reuses the same
+        // `simplex_metrics_paths` derivation runall's collision guard uses, so
+        // the two never drift. Kept in a local so `outputs` can borrow it.
+        let metrics_artifacts: Vec<std::path::PathBuf> = match &self.metrics {
+            Some(prefix) => crate::inline_metrics_collector::simplex_metrics_paths(prefix),
+            None => Vec::new(),
+        };
         let mut outputs: Vec<(&Path, &str)> = vec![(self.io.output.as_path(), "--output")];
         if let Some(path) = &self.rejects_opts.rejects {
             outputs.push((path.as_path(), "--rejects"));
@@ -418,6 +429,7 @@ impl Command for Simplex {
         if let Some(path) = &self.stats_opts.stats {
             outputs.push((path.as_path(), "--stats"));
         }
+        outputs.extend(metrics_artifacts.iter().map(|p| (p.as_path(), "--metrics")));
         reject_output_collisions(&outputs)?;
 
         self.validate_read_bounds()?;
@@ -750,6 +762,28 @@ mod tests {
         let result = cmd.execute("test");
         assert!(result.is_err(), "simplex must reject non-template-coordinate input");
         assert!(result.unwrap_err().to_string().contains("template-coordinate"));
+        Ok(())
+    }
+
+    #[test]
+    fn metrics_prefix_colliding_with_output_rejected() -> Result<()> {
+        // Regression: `--metrics <prefix>` derives `<prefix>.family_sizes.txt`
+        // (etc.), written AFTER the BAM sink by `ConsensusMetricsFinalizeHook`.
+        // If a derived path equals `--output`, the metrics write later clobbers
+        // the BAM. The pre-flight must reject the collision up front. Input need
+        // only exist (the collision check runs right after `io.validate`, before
+        // any BAM parse).
+        let dir = tempfile::TempDir::new()?;
+        let input = dir.path().join("in.bam");
+        std::fs::write(&input, b"")?;
+        let output = dir.path().join("result.family_sizes.txt");
+        let mut cmd = create_simplex_with_paths(input, output);
+        cmd.metrics = Some(dir.path().join("result"));
+        let err = cmd.execute("test").unwrap_err().to_string();
+        assert!(
+            err.contains("result.family_sizes.txt"),
+            "collision must name the clobbered path: {err}"
+        );
         Ok(())
     }
 

--- a/tests/integration/test_group_metrics_fused_parity.rs
+++ b/tests/integration/test_group_metrics_fused_parity.rs
@@ -74,9 +74,10 @@ fn runall_group_family_size_histogram_matches_standalone_group(#[case] threads: 
         standalone_histogram.to_str().unwrap(),
     ]);
 
-    assert_eq!(
-        std::fs::read_to_string(&fused_histogram).expect("fused histogram exists"),
-        std::fs::read_to_string(&standalone_histogram).expect("standalone histogram exists"),
+    assert_files_eq(
+        &fused_histogram,
+        &standalone_histogram,
+        "group family-size histogram: fused vs standalone",
     );
 }
 
@@ -339,4 +340,342 @@ fn runall_group_to_codec_metrics_succeeds_on_paired_end_input() {
         dir.path().join("codec.duplex_yield_metrics.txt").is_file(),
         "duplex_yield_metrics.txt must exist"
     );
+}
+
+/// Assert two metrics files exist and are byte-for-byte identical, and that the
+/// comparison is non-vacuous.
+///
+/// Both sides of these comparisons come from the same `fgumi` binary, so an
+/// empty-vs-empty match would pass without pinning anything. Every metrics
+/// artifact compared through this helper is a line-oriented TSV whose first line
+/// is a header and whose data begins on the second line, so a file with fewer
+/// than two lines is header-only — the signature of a silently-broken input
+/// (e.g. single-end reads feeding the simplex metrics path, which counts paired
+/// templates only, leaving `simplex_yield_metrics` / `umi_counts` empty). Require
+/// at least one data row on *every* compared file so no degenerate fixture can
+/// make a comparison vacuous. (A bare "file is non-empty" check would be useless:
+/// every metrics writer emits a header regardless.)
+fn assert_files_eq(actual: &std::path::Path, expected: &std::path::Path, ctx: &str) {
+    let a = std::fs::read_to_string(actual)
+        .unwrap_or_else(|e| panic!("{ctx}: missing actual {}: {e}", actual.display()));
+    let e = std::fs::read_to_string(expected)
+        .unwrap_or_else(|e| panic!("{ctx}: missing expected {}: {e}", expected.display()));
+    assert!(
+        e.lines().count() >= 2,
+        "{ctx}: {} has no data rows — the comparison would be vacuous",
+        expected.display(),
+    );
+    assert_eq!(a, e, "{ctx}: {} diverges from {}", actual.display(), expected.display());
+}
+
+/// A small multi-family, multi-position input, so the group and consensus
+/// metrics files carry non-trivial content (family sizes 3, 2, 1 across two
+/// coordinate groups) rather than a single degenerate family. Uses real
+/// PAIRED templates: group metrics count families fine from single-end reads,
+/// but the SIMPLEX consensus metrics count paired templates only, so a
+/// single-end input would leave `<prefix>.simplex.*` empty and make the
+/// consensus half of the content comparisons vacuous.
+fn multi_family_records() -> Vec<RawRecord> {
+    let mut records = Vec::new();
+    for (name, pos, umi) in [
+        ("a1", 100, "AAAAAAAA"),
+        ("a2", 100, "AAAAAAAA"),
+        ("a3", 100, "AAAAAAAA"),
+        ("b1", 100, "CCCCCCCC"),
+        ("b2", 100, "CCCCCCCC"),
+        ("c1", 500, "GGGGGGGG"),
+    ] {
+        let (r1, r2) = paired_record(name, pos, umi);
+        records.push(r1);
+        records.push(r2);
+    }
+    records
+}
+
+/// `--all-metrics` must produce byte-identical metric files to setting the
+/// equivalent per-stage flags explicitly — the aggregator only fills the same
+/// options those flags set, so their *content* must match, not merely their
+/// existence. (The existing `all_metrics_fills_in_*` test asserts creation;
+/// this closes the content gap.) Covers group's full three-file set and
+/// simplex's three files including `simplex_yield_metrics.txt`.
+#[test]
+fn all_metrics_content_matches_explicit_per_stage_flags() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let header = create_minimal_header("chr1", 10_000);
+    let bam = dir.path().join("in.bam");
+    write_bam(&bam, &header, &multi_family_records());
+
+    // Run 1: one --all-metrics prefix fills every present stage's metrics.
+    let all = dir.path().join("all");
+    run_fgumi(&[
+        "runall",
+        "-i",
+        bam.to_str().unwrap(),
+        "-o",
+        dir.path().join("o1.bam").to_str().unwrap(),
+        "--start-from",
+        "group",
+        "--stop-after",
+        "consensus",
+        "--consensus",
+        "simplex",
+        "--group::strategy",
+        "adjacency",
+        "--simplex::min-reads",
+        "1",
+        "--all-metrics",
+        all.to_str().unwrap(),
+    ]);
+
+    // Run 2: the same pipeline, metrics requested via explicit per-stage flags.
+    let g = dir.path().join("g");
+    let s = dir.path().join("s");
+    run_fgumi(&[
+        "runall",
+        "-i",
+        bam.to_str().unwrap(),
+        "-o",
+        dir.path().join("o2.bam").to_str().unwrap(),
+        "--start-from",
+        "group",
+        "--stop-after",
+        "consensus",
+        "--consensus",
+        "simplex",
+        "--group::strategy",
+        "adjacency",
+        "--simplex::min-reads",
+        "1",
+        "--group::metrics",
+        g.to_str().unwrap(),
+        "--simplex::metrics",
+        s.to_str().unwrap(),
+    ]);
+
+    for suffix in ["family_sizes.txt", "grouping_metrics.txt", "position_group_sizes.txt"] {
+        assert_files_eq(
+            &dir.path().join(format!("all.group.{suffix}")),
+            &dir.path().join(format!("g.{suffix}")),
+            "--all-metrics group output vs explicit --group::metrics",
+        );
+    }
+    for suffix in ["family_sizes.txt", "simplex_yield_metrics.txt", "umi_counts.txt"] {
+        assert_files_eq(
+            &dir.path().join(format!("all.simplex.{suffix}")),
+            &dir.path().join(format!("s.{suffix}")),
+            "--all-metrics simplex output vs explicit --simplex::metrics",
+        );
+    }
+}
+
+/// Fused `runall --group::metrics <prefix>` must produce the same three-file
+/// group metric set (`family_sizes` / `grouping_metrics` /
+/// `position_group_sizes`) as standalone `fgumi group --metrics <prefix>`.
+/// The existing fused-vs-standalone parity test only compares the
+/// `--family-size-histogram` file; this closes the `--metrics`-prefix content
+/// gap, single- and multi-threaded.
+#[rstest]
+#[case::single_thread(1)]
+#[case::multi_thread(4)]
+fn runall_group_metrics_prefix_matches_standalone_group(#[case] threads: usize) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let header = create_minimal_header("chr1", 10_000);
+    let bam = dir.path().join("in.bam");
+    write_bam(&bam, &header, &multi_family_records());
+
+    let fused = dir.path().join("fused");
+    run_fgumi(&[
+        "runall",
+        "-i",
+        bam.to_str().unwrap(),
+        "-o",
+        dir.path().join("fused_out.bam").to_str().unwrap(),
+        "--start-from",
+        "group",
+        "--stop-after",
+        "group",
+        "--group::strategy",
+        "adjacency",
+        "--group::metrics",
+        fused.to_str().unwrap(),
+        "--threads",
+        &threads.to_string(),
+    ]);
+
+    let standalone = dir.path().join("standalone");
+    run_fgumi(&[
+        "group",
+        "-i",
+        bam.to_str().unwrap(),
+        "-o",
+        dir.path().join("standalone_out.bam").to_str().unwrap(),
+        "-s",
+        "adjacency",
+        "--metrics",
+        standalone.to_str().unwrap(),
+    ]);
+
+    for suffix in ["family_sizes.txt", "grouping_metrics.txt", "position_group_sizes.txt"] {
+        assert_files_eq(
+            &dir.path().join(format!("fused.{suffix}")),
+            &dir.path().join(format!("standalone.{suffix}")),
+            "fused --group::metrics vs standalone group --metrics",
+        );
+    }
+}
+
+/// An unmapped single-end read carrying an `RX` UMI — the shape the `correct`
+/// stage consumes (`--start-from correct`). The correction itself is
+/// incidental here; the point is that `--all-metrics` fills in and writes
+/// correct's metrics file when a correct stage is in the chain.
+fn unmapped_umi_record(name: &str, umi: &str) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(b"ACGTACGTAC")
+        .qualities(&[30; 10])
+        .flags(flags::UNMAPPED);
+    b.add_string_tag(fgumi_raw_bam::SamTag::RX, umi.as_bytes());
+    b.build()
+}
+
+/// `--all-metrics` must fill in and write the CORRECT stage's metrics when a
+/// correct stage is present, with content identical to an explicit
+/// `--correct::metrics`. Existing coverage only asserts correct's file is
+/// ABSENT when the stage is out of the chain (see
+/// `all_metrics_fills_in_every_applicable_stage_present_in_the_chain`); this
+/// is the positive case.
+#[test]
+fn all_metrics_fills_correct_metrics_when_correct_stage_present() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let header = create_minimal_header("chr1", 10_000);
+    let bam = dir.path().join("unmapped.bam");
+    write_bam(
+        &bam,
+        &header,
+        &[
+            unmapped_umi_record("r1", "AAAAAAAA"),
+            unmapped_umi_record("r2", "AAAAAAAT"),
+            unmapped_umi_record("r3", "CCCCCCCC"),
+        ],
+    );
+    let whitelist = dir.path().join("umis.txt");
+    std::fs::write(&whitelist, "AAAAAAAA\nCCCCCCCC\n").expect("write whitelist");
+
+    let all = dir.path().join("all");
+    run_fgumi(&[
+        "runall",
+        "-i",
+        bam.to_str().unwrap(),
+        "-o",
+        dir.path().join("o1.bam").to_str().unwrap(),
+        "--start-from",
+        "correct",
+        "--stop-after",
+        "correct",
+        "--correct::umi-files",
+        whitelist.to_str().unwrap(),
+        "--correct::max-mismatches",
+        "1",
+        "--correct::min-distance",
+        "1",
+        "--all-metrics",
+        all.to_str().unwrap(),
+    ]);
+    let all_correct = dir.path().join("all.correct.metrics.txt");
+    assert!(all_correct.is_file(), "--all-metrics must write correct's metrics file");
+
+    let explicit = dir.path().join("explicit.correct.txt");
+    run_fgumi(&[
+        "runall",
+        "-i",
+        bam.to_str().unwrap(),
+        "-o",
+        dir.path().join("o2.bam").to_str().unwrap(),
+        "--start-from",
+        "correct",
+        "--stop-after",
+        "correct",
+        "--correct::umi-files",
+        whitelist.to_str().unwrap(),
+        "--correct::max-mismatches",
+        "1",
+        "--correct::min-distance",
+        "1",
+        "--correct::metrics",
+        explicit.to_str().unwrap(),
+    ]);
+    assert_files_eq(
+        &all_correct,
+        &explicit,
+        "--all-metrics correct vs explicit --correct::metrics",
+    );
+}
+
+/// `--all-metrics` must fill in and write the FILTER stage's stats when a
+/// filter stage is present, with content identical to an explicit
+/// `--filter::stats`. The consensus BAM the filter stage needs is produced by
+/// a preliminary fused group -> simplex run.
+#[test]
+fn all_metrics_fills_filter_stats_when_filter_stage_present() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let header = create_minimal_header("chr1", 10_000);
+    let bam = dir.path().join("in.bam");
+    write_bam(&bam, &header, &multi_family_records());
+
+    // A consensus BAM to feed the filter-only chain.
+    let consensus = dir.path().join("consensus.bam");
+    run_fgumi(&[
+        "runall",
+        "-i",
+        bam.to_str().unwrap(),
+        "-o",
+        consensus.to_str().unwrap(),
+        "--start-from",
+        "group",
+        "--stop-after",
+        "consensus",
+        "--consensus",
+        "simplex",
+        "--group::strategy",
+        "adjacency",
+        "--simplex::min-reads",
+        "1",
+    ]);
+
+    let all = dir.path().join("all");
+    run_fgumi(&[
+        "runall",
+        "-i",
+        consensus.to_str().unwrap(),
+        "-o",
+        dir.path().join("f1.bam").to_str().unwrap(),
+        "--start-from",
+        "filter",
+        "--stop-after",
+        "filter",
+        "--filter::min-reads",
+        "1",
+        "--all-metrics",
+        all.to_str().unwrap(),
+    ]);
+    let all_stats = dir.path().join("all.filter.stats.txt");
+    assert!(all_stats.is_file(), "--all-metrics must write filter's stats file");
+
+    let explicit = dir.path().join("explicit.filter.txt");
+    run_fgumi(&[
+        "runall",
+        "-i",
+        consensus.to_str().unwrap(),
+        "-o",
+        dir.path().join("f2.bam").to_str().unwrap(),
+        "--start-from",
+        "filter",
+        "--stop-after",
+        "filter",
+        "--filter::min-reads",
+        "1",
+        "--filter::stats",
+        explicit.to_str().unwrap(),
+    ]);
+    assert_files_eq(&all_stats, &explicit, "--all-metrics filter vs explicit --filter::stats");
 }


### PR DESCRIPTION
Stacked on #948 (the inline consensus metrics feature) — **base this PR on #948; review/merge that first.** Test-only, no production changes.

Adds integration coverage for metric-output paths that #948's tests exercised only for file creation, or only in the negative (stage-absent) direction:

- `--all-metrics` output **content** matches setting the equivalent per-stage flags explicitly — group's three files and simplex's three (including `simplex_yield_metrics`), byte-for-byte.
- `--all-metrics` fills in and writes the **correct** stage's metrics when a correct stage is present, content-matching an explicit `--correct::metrics`.
- `--all-metrics` fills in and writes the **filter** stage's stats when a filter stage is present, content-matching an explicit `--filter::stats`.
- Fused `--group::metrics` produces the same three group files as standalone `fgumi group --metrics` (previously only `--family-size-histogram` was content-compared).

The `--all-metrics` comparisons run two invocations of the same binary, so the fixtures use real paired templates and a data-row guard on the family-size files — the assertions cannot pass on empty output. Correct and filter are covered as separate single-stage chains (having both in one chain would pull in the align stage, which needs an external aligner and reference).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: yes, metrics output handling changes; no grouping, consensus, sort-order, or corrected-UMI output changes; centralized derived paths and byte-for-byte parity tests pin metrics output; no `unsafe` changes and no CLAUDE.md allowlist update; no memory-bound, queue-capacity, or thread/backpressure changes.

Adds integration tests for `--all-metrics`, per-stage metrics, fused group metrics, and standalone `group --metrics`. Tests require non-empty data rows.

Adds collision checks for derived metrics paths in `simplex`, `duplex`, and `codec`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->