### PR TITLE
fix(bam-io): return an error instead of panicking on >65,535 libraries

### DIFF
--- a/crates/fgumi-bam-io/src/grouping.rs
+++ b/crates/fgumi-bam-io/src/grouping.rs
@@ -648,7 +648,7 @@ mod tests {
                 .expect("read group builds");
             header = header.add_read_group(bstr::BString::from(id), rg);
         }
-        LibraryIndex::from_header(&header.build())
+        LibraryIndex::from_header(&header.build()).expect("builds")
     }
 
     /// Build one mapped mate of a pair carrying `RG`, `CB` and `MC`.

--- a/crates/fgumi-bam-io/src/library.rs
+++ b/crates/fgumi-bam-io/src/library.rs
@@ -99,11 +99,13 @@ impl LibraryIndex {
     /// Each unique library name gets a sequential index starting from 0.
     /// Index 0 is reserved for "unknown" library.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the header contains more than 65,535 distinct libraries.
-    #[must_use]
-    pub fn from_header(header: &Header) -> Self {
+    /// Returns an error if the header contains more than 65,535 distinct
+    /// libraries, since the per-library index is a `u16`.
+    pub fn from_header(header: &Header) -> anyhow::Result<Self> {
+        use std::collections::hash_map::Entry;
+
         let mut lookup = ahash::AHashMap::new();
         let mut names = vec![Arc::clone(&UNKNOWN_LIBRARY)]; // Index 0 = unknown
         let mut library_to_idx: ahash::AHashMap<Arc<str>, u16> = ahash::AHashMap::new();
@@ -116,20 +118,29 @@ impl LibraryIndex {
                 .get(&rg_tag::LIBRARY)
                 .map_or_else(|| Arc::clone(&UNKNOWN_LIBRARY), |s| Arc::from(s.to_string()));
 
-            // Get or create library index
-            let lib_idx = *library_to_idx.entry(library.clone()).or_insert_with(|| {
-                let idx: u16 =
-                    names.len().try_into().expect("too many distinct libraries for u16 index");
-                names.push(library);
-                idx
-            });
+            // Get or create library index. A fresh library takes the next `u16`
+            // slot; error rather than panic once the header exceeds the range.
+            let lib_idx = match library_to_idx.entry(library.clone()) {
+                Entry::Occupied(entry) => *entry.get(),
+                Entry::Vacant(entry) => {
+                    let idx: u16 = names.len().try_into().map_err(|_| {
+                        anyhow::anyhow!(
+                            "header has more than {} distinct libraries; \
+                             the library index is limited to a u16",
+                            u16::MAX
+                        )
+                    })?;
+                    names.push(library);
+                    *entry.insert(idx)
+                }
+            };
 
             // Hash the RG string and map to library index
             let rg_hash = Self::hash_rg(id.as_bytes());
             lookup.insert(rg_hash, lib_idx);
         }
 
-        Self { lookup, names, unknown_idx: 0 }
+        Ok(Self { lookup, names, unknown_idx: 0 })
     }
 
     /// Get the library index for a read group hash.
@@ -224,7 +235,7 @@ mod tests {
     /// one group in half.
     #[test]
     fn from_header_assigns_one_index_per_distinct_library() {
-        let index = LibraryIndex::from_header(&header_with_read_groups());
+        let index = LibraryIndex::from_header(&header_with_read_groups()).expect("builds");
 
         let idx1 = index.get(LibraryIndex::hash_rg(b"RG1"));
         let idx2 = index.get(LibraryIndex::hash_rg(b"RG2"));
@@ -244,7 +255,7 @@ mod tests {
     /// group together rather than each forming a singleton.
     #[test]
     fn from_header_maps_missing_library_and_unknown_read_group_to_index_zero() {
-        let index = LibraryIndex::from_header(&header_with_read_groups());
+        let index = LibraryIndex::from_header(&header_with_read_groups()).expect("builds");
 
         assert_eq!(index.get(LibraryIndex::hash_rg(b"RG4")), 0, "no LB field → unknown");
         assert_eq!(index.get(LibraryIndex::hash_rg(b"ABSENT")), 0, "unseen RG → unknown");
@@ -254,7 +265,7 @@ mod tests {
     /// Out-of-range indices fall back to "unknown" rather than panicking.
     #[test]
     fn library_name_saturates_to_unknown_for_an_out_of_range_index() {
-        let index = LibraryIndex::from_header(&header_with_read_groups());
+        let index = LibraryIndex::from_header(&header_with_read_groups()).expect("builds");
         assert_eq!(index.library_name(u16::MAX).as_ref(), "unknown");
     }
 
@@ -274,9 +285,61 @@ mod tests {
     /// An empty header yields an index that resolves everything to unknown.
     #[test]
     fn from_header_with_no_read_groups_resolves_everything_to_unknown() {
-        let index = LibraryIndex::from_header(&Header::default());
+        let index = LibraryIndex::from_header(&Header::default()).expect("builds");
         assert_eq!(index.get(LibraryIndex::hash_rg(b"RG1")), 0);
         assert!(build_library_lookup(&Header::default()).is_empty());
+    }
+
+    /// The per-library index is a `u16`, so a header carrying more than 65,535
+    /// distinct libraries cannot be represented. `from_header` must surface that
+    /// as an error the caller can propagate, not panic (previously a
+    /// `.try_into().expect(...)` crash).
+    #[test]
+    fn from_header_errors_when_distinct_libraries_exceed_u16() {
+        // u16::MAX distinct libraries fit (indices 1..=65535); one more overflows.
+        // Index 0 is reserved for "unknown", so the first over-range library is
+        // the (u16::MAX + 1)-th distinct one.
+        let distinct = usize::from(u16::MAX) + 1;
+        let mut header = Header::builder();
+        for i in 0..distinct {
+            let rg = Map::<ReadGroup>::builder()
+                .insert(rg_tag::LIBRARY, format!("lib{i}"))
+                .build()
+                .expect("read group builds");
+            header = header.add_read_group(bstr::BString::from(format!("RG{i}")), rg);
+        }
+
+        let err = LibraryIndex::from_header(&header.build())
+            .expect_err("more than u16::MAX distinct libraries must error");
+        assert!(
+            err.to_string().contains("distinct libraries"),
+            "error should name the distinct-library overflow, got: {err}"
+        );
+    }
+
+    /// Exactly `u16::MAX` distinct libraries is the boundary that still fits.
+    #[test]
+    fn from_header_accepts_u16_max_distinct_libraries() {
+        let distinct = usize::from(u16::MAX);
+        let mut header = Header::builder();
+        for i in 0..distinct {
+            let rg = Map::<ReadGroup>::builder()
+                .insert(rg_tag::LIBRARY, format!("lib{i}"))
+                .build()
+                .expect("read group builds");
+            header = header.add_read_group(bstr::BString::from(format!("RG{i}")), rg);
+        }
+
+        let index = LibraryIndex::from_header(&header.build())
+            .expect("u16::MAX distinct libraries must fit");
+        // The last read group added is the u16::MAX-th distinct library and must
+        // resolve to the highest valid index — this is the boundary the test pins.
+        assert_eq!(index.get(LibraryIndex::hash_rg(b"RG0")), 1, "first library gets index 1");
+        assert_eq!(
+            index.get(LibraryIndex::hash_rg(b"RG65534")),
+            u16::MAX,
+            "the u16::MAX-th distinct library resolves to the highest valid index"
+        );
     }
 
     /// `hash_bytes(None)` is the documented zero sentinel, and the typed wrappers

--- a/src/lib/commands/shared_metrics.rs
+++ b/src/lib/commands/shared_metrics.rs
@@ -953,7 +953,7 @@ where
 
     // Library index (RG -> LB) for partitioning families by library, matching fgbio's
     // ReadInfo.library and fgumi's own group/dedup grouping.
-    let library_index = LibraryIndex::from_header(&header);
+    let library_index = LibraryIndex::from_header(&header)?;
 
     let template_iter = TemplateIterator::new(reader);
 
@@ -1220,7 +1220,7 @@ pub(crate) mod tests {
         let header = test_header();
         let r1 = fgumi_raw_bam::encode_record_buf_to_raw(&r1_buf, &header).expect("encode r1");
         let r2 = fgumi_raw_bam::encode_record_buf_to_raw(&r2_buf, &header).expect("encode r2");
-        let library_index = LibraryIndex::from_header(&header);
+        let library_index = LibraryIndex::from_header(&header).expect("builds");
 
         let (info, key) = build_template_info(&r1, &r2, &header, &library_index)
             .expect("build_template_info succeeds")

--- a/src/lib/inline_metrics_collector.rs
+++ b/src/lib/inline_metrics_collector.rs
@@ -1201,7 +1201,7 @@ mod coordinate_group_from_processed_position_tests {
         let template1 = template_from_pair("t1", &header, "0");
         let template2 = template_from_pair("t2", &header, "1");
 
-        let library_index = LibraryIndex::from_header(&header);
+        let library_index = LibraryIndex::from_header(&header).expect("builds");
         let infos = coordinate_group_from_processed_position(
             &[template1, template2],
             &header,
@@ -1222,7 +1222,7 @@ mod coordinate_group_from_processed_position_tests {
         let r1 = fgumi_raw_bam::encode_record_buf_to_raw(&r1_buf, &header).expect("encode r1");
         let template = Template::from_records(vec![r1]).expect("builds R1-only template");
 
-        let library_index = LibraryIndex::from_header(&header);
+        let library_index = LibraryIndex::from_header(&header).expect("builds");
         let infos = coordinate_group_from_processed_position(&[template], &header, &library_index)
             .expect("converts");
 
@@ -1269,7 +1269,7 @@ mod coordinate_group_from_processed_position_tests {
 
         let template = Template::from_records(vec![build(true, 99, 149), build(false, 149, 99)])
             .expect("builds template");
-        let library_index = LibraryIndex::from_header(&header);
+        let library_index = LibraryIndex::from_header(&header).expect("builds");
         let infos = coordinate_group_from_processed_position(&[template], &header, &library_index)
             .expect("converts");
 
@@ -1282,7 +1282,7 @@ mod coordinate_group_from_processed_position_tests {
     #[test]
     fn coordinate_group_from_processed_position_handles_an_empty_group() {
         let header = crate::commands::shared_metrics::tests::test_header();
-        let library_index = LibraryIndex::from_header(&header);
+        let library_index = LibraryIndex::from_header(&header).expect("builds");
         let infos = coordinate_group_from_processed_position(&[], &header, &library_index)
             .expect("converts");
         assert!(infos.is_empty());
@@ -1353,7 +1353,7 @@ mod coordinate_group_from_processed_position_tests {
         // aux tag.
         template.mi = fgumi_umi::MoleculeId::PairedA(7);
 
-        let library_index = LibraryIndex::from_header(&header);
+        let library_index = LibraryIndex::from_header(&header).expect("builds");
         let infos = coordinate_group_from_processed_position(&[template], &header, &library_index)
             .expect("must succeed by reading Template.mi, not error on the absent MI aux tag");
 
@@ -1443,7 +1443,7 @@ mod pair_and_push_tests {
     #[test]
     fn push_mi_group_entries_converts_every_qualifying_pair() {
         let header = crate::commands::shared_metrics::tests::test_header();
-        let library_index = LibraryIndex::from_header(&header);
+        let library_index = LibraryIndex::from_header(&header).expect("builds");
         let (a1, a2) = raw_pair("a", "0", &header);
         let (b1, b2) = raw_pair("b", "1", &header);
         let group = MiGroup::new("0".to_string(), vec![a1, a2, b1, b2]);
@@ -1460,7 +1460,7 @@ mod pair_and_push_tests {
     #[test]
     fn push_mi_group_entries_appends_onto_a_non_empty_accumulator() {
         let header = crate::commands::shared_metrics::tests::test_header();
-        let library_index = LibraryIndex::from_header(&header);
+        let library_index = LibraryIndex::from_header(&header).expect("builds");
         let (a1, a2) = raw_pair("a", "0", &header);
         let group = MiGroup::new("0".to_string(), vec![a1, a2]);
 

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -875,7 +875,7 @@ impl<'a> ChainBuilder<'a> {
                 // GroupKeyConfig: used by DecodeRecords (BAM) and ParseSamChunk (SAM).
                 // Queryname-grouping first stages (correct) skip cell-barcode
                 // extraction — see `source_group_key_config`.
-                let group_key_config = self.source_group_key_config();
+                let group_key_config = self.source_group_key_config()?;
 
                 match input {
                     InputSource::Bam { reader, .. } => {
@@ -963,7 +963,7 @@ impl<'a> ChainBuilder<'a> {
                 }
 
                 // GroupKeyConfig used by DecodeRecords (BAM) and ParseSamChunk (SAM).
-                let group_key_config = self.bam_group_key_config();
+                let group_key_config = self.bam_group_key_config()?;
 
                 // ── Unmapped preamble: always BAM (guaranteed by open_source) ──
                 let unmapped_tail = match unmapped {
@@ -1171,11 +1171,11 @@ impl<'a> ChainBuilder<'a> {
     /// hoist a call above a `self.header = …` reassignment.
     ///
     /// [`GroupKeyConfig`]: fgumi_bam_io::GroupKeyConfig
-    fn bam_group_key_config(&self) -> fgumi_bam_io::GroupKeyConfig {
+    fn bam_group_key_config(&self) -> Result<fgumi_bam_io::GroupKeyConfig> {
         use crate::sam::SamTag;
         use noodles::sam::alignment::record::data::field::Tag;
         let cell_tag = Tag::from(SamTag::CB);
-        let library_index = fgumi_bam_io::LibraryIndex::from_header(&self.header);
+        let library_index = fgumi_bam_io::LibraryIndex::from_header(&self.header)?;
         let config = fgumi_bam_io::GroupKeyConfig::new(library_index, cell_tag);
         // When a Group or Dedup stage is in the chain, cache the UMI (RX) value
         // position during decode so the per-template UMI-assignment lookup
@@ -1200,9 +1200,9 @@ impl<'a> ChainBuilder<'a> {
         // `stages_want_umi_cache`, which stays a pure function of `stages` alone)
         // since only this call site has `self.spec.stage_opts` in scope.
         if umi_cache_enabled(&self.spec.stages, self.stage_no_umi()) {
-            config.with_umi_tag(*SamTag::RX)
+            Ok(config.with_umi_tag(*SamTag::RX))
         } else {
-            config
+            Ok(config)
         }
     }
 
@@ -1242,10 +1242,10 @@ impl<'a> ChainBuilder<'a> {
     /// `fgumi-bam-io`, and the `name_hash_only` branches in `DecodeRecords`
     /// and `parse_sam_chunk_into_decoded`, which call it without touching
     /// `library_index` at all), so resolving it from the header is pure waste
-    /// for these stages — and `LibraryIndex::from_header` panics on a header
-    /// with more than 65,535 distinct `@RG` libraries, a needless crash risk
-    /// this avoids.
-    fn source_group_key_config(&self) -> fgumi_bam_io::GroupKeyConfig {
+    /// for these stages — and `LibraryIndex::from_header` errors on a header
+    /// with more than 65,535 distinct `@RG` libraries, a needless failure this
+    /// avoids.
+    fn source_group_key_config(&self) -> Result<fgumi_bam_io::GroupKeyConfig> {
         match self.spec.stages.first() {
             Some(
                 Stage::Correct
@@ -1254,9 +1254,9 @@ impl<'a> ChainBuilder<'a> {
                 | Stage::Retag
                 | Stage::Filter
                 | Stage::Clip,
-            ) => {
-                fgumi_bam_io::GroupKeyConfig::name_hash_only(fgumi_bam_io::LibraryIndex::default())
-            }
+            ) => Ok(fgumi_bam_io::GroupKeyConfig::name_hash_only(
+                fgumi_bam_io::LibraryIndex::default(),
+            )),
             _ => self.bam_group_key_config(),
         }
     }
@@ -1286,23 +1286,25 @@ impl<'a> ChainBuilder<'a> {
             crate::pipeline::core::topology::BranchIdx,
         ),
         position: StagePosition,
-    ) -> (crate::pipeline::core::topology::StepIdx, crate::pipeline::core::topology::BranchIdx)
-    {
+    ) -> Result<(
+        crate::pipeline::core::topology::StepIdx,
+        crate::pipeline::core::topology::BranchIdx,
+    )> {
         match position {
             // terminal: tail is DecompressedBlock (serialized bytes) → SerializedBytes.
             StagePosition::Terminal => {
                 self.chain_tail_kind = ChainTailKind::SerializedBytes;
-                tail
+                Ok(tail)
             }
             StagePosition::Intermediate => {
                 use crate::pipeline::steps::parse::decode::DecodeRecords;
-                let group_key_config = self.bam_group_key_config();
+                let group_key_config = self.bam_group_key_config()?;
                 let tail = self.pipeline.append_step(
                     DecodeRecords::new(group_key_config, self.tuning.per_step_byte_limit),
                     tail,
                 );
                 self.chain_tail_kind = ChainTailKind::DecodedRecordBatch;
-                tail
+                Ok(tail)
             }
         }
     }
@@ -3071,7 +3073,7 @@ impl<'a> ChainBuilder<'a> {
                 )
                 .with_sort_stats(sort.sort_stats);
                 let merge_tail = self.pipeline.append_step(merge, decompress_tail);
-                let group_key_config = self.bam_group_key_config();
+                let group_key_config = self.bam_group_key_config()?;
                 let tail = self.pipeline.append_step(
                     DecodeFromRecords::new(group_key_config, self.tuning.per_step_byte_limit),
                     merge_tail,
@@ -3311,7 +3313,7 @@ impl<'a> ChainBuilder<'a> {
         let (header_arc, library_index_arc) = if consensus_metrics.is_some() {
             (
                 Some(Arc::new(self.header.clone())),
-                Some(Arc::new(fgumi_bam_io::LibraryIndex::from_header(&self.header))),
+                Some(Arc::new(fgumi_bam_io::LibraryIndex::from_header(&self.header)?)),
             )
         } else {
             (None, None)
@@ -3671,7 +3673,7 @@ impl<'a> ChainBuilder<'a> {
         let (header_arc, library_index_arc) = if metrics_on {
             (
                 Some(Arc::new(input_header.clone())),
-                Some(Arc::new(fgumi_bam_io::LibraryIndex::from_header(&input_header))),
+                Some(Arc::new(fgumi_bam_io::LibraryIndex::from_header(&input_header)?)),
             )
         } else {
             (None, None)
@@ -3783,7 +3785,7 @@ impl<'a> ChainBuilder<'a> {
         // Branch 0 = consensus DecompressedBlock. For an Intermediate consensus
         // stage finish_consensus_tail appends DecodeRecords; Terminal leaves the
         // DecompressedBlock for add_sink.
-        let tail = self.finish_consensus_tail(consensus_branch0, position);
+        let tail = self.finish_consensus_tail(consensus_branch0, position)?;
         self.current_tail = Some(tail);
 
         // Register the simplex finalize hook.
@@ -4036,7 +4038,7 @@ impl<'a> ChainBuilder<'a> {
         let (header_arc, library_index_arc) = if metrics_on {
             (
                 Some(Arc::new(input_header.clone())),
-                Some(Arc::new(fgumi_bam_io::LibraryIndex::from_header(&input_header))),
+                Some(Arc::new(fgumi_bam_io::LibraryIndex::from_header(&input_header)?)),
             )
         } else {
             (None, None)
@@ -4167,7 +4169,7 @@ impl<'a> ChainBuilder<'a> {
         };
         // Branch 0 = consensus DecompressedBlock. Intermediate appends
         // DecodeRecords; Terminal leaves the DecompressedBlock for add_sink.
-        let tail = self.finish_consensus_tail(consensus_branch0, position);
+        let tail = self.finish_consensus_tail(consensus_branch0, position)?;
         self.current_tail = Some(tail);
 
         // Register the duplex finalize hook.
@@ -4431,7 +4433,7 @@ impl<'a> ChainBuilder<'a> {
         let (header_arc, library_index_arc) = if metrics_on {
             (
                 Some(Arc::new(input_header.clone())),
-                Some(Arc::new(fgumi_bam_io::LibraryIndex::from_header(&input_header))),
+                Some(Arc::new(fgumi_bam_io::LibraryIndex::from_header(&input_header)?)),
             )
         } else {
             (None, None)
@@ -4510,7 +4512,7 @@ impl<'a> ChainBuilder<'a> {
         };
         // Branch 0 = consensus DecompressedBlock. Intermediate appends
         // DecodeRecords; Terminal leaves the DecompressedBlock for add_sink.
-        let tail = self.finish_consensus_tail(consensus_branch0, position);
+        let tail = self.finish_consensus_tail(consensus_branch0, position)?;
         self.current_tail = Some(tail);
 
         // Register the codec finalize hook.
@@ -5372,7 +5374,7 @@ impl<'a> ChainBuilder<'a> {
             // `dedup.duplication_ladder`, so `zip` yields `Some` exactly when the
             // flag is set — the invariant is now in the type, not an assert.
             duplication_ladder: dedup.duplication_ladder.clone().zip(ladder_recorder),
-            library_index: fgumi_bam_io::LibraryIndex::from_header(&self.header),
+            library_index: fgumi_bam_io::LibraryIndex::from_header(&self.header)?,
             sample: crate::commands::dedup::resolve_sample(&self.header, dedup.sample.as_deref()),
             timer,
         }));
@@ -5615,7 +5617,7 @@ mod tests {
     fn source_group_key_config_is_name_hash_only_for_filter_first_stage() {
         let spec = empty_spec(vec![Stage::Filter]);
         let builder = chain_builder_for_stages(&spec);
-        let config = builder.source_group_key_config();
+        let config = builder.source_group_key_config().expect("builds");
         assert!(
             config.name_hash_only,
             "Stage::Filter as the first stage must skip the discarded position/RG/CB key"
@@ -5633,7 +5635,7 @@ mod tests {
     fn source_group_key_config_is_name_hash_only_for_clip_first_stage() {
         let spec = empty_spec(vec![Stage::Clip]);
         let builder = chain_builder_for_stages(&spec);
-        let config = builder.source_group_key_config();
+        let config = builder.source_group_key_config().expect("builds");
         assert!(
             config.name_hash_only,
             "Stage::Clip as the first stage must skip the discarded position/RG/CB key"
@@ -5647,7 +5649,7 @@ mod tests {
     fn source_group_key_config_is_full_for_group_first_stage() {
         let spec = empty_spec(vec![Stage::Group]);
         let builder = chain_builder_for_stages(&spec);
-        let config = builder.source_group_key_config();
+        let config = builder.source_group_key_config().expect("builds");
         assert!(
             !config.name_hash_only,
             "Stage::Group as the first stage must compute the full position/RG/CB key"
@@ -5845,7 +5847,7 @@ mod tests {
         let mut spec = empty_spec(vec![Stage::Dedup]);
         spec.stage_opts.dedup = Some(dedup);
         let builder = chain_builder_for_stages(&spec);
-        assert_eq!(builder.bam_group_key_config().umi_tag, expected_umi_tag);
+        assert_eq!(builder.bam_group_key_config().expect("builds").umi_tag, expected_umi_tag);
     }
 
     /// `add_copy_umi` refuses an intermediate position: copy-umi is a terminal,

--- a/src/lib/pipeline/steps/chain_tests.rs
+++ b/src/lib/pipeline/steps/chain_tests.rs
@@ -763,8 +763,9 @@ fn sam_chain_decodes_every_line_in_order(#[values(1, 4)] threads: usize) {
         })
         .collect();
 
-    let key_config =
-        GroupKeyConfig::new_raw_no_cell(fgumi_bam_io::LibraryIndex::from_header(&header));
+    let key_config = GroupKeyConfig::new_raw_no_cell(
+        fgumi_bam_io::LibraryIndex::from_header(&header).expect("builds"),
+    );
     let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
     let sink_handle = Arc::clone(&collected);
     let builder = Pipeline::builder();

--- a/src/lib/pipeline/steps/parse/decode.rs
+++ b/src/lib/pipeline/steps/parse/decode.rs
@@ -477,7 +477,7 @@ mod tests {
                 .expect("read group builds");
             header = header.add_read_group(bstr::BString::from(id), rg);
         }
-        let lib = LibraryIndex::from_header(&header.build());
+        let lib = LibraryIndex::from_header(&header.build()).expect("builds");
         let cb = Some(Tag::from([b'C', b'B']));
 
         // Two paired templates, each R1+R2 sharing a name; the templates carry

--- a/src/lib/pipeline/steps/parse/sam.rs
+++ b/src/lib/pipeline/steps/parse/sam.rs
@@ -252,7 +252,7 @@ read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
     }
 
     fn key_config_for(header: &sam::Header) -> GroupKeyConfig {
-        let library_index = fgumi_bam_io::LibraryIndex::from_header(header);
+        let library_index = fgumi_bam_io::LibraryIndex::from_header(header).expect("builds");
         GroupKeyConfig::new_raw_no_cell(library_index)
     }
 
@@ -448,7 +448,7 @@ read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
     #[test]
     fn parse_sam_chunk_honors_name_hash_only() {
         let header = parse_header(SAM_TEXT);
-        let library_index = fgumi_bam_io::LibraryIndex::from_header(&header);
+        let library_index = fgumi_bam_io::LibraryIndex::from_header(&header).expect("builds");
         let key_config = GroupKeyConfig::name_hash_only(library_index);
 
         let chunk = sam_chunk_from_records(0);
@@ -512,7 +512,7 @@ read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
         use crate::sam::SamTag;
 
         let header = parse_header(SAM_TEXT);
-        let library_index = fgumi_bam_io::LibraryIndex::from_header(&header);
+        let library_index = fgumi_bam_io::LibraryIndex::from_header(&header).expect("builds");
         let key_config = GroupKeyConfig::new_raw_no_cell(library_index).with_umi_tag(*SamTag::RX);
 
         let line = "read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTA\tIIIII\tRX:Z:ACGTACGT\n";


### PR DESCRIPTION
LibraryIndex::from_header assigned each distinct @RG library a sequential u16 index via `names.len().try_into().expect(...)`, which panics once a header carries more than 65,535 distinct libraries. Every consensus-metrics, grouping, and dedup path that builds a LibraryIndex from an untrusted input header could therefore crash the process rather than surface a diagnosable error. CodeRabbit flagged this on #952 as a pre-existing, out-of-scope issue; this PR addresses it against `main`.

## What changed

- `LibraryIndex::from_header` is now fallible (`-> anyhow::Result<Self>`): the vacant-entry arm maps the `u16` overflow to an error naming the distinct-library limit, replacing the panicking `.expect(...)`. The `# Panics` doc becomes `# Errors`.
- `Result` is threaded through the three builder seams that construct a `LibraryIndex` from a header — `bam_group_key_config`, `source_group_key_config`, and `finish_consensus_tail` — plus the direct group/simplex/duplex/codec/dedup metrics sites and `process_templates_from_bam`.
- Test-only construction (tiny fixtures that cannot overflow) uses `.expect`.

## Tests

- New regression test: a header with `u16::MAX + 1` distinct libraries errors rather than panics.
- New boundary test: exactly `u16::MAX` distinct libraries still builds.
- Full suite green (4621 passed), `cargo fmt --check` and `clippy --all-features --all-targets` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: command output changes: none; `unsafe` changes: none, and `CLAUDE.md` allowlist changes: none; memory bounds, queue capacity, and thread/backpressure policy changes: none.

`LibraryIndex::from_header` now returns an error instead of panicking when a header exceeds 65,535 distinct libraries. The error propagates through grouping, consensus, codec, deduplication, and metrics paths.

Tests cover overflow and the supported 65,535-library boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->